### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/Joe-Heffer/sys2txt/security/code-scanning/1](https://github.com/Joe-Heffer/sys2txt/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the `GITHUB_TOKEN` to the least privilege required, which for this job is `contents: read`. This can be accomplished by adding a `permissions:` key at the root level of the workflow YAML file, above the `jobs` section. This ensures all jobs in the workflow inherit these limited permissions unless overridden. No other code or configuration is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
