### PR TITLE
fix: prevent freezing on in-progress segments and add whisper.cpp engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,10 @@ sys2txt is a CLI tool for recording Ubuntu system audio (via PulseAudio/PipeWire
 - **once**: Record until stopped, then transcribe once
 - **live**: Segment recording every N seconds and transcribe continuously
 
-The tool automatically selects faster-whisper (ctranslate2) for better performance when available, falling back to openai-whisper if not.
+The tool supports three transcription engines:
+- **faster-whisper**: Primary engine (ctranslate2), auto-selected when available
+- **openai-whisper**: Fallback reference implementation
+- **whisper.cpp**: Optional C++ implementation with Vulkan GPU support for AMD GPUs
 
 ## Development Setup
 
@@ -53,12 +56,15 @@ Alternatively, run as a module without installing: `python -m sys2txt once --mod
 Common flags:
 - `--source <name>`: Specify PulseAudio/PipeWire source (e.g., `alsa_output.pci-0000_00_1f.3.analog-stereo.monitor`)
 - `--model {tiny,base,small,medium,large-v2}`: Whisper model size (default: small)
-- `--engine {auto,faster,whisper}`: Force specific engine (default: auto)
+- `--engine {auto,faster,whisper,cpp}`: Force specific engine (default: auto)
+- `--device {auto,cpu,vulkan,gpu,cuda}`: Device for transcription (default: auto)
 - `--language <code>`: Force language code (e.g., en)
 - `--output <path>`: Write transcript to file
 - `--duration <seconds>`: (once mode) Fixed recording duration
 - `--segment-seconds <n>`: (live mode) Segment length (default: 8)
 - `--timestamps`: Include timestamps in output
+- `--model-path <path>`: Path to whisper.cpp model file (for cpp engine)
+- `--whisper-cpp-path <path>`: Path to whisper-cli binary (for cpp engine)
 
 ## Architecture
 
@@ -77,10 +83,14 @@ The codebase is organized into focused modules by functionality:
 - `run_command()`: Helper for running system commands
 
 **transcribe.py** - Whisper transcription:
-- `transcribe_file()`: Auto-selects engine (faster-whisper preferred, openai-whisper fallback)
-- `_transcribe_faster_whisper()`: Uses faster_whisper.WhisperModel with VAD filter, device selection via SYS2TXT_DEVICE env var (default: CPU int8)
+- `transcribe_file()`: Main entry point, dispatches to appropriate engine
+- `_transcribe_faster_whisper()`: Uses faster_whisper.WhisperModel with VAD filter
 - `_transcribe_openai_whisper()`: Uses whisper.load_model() and model.transcribe()
-- Both support timestamps flag for per-segment timing output
+- `_transcribe_whisper_cpp()`: Runs whisper-cli subprocess with GPU/CPU support
+- `_resolve_whisper_cpp_binary()`: Resolves whisper-cli path from arg/env/PATH
+- `_resolve_whisper_cpp_model_path()`: Resolves model path from arg/env/default
+- `_parse_whisper_cpp_output()`: Parses whisper.cpp output format
+- All engines support timestamps flag for per-segment timing output
 
 **utils.py** - Utility functions:
 - `which()`: Find command in PATH or raise RuntimeError
@@ -95,9 +105,22 @@ The codebase is organized into focused modules by functionality:
 - **pactl**: System command for PulseAudio/PipeWire source enumeration
 - **faster-whisper**: Primary transcription engine (optional, auto-detected)
 - **openai-whisper**: Fallback transcription engine
+- **whisper.cpp**: Optional C++ engine with Vulkan GPU support (external binary)
 
 ### GPU Acceleration
-Set `SYS2TXT_DEVICE=cuda` environment variable to enable CUDA acceleration for faster-whisper (requires compatible ctranslate2 build with CUDA support).
+
+**For faster-whisper (CUDA/NVIDIA):**
+- Set `SYS2TXT_DEVICE=cuda` or use `--device cuda`
+- Requires compatible ctranslate2 build with CUDA support
+
+**For whisper.cpp (Vulkan/AMD):**
+- Build whisper.cpp with `-DGGML_VULKAN=1` cmake flag
+- GPU is used by default; use `--device cpu` to force CPU
+
+### Environment Variables
+- `SYS2TXT_DEVICE`: Device selection for faster-whisper (`cpu`, `cuda`)
+- `SYS2TXT_WHISPER_CPP`: Path to whisper-cli binary
+- `SYS2TXT_WHISPER_CPP_MODELS`: Directory containing whisper.cpp model files (e.g., `ggml-small.bin`)
 
 ## Continuous Integration & Deployment
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ Record system audio and automatically transcribe to text using ✨AI✨.
 - On-demand: Record until you stop, then transcribe once
 - Live-ish: Segment the recording every *N* seconds and transcribe each segment as it’s created (prints continuously)
 
-You can use either the `openai-whisper` (Python) reference implementation or the [`faster-whisper`](https://github.com/SYSTRAN/faster-whisper) engine if installed. The tool auto-selects `faster-whisper` when available for better speed on CPU and especially GPU.
+You can use any of three transcription engines:
+- [`faster-whisper`](https://github.com/SYSTRAN/faster-whisper) - Default, best for CPU and NVIDIA GPUs
+- `openai-whisper` - Reference Python implementation
+- [`whisper.cpp`](https://github.com/ggerganov/whisper.cpp) - C++ implementation with Vulkan GPU support for AMD GPUs
+
+The tool auto-selects `faster-whisper` when available for better speed.
 
 ## Installation
 
@@ -64,7 +69,8 @@ sys2txt live --model small.en --segment-seconds 8
 - `--source <pulse_source_name>` - Explicit PulseAudio/PipeWire source (e.g., alsa_output.pci-0000_00_1f.3.analog-stereo.monitor)
 - `--list-sources` - List available Pulse sources and exit
 - `--model <size>` - tiny|base|small|medium|large-v2 (default: small)
-- `--engine <auto|faster|whisper>` - Force a specific engine (default: auto)
+- `--engine <auto|faster|whisper|cpp>` - Force a specific engine (default: auto)
+- `--device <auto|cpu|vulkan|gpu|cuda>` - Device for transcription (default: auto)
 - `--language <code>` - Force language code (e.g., en). Omit to auto-detect
 - `--output <path>` - Write final transcript to a file (in live mode, appends)
 - `--duration <seconds>` - (once mode) Record fixed duration instead of waiting for Ctrl-C
@@ -124,13 +130,61 @@ Transcribe with openai-whisper CLI:
 whisper out.wav --model small --task transcribe --language en
 ```
 
+## Whisper.cpp with Vulkan GPU
+
+For AMD GPUs (or other GPUs not supported by CUDA), you can use whisper.cpp with Vulkan acceleration for ~8x speedup over CPU.
+
+### Build whisper.cpp with Vulkan
+
+```bash
+# Install Vulkan SDK
+sudo apt install libvulkan-dev vulkan-tools
+
+# Clone and build whisper.cpp
+git clone https://github.com/ggerganov/whisper.cpp.git
+cd whisper.cpp
+cmake -B build -DGGML_VULKAN=1
+cmake --build build --config Release
+```
+
+### Download models
+
+```bash
+# Download a model (e.g., small)
+./models/download-ggml-model.sh small
+
+# Or manually download to default location
+mkdir -p ~/.local/share/whisper.cpp/models
+wget -O ~/.local/share/whisper.cpp/models/ggml-small.bin \
+  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin
+```
+
+### Usage with whisper.cpp
+
+```bash
+# Using explicit paths
+sys2txt once --engine cpp --model small \
+  --whisper-cpp-path /path/to/whisper.cpp/build/bin/whisper-cli \
+  --model-path /path/to/whisper.cpp/models/ggml-small.bin
+
+# Or set environment variables
+export SYS2TXT_WHISPER_CPP=/path/to/whisper-cli
+export SYS2TXT_WHISPER_CPP_MODELS=/path/to/models
+
+sys2txt once --engine cpp --model small
+
+# Force CPU-only (disable GPU)
+sys2txt once --engine cpp --model small --device cpu
+```
+
 ## Tips and troubleshooting
 
 - If you get silence, ensure you are using the monitor source for your output device (the name ends with `.monitor`). Use `--list-sources` to view options.
 - Make sure the application you want to capture is playing through the same output sink as your default sink. You can manage routes with `pavucontrol`.
 - PipeWire systems expose PulseAudio-compatible sources, so `-f pulse` in ffmpeg still works.
 - For better performance on CPU, use faster-whisper with model `base` or `small`. For the best accuracy, use `medium` or `large-v2` (these are heavier).
-- GPU acceleration for faster-whisper requires a compatible ctranslate2 CUDA wheel. Set `SYS2TXT_DEVICE=cuda` to enable it. If not available, it will run on CPU.
+- GPU acceleration for faster-whisper requires a compatible ctranslate2 CUDA wheel. Set `SYS2TXT_DEVICE=cuda` or use `--device cuda` to enable it.
+- For AMD GPUs, use whisper.cpp with Vulkan support (see above).
 
 ## Contributing
 

--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -49,11 +49,30 @@ def main():
         help=f"Whisper model size (default: {WHISPER_MODEL})",
     )
     common.add_argument(
-        "--engine", choices=["auto", "faster", "whisper"], default="auto", help="Transcription engine (default: auto)"
+        "--engine",
+        choices=["auto", "faster", "whisper", "cpp"],
+        default="auto",
+        help="Transcription engine (default: auto)",
     )
     common.add_argument("--language", default=None, help="Force language code (e.g., en). Defaults to auto-detect")
     common.add_argument("--timestamps", action="store_true", help="Print timestamps with transcript")
     common.add_argument("--list-sources", action="store_true", help="List PulseAudio sources and exit")
+    common.add_argument(
+        "--device",
+        choices=["auto", "cpu", "vulkan", "gpu", "cuda"],
+        default="auto",
+        help="Device to use for transcription (default: auto)",
+    )
+    common.add_argument(
+        "--model-path",
+        default=None,
+        help="Path to whisper.cpp model file (for cpp engine)",
+    )
+    common.add_argument(
+        "--whisper-cpp-path",
+        default=None,
+        help="Path to whisper-cli binary (for cpp engine)",
+    )
 
     once = sub.add_parser("once", parents=[common], help="Record once and transcribe after")
     once.add_argument("--duration", type=int, default=None, help="Record for N seconds instead of Ctrl-C")
@@ -103,6 +122,9 @@ def main():
                     model_size=args.model_size,
                     language=args.language,
                     timestamps=args.timestamps,
+                    model_path=args.model_path,
+                    whisper_cpp_path=args.whisper_cpp_path,
+                    device=args.device,
                 )
                 print(text)
                 with open(output_file, "w", encoding="utf-8") as w:
@@ -116,6 +138,9 @@ def main():
             model_size=args.model_size,
             language=args.language,
             timestamps=args.timestamps,
+            model_path=args.model_path,
+            whisper_cpp_path=args.whisper_cpp_path,
+            device=args.device,
         )
         print(text)
         with open(output_file, "w", encoding="utf-8") as w:
@@ -142,6 +167,9 @@ def main():
                 model_size=args.model_size,
                 language=args.language,
                 timestamps=args.timestamps,
+                model_path=args.model_path,
+                whisper_cpp_path=args.whisper_cpp_path,
+                device=args.device,
             )
             if args.timestamps:
                 # Add segment time window prefix

--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -61,7 +61,10 @@ def main():
         "--device",
         choices=["auto", "cpu", "vulkan", "gpu", "cuda"],
         default="auto",
-        help="Device to use for transcription (default: auto)",
+        help=(
+            "Device for transcription: cpu (force CPU), cuda (NVIDIA, faster-whisper only), "
+            "vulkan/gpu (AMD/Vulkan, whisper.cpp only), auto (default, let engine decide)"
+        ),
     )
     common.add_argument(
         "--model-path",
@@ -84,6 +87,12 @@ def main():
     live.add_argument("--output", default=None, help="Append live transcript to this file as it's produced")
 
     args = parser.parse_args()
+
+    if args.engine not in ("cpp", "auto"):
+        if args.model_path:
+            print("Warning: --model-path is only used with --engine cpp", file=sys.stderr)
+        if args.whisper_cpp_path:
+            print("Warning: --whisper-cpp-path is only used with --engine cpp", file=sys.stderr)
 
     if args.list_sources:
         sources = list_pulse_sources()

--- a/src/sys2txt/audio.py
+++ b/src/sys2txt/audio.py
@@ -107,7 +107,11 @@ def segment_and_transcribe_live(
             while True:
                 # sorted ensures we process in chronological order
                 files = sorted(f for f in os.listdir(tmp) if f.startswith("seg_") and f.endswith(".wav"))
-                new_files = [f for f in files if f not in processed]
+                # While ffmpeg is running, the last file is always the one currently
+                # being written. Only process files that have been finalized, which is
+                # guaranteed when a newer segment exists after them.
+                safe_to_process = files[:-1] if len(files) > 1 else []
+                new_files = [f for f in safe_to_process if f not in processed]
                 for f in new_files:
                     full = os.path.join(tmp, f)
                     # Ensure the segment has been finalized and has content

--- a/src/sys2txt/audio.py
+++ b/src/sys2txt/audio.py
@@ -5,6 +5,8 @@ import signal
 import subprocess
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Optional
 
 from .utils import which
@@ -57,7 +59,7 @@ def record_once(source: str, out_wav: str, sample_rate: int, channels: int, dura
     print("Recording finished.")
 
 
-def _process_segment_file(f, tmp, processed, transcribe_callback, output_path):
+def _process_segment_file(f, tmp, processed, transcribe_callback, output_path, executor, timeout):
     """Process a single finalized segment file: transcribe and print/write output."""
     full = os.path.join(tmp, f)
     if os.path.getsize(full) < 64:
@@ -67,7 +69,18 @@ def _process_segment_file(f, tmp, processed, transcribe_callback, output_path):
         idx = int(os.path.splitext(f)[0].split("_")[-1])
     except Exception:
         idx = 0
-    text = transcribe_callback(full, idx)
+    if executor and timeout:
+        future = executor.submit(transcribe_callback, full, idx)
+        try:
+            text = future.result(timeout=timeout)
+        except FuturesTimeoutError:
+            print(f"[Warning] Segment {f} transcription timed out, skipping", flush=True)
+            return
+        except Exception as e:
+            print(f"[Warning] Segment {f} transcription failed: {e}", flush=True)
+            return
+    else:
+        text = transcribe_callback(full, idx)
     print(text, flush=True)
     if output_path:
         with open(output_path, "a", encoding="utf-8") as w:
@@ -120,6 +133,9 @@ def segment_and_transcribe_live(
         print(f"Live mode: segmenting every {segment_seconds}s from '{source}'. Press Ctrl-C to stop.")
         proc = subprocess.Popen(args, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
         processed: set[str] = set()
+        # Timeout: allow generous time but prevent indefinite hangs
+        transcribe_timeout = max(segment_seconds * 5, 60)
+        executor = ThreadPoolExecutor(max_workers=1)
         try:
             while True:
                 # sorted ensures we process in chronological order
@@ -130,7 +146,9 @@ def segment_and_transcribe_live(
                 safe_to_process = files[:-1] if len(files) > 1 else []
                 new_files = [f for f in safe_to_process if f not in processed]
                 for f in new_files:
-                    _process_segment_file(f, tmp, processed, transcribe_callback, output_path)
+                    _process_segment_file(
+                        f, tmp, processed, transcribe_callback, output_path, executor, transcribe_timeout
+                    )
 
                 # If ffmpeg has exited and no new files pending, break
                 ret = proc.poll()
@@ -138,10 +156,13 @@ def segment_and_transcribe_live(
                     # flush remaining unprocessed files (including the last segment)
                     files = sorted(f for f in os.listdir(tmp) if f.startswith("seg_") and f.endswith(".wav"))
                     for f in [f for f in files if f not in processed]:
-                        _process_segment_file(f, tmp, processed, transcribe_callback, output_path)
+                        _process_segment_file(
+                            f, tmp, processed, transcribe_callback, output_path, executor, transcribe_timeout
+                        )
                     break
                 time.sleep(0.3)
         except KeyboardInterrupt:
+            executor.shutdown(wait=False)
             print("\nStopping live capture...")
             try:
                 # Send 'q' command to ffmpeg to quit gracefully

--- a/src/sys2txt/audio.py
+++ b/src/sys2txt/audio.py
@@ -57,6 +57,23 @@ def record_once(source: str, out_wav: str, sample_rate: int, channels: int, dura
     print("Recording finished.")
 
 
+def _process_segment_file(f, tmp, processed, transcribe_callback, output_path):
+    """Process a single finalized segment file: transcribe and print/write output."""
+    full = os.path.join(tmp, f)
+    if os.path.getsize(full) < 64:
+        return
+    processed.add(f)
+    try:
+        idx = int(os.path.splitext(f)[0].split("_")[-1])
+    except Exception:
+        idx = 0
+    text = transcribe_callback(full, idx)
+    print(text, flush=True)
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as w:
+            w.write(text + "\n")
+
+
 def segment_and_transcribe_live(
     source: str,
     sample_rate: int,
@@ -113,44 +130,15 @@ def segment_and_transcribe_live(
                 safe_to_process = files[:-1] if len(files) > 1 else []
                 new_files = [f for f in safe_to_process if f not in processed]
                 for f in new_files:
-                    full = os.path.join(tmp, f)
-                    # Ensure the segment has been finalized and has content
-                    if os.path.getsize(full) < 64:
-                        continue
-                    processed.add(f)
-
-                    # Extract segment index from filename
-                    try:
-                        idx = int(os.path.splitext(f)[0].split("_")[-1])
-                    except Exception:
-                        idx = 0
-
-                    text = transcribe_callback(full, idx)
-                    print(text, flush=True)
-                    if output_path:
-                        with open(output_path, "a", encoding="utf-8") as w:
-                            w.write(text + "\n")
+                    _process_segment_file(f, tmp, processed, transcribe_callback, output_path)
 
                 # If ffmpeg has exited and no new files pending, break
                 ret = proc.poll()
                 if ret is not None:
-                    # flush remaining unprocessed files
+                    # flush remaining unprocessed files (including the last segment)
                     files = sorted(f for f in os.listdir(tmp) if f.startswith("seg_") and f.endswith(".wav"))
-                    new_files = [f for f in files if f not in processed]
-                    for f in new_files:
-                        full = os.path.join(tmp, f)
-                        if os.path.getsize(full) < 64:
-                            continue
-                        processed.add(f)
-                        try:
-                            idx = int(os.path.splitext(f)[0].split("_")[-1])
-                        except Exception:
-                            idx = 0
-                        text = transcribe_callback(full, idx)
-                        print(text, flush=True)
-                        if output_path:
-                            with open(output_path, "a", encoding="utf-8") as w:
-                                w.write(text + "\n")
+                    for f in [f for f in files if f not in processed]:
+                        _process_segment_file(f, tmp, processed, transcribe_callback, output_path)
                     break
                 time.sleep(0.3)
         except KeyboardInterrupt:

--- a/src/sys2txt/transcribe.py
+++ b/src/sys2txt/transcribe.py
@@ -1,18 +1,34 @@
 """Transcription functionality using Whisper models."""
 
 import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
 from typing import Optional
 
 
-def transcribe_file(path: str, engine: str, model_size: str, language: Optional[str], timestamps: bool) -> str:
+def transcribe_file(
+    path: str,
+    engine: str,
+    model_size: str,
+    language: Optional[str],
+    timestamps: bool,
+    model_path: Optional[str] = None,
+    whisper_cpp_path: Optional[str] = None,
+    device: str = "auto",
+) -> str:
     """Transcribe an audio file using the specified Whisper engine.
 
     Args:
         path: Path to audio file
-        engine: Engine to use ("auto", "faster", or "whisper")
+        engine: Engine to use ("auto", "faster", "whisper", or "cpp")
         model_size: Whisper model size (tiny, base, small, medium, large-v2)
         language: Optional language code (e.g., "en"). If None, auto-detect.
         timestamps: Whether to include timestamps in output
+        model_path: Path to whisper.cpp model file (for cpp engine)
+        whisper_cpp_path: Path to whisper-cli binary (for cpp engine)
+        device: Device to use ("auto", "cpu", "vulkan", "gpu", "cuda")
 
     Returns:
         Transcribed text
@@ -25,30 +41,36 @@ def transcribe_file(path: str, engine: str, model_size: str, language: Optional[
             engine = "whisper"
 
     if engine == "faster":
-        return _transcribe_faster_whisper(path, model_size, language, timestamps)
+        return _transcribe_faster_whisper(path, model_size, language, timestamps, device)
     elif engine == "whisper":
         return _transcribe_openai_whisper(path, model_size, language, timestamps)
+    elif engine == "cpp":
+        return _transcribe_whisper_cpp(path, model_size, language, timestamps, model_path, whisper_cpp_path, device)
     else:
         raise ValueError(f"Unknown engine: {engine}")
 
 
-def _transcribe_faster_whisper(path: str, model_size: str, language: Optional[str], timestamps: bool) -> str:
+def _transcribe_faster_whisper(
+    path: str, model_size: str, language: Optional[str], timestamps: bool, device: str = "auto"
+) -> str:
     """Transcribe using faster-whisper (ctranslate2 backend)."""
     try:
         from faster_whisper import WhisperModel  # type: ignore
     except Exception as e:
         raise RuntimeError("faster-whisper is not installed. pip install faster-whisper") from e
 
-    # Auto device selection
-    device = "cpu"
-    compute_type = "int8"
-    # If user has a CUDA-enabled ctranslate2 build installed, they can switch manually by editing below
-    # or by setting environment variable SYS2TXT_DEVICE=cuda
-    if os.environ.get("SYS2TXT_DEVICE") == "cuda":
-        device = "cuda"
-        compute_type = "float16"
+    # Device selection: CLI arg > env var > default (cpu)
+    if device == "auto":
+        device = os.environ.get("SYS2TXT_DEVICE", "cpu")
 
-    model = WhisperModel(model_size, device=device, compute_type=compute_type)
+    if device == "cuda":
+        fw_device = "cuda"
+        compute_type = "float16"
+    else:
+        fw_device = "cpu"
+        compute_type = "int8"
+
+    model = WhisperModel(model_size, device=fw_device, compute_type=compute_type)
     segments, info = model.transcribe(path, vad_filter=True, language=language)
     if timestamps:
         lines = []
@@ -80,3 +102,199 @@ def _transcribe_openai_whisper(path: str, model_size: str, language: Optional[st
         return "\n".join(lines)
     else:
         return result.get("text", "").strip()
+
+
+def _resolve_whisper_cpp_binary(whisper_cpp_path: Optional[str]) -> str:
+    """Resolve the path to the whisper-cli binary.
+
+    Priority:
+    1. Explicit path argument
+    2. SYS2TXT_WHISPER_CPP environment variable
+    3. PATH lookup for 'whisper-cli'
+
+    Args:
+        whisper_cpp_path: Explicit path to whisper-cli binary
+
+    Returns:
+        Path to whisper-cli binary
+
+    Raises:
+        RuntimeError: If binary cannot be found
+    """
+    if whisper_cpp_path:
+        if not os.path.isfile(whisper_cpp_path):
+            raise RuntimeError(f"whisper-cli binary not found at: {whisper_cpp_path}")
+        return whisper_cpp_path
+
+    env_path = os.environ.get("SYS2TXT_WHISPER_CPP")
+    if env_path:
+        if not os.path.isfile(env_path):
+            raise RuntimeError(f"whisper-cli binary not found at SYS2TXT_WHISPER_CPP: {env_path}")
+        return env_path
+
+    path_lookup = shutil.which("whisper-cli")
+    if path_lookup:
+        return path_lookup
+
+    raise RuntimeError(
+        "whisper-cli binary not found. Install whisper.cpp and either:\n"
+        "  1. Add whisper-cli to PATH\n"
+        "  2. Set SYS2TXT_WHISPER_CPP environment variable\n"
+        "  3. Use --whisper-cpp-path argument"
+    )
+
+
+def _resolve_whisper_cpp_model_path(model_path: Optional[str], model_size: str) -> str:
+    """Resolve the path to a whisper.cpp model file.
+
+    Priority:
+    1. Explicit model_path argument
+    2. SYS2TXT_WHISPER_CPP_MODELS directory + ggml-{model_size}.bin
+    3. ~/.local/share/whisper.cpp/models/ggml-{model_size}.bin
+
+    Args:
+        model_path: Explicit path to model file
+        model_size: Whisper model size (tiny, base, small, medium, large-v2)
+
+    Returns:
+        Path to model file
+
+    Raises:
+        RuntimeError: If model file cannot be found
+    """
+    if model_path:
+        if not os.path.isfile(model_path):
+            raise RuntimeError(f"whisper.cpp model not found at: {model_path}")
+        return model_path
+
+    model_filename = f"ggml-{model_size}.bin"
+
+    env_models_dir = os.environ.get("SYS2TXT_WHISPER_CPP_MODELS")
+    if env_models_dir:
+        env_model_path = os.path.join(env_models_dir, model_filename)
+        if os.path.isfile(env_model_path):
+            return env_model_path
+
+    default_dir = Path.home() / ".local" / "share" / "whisper.cpp" / "models"
+    default_path = default_dir / model_filename
+    if default_path.is_file():
+        return str(default_path)
+
+    raise RuntimeError(
+        f"whisper.cpp model '{model_filename}' not found. Either:\n"
+        "  1. Use --model-path to specify the model file\n"
+        f"  2. Set SYS2TXT_WHISPER_CPP_MODELS to directory containing {model_filename}\n"
+        f"  3. Place model at {default_path}"
+    )
+
+
+def _parse_whisper_cpp_output(output: str, timestamps: bool) -> str:
+    """Parse whisper.cpp stdout format.
+
+    Whisper.cpp outputs lines like:
+    [00:00:00.000 --> 00:00:05.120]   Hello world
+
+    Args:
+        output: Raw stdout from whisper-cli
+        timestamps: Whether to include timestamps in output
+
+    Returns:
+        Parsed transcription text
+    """
+    lines = []
+    # Pattern: [HH:MM:SS.mmm --> HH:MM:SS.mmm] text
+    pattern = re.compile(r"\[(\d{2}:\d{2}:\d{2}\.\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}\.\d{3})\]\s*(.*)")
+
+    for line in output.splitlines():
+        match = pattern.match(line.strip())
+        if match:
+            start_str, end_str, text = match.groups()
+            text = text.strip()
+            if not text:
+                continue
+            if timestamps:
+                # Convert HH:MM:SS.mmm to seconds for consistent formatting
+                start_secs = _timestamp_to_seconds(start_str)
+                end_secs = _timestamp_to_seconds(end_str)
+                lines.append(f"[{start_secs:6.2f}-{end_secs:6.2f}] {text}")
+            else:
+                lines.append(text)
+
+    if timestamps:
+        return "\n".join(lines)
+    else:
+        return " ".join(lines).strip()
+
+
+def _timestamp_to_seconds(ts: str) -> float:
+    """Convert HH:MM:SS.mmm timestamp to seconds.
+
+    Args:
+        ts: Timestamp string like "00:01:23.456"
+
+    Returns:
+        Time in seconds as float
+    """
+    parts = ts.split(":")
+    hours = int(parts[0])
+    minutes = int(parts[1])
+    seconds = float(parts[2])
+    return hours * 3600 + minutes * 60 + seconds
+
+
+def _transcribe_whisper_cpp(
+    path: str,
+    model_size: str,
+    language: Optional[str],
+    timestamps: bool,
+    model_path: Optional[str],
+    whisper_cpp_path: Optional[str],
+    device: str,
+) -> str:
+    """Transcribe using whisper.cpp (with optional Vulkan GPU support).
+
+    Args:
+        path: Path to audio file
+        model_size: Whisper model size (tiny, base, small, medium, large-v2)
+        language: Optional language code (e.g., "en"). If None, auto-detect.
+        timestamps: Whether to include timestamps in output
+        model_path: Path to whisper.cpp model file
+        whisper_cpp_path: Path to whisper-cli binary
+        device: Device to use ("auto", "cpu", "vulkan", "gpu", "cuda")
+
+    Returns:
+        Transcribed text
+
+    Raises:
+        RuntimeError: If whisper-cli binary or model not found, or transcription fails
+    """
+    binary = _resolve_whisper_cpp_binary(whisper_cpp_path)
+    model = _resolve_whisper_cpp_model_path(model_path, model_size)
+
+    # Build command
+    cmd = [binary, "-m", model, "-f", path, "-np"]  # -np = no progress
+
+    # Device selection
+    if device == "cpu":
+        cmd.append("--no-gpu")
+    # For auto/vulkan/gpu/cuda, let whisper.cpp use GPU if available
+
+    if language:
+        cmd.extend(["-l", language])
+
+    if not timestamps:
+        cmd.append("--no-timestamps")
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=300)
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"whisper-cli timed out after 300 seconds (possible GPU hang or malformed audio): {binary}"
+        ) from e
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.strip() if e.stderr else "No error output"
+        raise RuntimeError(f"whisper-cli failed: {stderr}") from e
+    except FileNotFoundError as e:
+        raise RuntimeError(f"whisper-cli binary not found: {binary}") from e
+
+    return _parse_whisper_cpp_output(result.stdout, timestamps)

--- a/src/sys2txt/transcribe.py
+++ b/src/sys2txt/transcribe.py
@@ -7,6 +7,12 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
+# Cached model instances to avoid expensive reloads on every segment
+_faster_whisper_model = None
+_faster_whisper_model_key: Optional[tuple] = None
+_openai_whisper_model = None
+_openai_whisper_model_key: Optional[str] = None
+
 
 def transcribe_file(
     path: str,
@@ -70,7 +76,12 @@ def _transcribe_faster_whisper(
         fw_device = "cpu"
         compute_type = "int8"
 
-    model = WhisperModel(model_size, device=fw_device, compute_type=compute_type)
+    global _faster_whisper_model, _faster_whisper_model_key
+    key = (model_size, fw_device, compute_type)
+    if _faster_whisper_model_key != key:
+        _faster_whisper_model = WhisperModel(model_size, device=fw_device, compute_type=compute_type)
+        _faster_whisper_model_key = key
+    model = _faster_whisper_model
     segments, info = model.transcribe(path, vad_filter=True, language=language)
     if timestamps:
         lines = []
@@ -90,7 +101,11 @@ def _transcribe_openai_whisper(path: str, model_size: str, language: Optional[st
     except Exception as e:
         raise RuntimeError("openai-whisper is not installed. pip install openai-whisper") from e
 
-    model = whisper.load_model(model_size)
+    global _openai_whisper_model, _openai_whisper_model_key
+    if _openai_whisper_model_key != model_size:
+        _openai_whisper_model = whisper.load_model(model_size)
+        _openai_whisper_model_key = model_size
+    model = _openai_whisper_model
     result = model.transcribe(path, language=language)
     if timestamps and "segments" in result:
         lines = []

--- a/src/sys2txt/transcribe.py
+++ b/src/sys2txt/transcribe.py
@@ -235,11 +235,14 @@ def _timestamp_to_seconds(ts: str) -> float:
     Returns:
         Time in seconds as float
     """
-    parts = ts.split(":")
-    hours = int(parts[0])
-    minutes = int(parts[1])
-    seconds = float(parts[2])
-    return hours * 3600 + minutes * 60 + seconds
+    try:
+        parts = ts.split(":")
+        hours = int(parts[0])
+        minutes = int(parts[1])
+        seconds = float(parts[2])
+        return hours * 3600 + minutes * 60 + seconds
+    except (IndexError, ValueError):
+        return 0.0
 
 
 def _transcribe_whisper_cpp(

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -4,7 +4,7 @@ import os
 import signal
 import tempfile
 import unittest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from sys2txt.audio import record_once, segment_and_transcribe_live
 
@@ -79,8 +79,14 @@ class TestSegmentAndTranscribeLive(unittest.TestCase):
         mock_proc.stdin = MagicMock()
         mock_popen.return_value = mock_proc
 
-        # Simulate two segments being created
-        mock_listdir.side_effect = [[], ["seg_00000.wav"], ["seg_00000.wav", "seg_00001.wav"], []]
+        # Simulate two segments being created. The flush-path listdir call must also
+        # return both files so the second segment is picked up after ffmpeg exits.
+        mock_listdir.side_effect = [
+            [],
+            ["seg_00000.wav"],
+            ["seg_00000.wav", "seg_00001.wav"],
+            ["seg_00000.wav", "seg_00001.wav"],  # flush path: seg_00001 not yet processed
+        ]
         mock_getsize.return_value = 1024  # Files have content
 
         transcribe_callback = MagicMock(side_effect=["transcript 1", "transcript 2"])
@@ -89,9 +95,7 @@ class TestSegmentAndTranscribeLive(unittest.TestCase):
             with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
                 mock_tmpdir.return_value.__enter__.return_value = tmpdir
 
-                segment_and_transcribe_live(
-                    "test.monitor", 16000, 1, 8, transcribe_callback, None
-                )
+                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None)
 
         # Verify ffmpeg was called with correct args
         mock_which.assert_called_once_with("ffmpeg")
@@ -130,9 +134,7 @@ class TestSegmentAndTranscribeLive(unittest.TestCase):
                 with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
                     mock_tmpdir.return_value.__enter__.return_value = tmpdir
 
-                    segment_and_transcribe_live(
-                        "test.monitor", 16000, 1, 8, transcribe_callback, output_path
-                    )
+                    segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, output_path)
 
             # Verify output was written
             with open(output_path, "r") as f:
@@ -145,9 +147,7 @@ class TestSegmentAndTranscribeLive(unittest.TestCase):
     @patch("sys2txt.audio.subprocess.Popen")
     @patch("sys2txt.audio.time.sleep")
     @patch("sys2txt.audio.os.listdir")
-    def test_segment_and_transcribe_live_keyboard_interrupt(
-        self, mock_listdir, mock_sleep, mock_popen, mock_which
-    ):
+    def test_segment_and_transcribe_live_keyboard_interrupt(self, mock_listdir, mock_sleep, mock_popen, mock_which):
         """Test segment_and_transcribe_live() handles KeyboardInterrupt gracefully."""
         mock_which.return_value = "/usr/bin/ffmpeg"
         mock_proc = MagicMock()
@@ -198,6 +198,77 @@ class TestSegmentAndTranscribeLive(unittest.TestCase):
 
         # Verify callback was NOT called for small file
         transcribe_callback.assert_not_called()
+
+    @patch("sys2txt.audio.which")
+    @patch("sys2txt.audio.subprocess.Popen")
+    @patch("sys2txt.audio.time.sleep")
+    @patch("sys2txt.audio.os.listdir")
+    @patch("sys2txt.audio.os.path.getsize")
+    def test_live_skips_last_segment_while_ffmpeg_running(
+        self, mock_getsize, mock_listdir, mock_sleep, mock_popen, mock_which
+    ):
+        """While ffmpeg is running, the newest segment (still being written) is not transcribed."""
+        mock_which.return_value = "/usr/bin/ffmpeg"
+        mock_proc = MagicMock()
+        # ffmpeg running on first poll, exits on second
+        mock_proc.poll.side_effect = [None, 0]
+        mock_proc.stdin = MagicMock()
+        mock_popen.return_value = mock_proc
+
+        mock_listdir.side_effect = [
+            ["seg_00000.wav", "seg_00001.wav"],  # live iter 1: seg_00000 safe, seg_00001 skipped
+            ["seg_00000.wav", "seg_00001.wav"],  # live iter 2: nothing new safe
+            ["seg_00000.wav", "seg_00001.wav"],  # flush path: seg_00001 now processed
+        ]
+        mock_getsize.return_value = 1024
+
+        transcribe_callback = MagicMock(side_effect=["transcript 0", "transcript 1"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
+                mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None)
+
+        # Both segments transcribed: seg_00000 in live loop, seg_00001 in flush path
+        self.assertEqual(transcribe_callback.call_count, 2)
+        first_call_path = transcribe_callback.call_args_list[0][0][0]
+        second_call_path = transcribe_callback.call_args_list[1][0][0]
+        self.assertIn("seg_00000", first_call_path)
+        self.assertIn("seg_00001", second_call_path)
+
+    @patch("sys2txt.audio.which")
+    @patch("sys2txt.audio.subprocess.Popen")
+    @patch("sys2txt.audio.time.sleep")
+    @patch("sys2txt.audio.os.listdir")
+    @patch("sys2txt.audio.os.path.getsize")
+    def test_live_processes_last_segment_in_flush_path(
+        self, mock_getsize, mock_listdir, mock_sleep, mock_popen, mock_which
+    ):
+        """After ffmpeg exits, the last segment (deferred during live polling) is transcribed."""
+        mock_which.return_value = "/usr/bin/ffmpeg"
+        mock_proc = MagicMock()
+        # ffmpeg exits immediately on first poll; single file only visible during flush
+        mock_proc.poll.side_effect = [0]
+        mock_proc.stdin = MagicMock()
+        mock_popen.return_value = mock_proc
+
+        mock_listdir.side_effect = [
+            ["seg_00000.wav"],  # live iter 1: one file, not safe (it's the active one) → skipped
+            ["seg_00000.wav"],  # flush path: ffmpeg closed it, now process it
+        ]
+        mock_getsize.return_value = 1024
+
+        transcribe_callback = MagicMock(return_value="transcript 0")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
+                mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None)
+
+        # Segment must have been transcribed (in the flush path, not the live loop)
+        transcribe_callback.assert_called_once()
+        call_path = transcribe_callback.call_args_list[0][0][0]
+        self.assertIn("seg_00000", call_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -81,6 +81,13 @@ class TestTranscribeFile(unittest.TestCase):
 class TestTranscribeFasterWhisper(unittest.TestCase):
     """Tests for the _transcribe_faster_whisper() function."""
 
+    def setUp(self):
+        """Reset cached model between tests."""
+        import sys2txt.transcribe as t
+
+        t._faster_whisper_model = None
+        t._faster_whisper_model_key = None
+
     @patch("faster_whisper.WhisperModel")
     def test_transcribe_faster_whisper_no_timestamps(self, mock_model_class):
         """Test _transcribe_faster_whisper() without timestamps."""
@@ -181,6 +188,13 @@ class TestTranscribeFasterWhisper(unittest.TestCase):
 
 class TestTranscribeOpenAIWhisper(unittest.TestCase):
     """Tests for the _transcribe_openai_whisper() function."""
+
+    def setUp(self):
+        """Reset cached model between tests."""
+        import sys2txt.transcribe as t
+
+        t._openai_whisper_model = None
+        t._openai_whisper_model_key = None
 
     @patch("whisper.load_model")
     def test_transcribe_openai_whisper_no_timestamps(self, mock_load_model):

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -2,6 +2,7 @@
 
 import os
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from sys2txt.transcribe import transcribe_file
@@ -19,7 +20,7 @@ class TestTranscribeFile(unittest.TestCase):
             result = transcribe_file("/path/to/audio.wav", "auto", "small", None, False)
 
         self.assertEqual(result, "test transcript")
-        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, False)
+        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, False, "auto")
 
     @patch("sys2txt.transcribe._transcribe_faster_whisper")
     def test_transcribe_file_faster_engine(self, mock_transcribe):
@@ -29,7 +30,7 @@ class TestTranscribeFile(unittest.TestCase):
         result = transcribe_file("/path/to/audio.wav", "faster", "base", "en", True)
 
         self.assertEqual(result, "faster transcript")
-        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "base", "en", True)
+        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "base", "en", True, "auto")
 
     @patch("sys2txt.transcribe._transcribe_openai_whisper")
     def test_transcribe_file_whisper_engine(self, mock_transcribe):
@@ -40,6 +41,33 @@ class TestTranscribeFile(unittest.TestCase):
 
         self.assertEqual(result, "whisper transcript")
         mock_transcribe.assert_called_once_with("/path/to/audio.wav", "medium", "fr", False)
+
+    @patch("sys2txt.transcribe._transcribe_whisper_cpp")
+    def test_transcribe_file_cpp_engine(self, mock_transcribe):
+        """Test transcribe_file() with cpp engine."""
+        mock_transcribe.return_value = "cpp transcript"
+
+        result = transcribe_file(
+            "/path/to/audio.wav",
+            "cpp",
+            "small",
+            "en",
+            True,
+            model_path="/path/to/model.bin",
+            whisper_cpp_path="/path/to/whisper-cli",
+            device="vulkan",
+        )
+
+        self.assertEqual(result, "cpp transcript")
+        mock_transcribe.assert_called_once_with(
+            "/path/to/audio.wav",
+            "small",
+            "en",
+            True,
+            "/path/to/model.bin",
+            "/path/to/whisper-cli",
+            "vulkan",
+        )
 
     def test_transcribe_file_invalid_engine(self):
         """Test transcribe_file() raises ValueError for invalid engine."""
@@ -104,16 +132,40 @@ class TestTranscribeFasterWhisper(unittest.TestCase):
 
     @patch("faster_whisper.WhisperModel")
     @patch.dict(os.environ, {"SYS2TXT_DEVICE": "cuda"})
-    def test_transcribe_faster_whisper_cuda_device(self, mock_model_class):
-        """Test _transcribe_faster_whisper() uses CUDA when env var set."""
+    def test_transcribe_faster_whisper_cuda_device_from_env(self, mock_model_class):
+        """Test _transcribe_faster_whisper() uses CUDA when env var set with auto device."""
         from sys2txt.transcribe import _transcribe_faster_whisper
 
         mock_model = mock_model_class.return_value
         mock_model.transcribe.return_value = ([], None)
 
-        _transcribe_faster_whisper("/path/to/audio.wav", "small", None, False)
+        _transcribe_faster_whisper("/path/to/audio.wav", "small", None, False, device="auto")
 
         mock_model_class.assert_called_once_with("small", device="cuda", compute_type="float16")
+
+    @patch("faster_whisper.WhisperModel")
+    def test_transcribe_faster_whisper_cuda_device_explicit(self, mock_model_class):
+        """Test _transcribe_faster_whisper() uses CUDA when device=cuda."""
+        from sys2txt.transcribe import _transcribe_faster_whisper
+
+        mock_model = mock_model_class.return_value
+        mock_model.transcribe.return_value = ([], None)
+
+        _transcribe_faster_whisper("/path/to/audio.wav", "small", None, False, device="cuda")
+
+        mock_model_class.assert_called_once_with("small", device="cuda", compute_type="float16")
+
+    @patch("faster_whisper.WhisperModel")
+    def test_transcribe_faster_whisper_cpu_device_explicit(self, mock_model_class):
+        """Test _transcribe_faster_whisper() uses CPU when device=cpu."""
+        from sys2txt.transcribe import _transcribe_faster_whisper
+
+        mock_model = mock_model_class.return_value
+        mock_model.transcribe.return_value = ([], None)
+
+        _transcribe_faster_whisper("/path/to/audio.wav", "small", None, False, device="cpu")
+
+        mock_model_class.assert_called_once_with("small", device="cpu", compute_type="int8")
 
     def test_transcribe_faster_whisper_not_installed(self):
         """Test _transcribe_faster_whisper() raises RuntimeError when not installed."""
@@ -176,6 +228,322 @@ class TestTranscribeOpenAIWhisper(unittest.TestCase):
                 _transcribe_openai_whisper("/path/to/audio.wav", "small", None, False)
 
             self.assertIn("openai-whisper is not installed", str(cm.exception))
+
+
+class TestResolveWhisperCppBinary(unittest.TestCase):
+    """Tests for the _resolve_whisper_cpp_binary() function."""
+
+    def test_explicit_path_valid(self):
+        """Test explicit path that exists."""
+        from sys2txt.transcribe import _resolve_whisper_cpp_binary
+
+        with patch("os.path.isfile", return_value=True):
+            result = _resolve_whisper_cpp_binary("/path/to/whisper-cli")
+
+        self.assertEqual(result, "/path/to/whisper-cli")
+
+    def test_explicit_path_invalid(self):
+        """Test explicit path that doesn't exist."""
+        from sys2txt.transcribe import _resolve_whisper_cpp_binary
+
+        with patch("os.path.isfile", return_value=False):
+            with self.assertRaises(RuntimeError) as cm:
+                _resolve_whisper_cpp_binary("/path/to/whisper-cli")
+
+        self.assertIn("not found at", str(cm.exception))
+
+    @patch.dict(os.environ, {"SYS2TXT_WHISPER_CPP": "/env/whisper-cli"})
+    def test_env_var_valid(self):
+        """Test environment variable path that exists."""
+        from sys2txt.transcribe import _resolve_whisper_cpp_binary
+
+        with patch("os.path.isfile", return_value=True):
+            result = _resolve_whisper_cpp_binary(None)
+
+        self.assertEqual(result, "/env/whisper-cli")
+
+    @patch.dict(os.environ, {"SYS2TXT_WHISPER_CPP": "/env/whisper-cli"})
+    def test_env_var_invalid(self):
+        """Test environment variable path that doesn't exist."""
+        from sys2txt.transcribe import _resolve_whisper_cpp_binary
+
+        with patch("os.path.isfile", return_value=False):
+            with self.assertRaises(RuntimeError) as cm:
+                _resolve_whisper_cpp_binary(None)
+
+        self.assertIn("SYS2TXT_WHISPER_CPP", str(cm.exception))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_path_lookup_found(self):
+        """Test PATH lookup succeeds."""
+        from sys2txt.transcribe import _resolve_whisper_cpp_binary
+
+        with patch("shutil.which", return_value="/usr/bin/whisper-cli"):
+            result = _resolve_whisper_cpp_binary(None)
+
+        self.assertEqual(result, "/usr/bin/whisper-cli")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_path_lookup_not_found(self):
+        """Test PATH lookup fails."""
+        from sys2txt.transcribe import _resolve_whisper_cpp_binary
+
+        with patch("shutil.which", return_value=None):
+            with self.assertRaises(RuntimeError) as cm:
+                _resolve_whisper_cpp_binary(None)
+
+        self.assertIn("whisper-cli binary not found", str(cm.exception))
+
+
+class TestResolveWhisperCppModelPath(unittest.TestCase):
+    """Tests for the _resolve_whisper_cpp_model_path() function."""
+
+    def test_explicit_path_valid(self):
+        """Test explicit model path that exists."""
+        from sys2txt.transcribe import _resolve_whisper_cpp_model_path
+
+        with patch("os.path.isfile", return_value=True):
+            result = _resolve_whisper_cpp_model_path("/path/to/model.bin", "small")
+
+        self.assertEqual(result, "/path/to/model.bin")
+
+    def test_explicit_path_invalid(self):
+        """Test explicit model path that doesn't exist."""
+        from sys2txt.transcribe import _resolve_whisper_cpp_model_path
+
+        with patch("os.path.isfile", return_value=False):
+            with self.assertRaises(RuntimeError) as cm:
+                _resolve_whisper_cpp_model_path("/path/to/model.bin", "small")
+
+        self.assertIn("not found at", str(cm.exception))
+
+    @patch.dict(os.environ, {"SYS2TXT_WHISPER_CPP_MODELS": "/models"})
+    def test_env_var_models_dir(self):
+        """Test models directory from environment variable."""
+        from sys2txt.transcribe import _resolve_whisper_cpp_model_path
+
+        with patch("os.path.isfile", return_value=True):
+            result = _resolve_whisper_cpp_model_path(None, "small")
+
+        self.assertEqual(result, "/models/ggml-small.bin")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_default_path(self):
+        """Test default path in ~/.local/share/whisper.cpp/models/."""
+        from sys2txt.transcribe import _resolve_whisper_cpp_model_path
+
+        expected_path = Path.home() / ".local" / "share" / "whisper.cpp" / "models" / "ggml-tiny.bin"
+
+        with patch.object(Path, "is_file", return_value=True):
+            result = _resolve_whisper_cpp_model_path(None, "tiny")
+
+        self.assertEqual(result, str(expected_path))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_model_not_found(self):
+        """Test model not found anywhere."""
+        from sys2txt.transcribe import _resolve_whisper_cpp_model_path
+
+        with patch("os.path.isfile", return_value=False):
+            with patch.object(Path, "is_file", return_value=False):
+                with self.assertRaises(RuntimeError) as cm:
+                    _resolve_whisper_cpp_model_path(None, "small")
+
+        self.assertIn("ggml-small.bin", str(cm.exception))
+
+
+class TestParseWhisperCppOutput(unittest.TestCase):
+    """Tests for the _parse_whisper_cpp_output() function."""
+
+    def test_parse_with_timestamps(self):
+        """Test parsing whisper.cpp output with timestamps enabled."""
+        from sys2txt.transcribe import _parse_whisper_cpp_output
+
+        output = """[00:00:00.000 --> 00:00:05.120]   Hello world
+[00:00:05.120 --> 00:00:10.240]   This is a test"""
+
+        result = _parse_whisper_cpp_output(output, timestamps=True)
+
+        self.assertIn("[  0.00-  5.12] Hello world", result)
+        self.assertIn("[  5.12- 10.24] This is a test", result)
+
+    def test_parse_without_timestamps(self):
+        """Test parsing whisper.cpp output without timestamps."""
+        from sys2txt.transcribe import _parse_whisper_cpp_output
+
+        output = """[00:00:00.000 --> 00:00:05.120]   Hello world
+[00:00:05.120 --> 00:00:10.240]   This is a test"""
+
+        result = _parse_whisper_cpp_output(output, timestamps=False)
+
+        self.assertEqual(result, "Hello world This is a test")
+
+    def test_parse_empty_segments_ignored(self):
+        """Test that empty segments are ignored."""
+        from sys2txt.transcribe import _parse_whisper_cpp_output
+
+        output = """[00:00:00.000 --> 00:00:05.120]   Hello
+[00:00:05.120 --> 00:00:10.240]
+[00:00:10.240 --> 00:00:15.000]   World"""
+
+        result = _parse_whisper_cpp_output(output, timestamps=False)
+
+        self.assertEqual(result, "Hello World")
+
+    def test_parse_non_matching_lines_ignored(self):
+        """Test that non-matching lines are ignored."""
+        from sys2txt.transcribe import _parse_whisper_cpp_output
+
+        output = """whisper_init_from_file_no_state: loading model...
+[00:00:00.000 --> 00:00:05.120]   Hello world
+main: some debug output"""
+
+        result = _parse_whisper_cpp_output(output, timestamps=False)
+
+        self.assertEqual(result, "Hello world")
+
+
+class TestTimestampToSeconds(unittest.TestCase):
+    """Tests for the _timestamp_to_seconds() function."""
+
+    def test_simple_seconds(self):
+        """Test simple seconds conversion."""
+        from sys2txt.transcribe import _timestamp_to_seconds
+
+        result = _timestamp_to_seconds("00:00:05.120")
+        self.assertAlmostEqual(result, 5.12, places=3)
+
+    def test_minutes_and_seconds(self):
+        """Test minutes and seconds conversion."""
+        from sys2txt.transcribe import _timestamp_to_seconds
+
+        result = _timestamp_to_seconds("00:02:30.500")
+        self.assertAlmostEqual(result, 150.5, places=3)
+
+    def test_hours_minutes_seconds(self):
+        """Test hours, minutes, and seconds conversion."""
+        from sys2txt.transcribe import _timestamp_to_seconds
+
+        result = _timestamp_to_seconds("01:30:45.750")
+        self.assertAlmostEqual(result, 5445.75, places=3)
+
+
+class TestTranscribeWhisperCpp(unittest.TestCase):
+    """Tests for the _transcribe_whisper_cpp() function."""
+
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
+    @patch("subprocess.run")
+    def test_transcribe_success(self, mock_run, mock_model_path, mock_binary):
+        """Test successful transcription."""
+        from sys2txt.transcribe import _transcribe_whisper_cpp
+
+        mock_binary.return_value = "/path/to/whisper-cli"
+        mock_model_path.return_value = "/path/to/model.bin"
+        mock_run.return_value = MagicMock(
+            stdout="[00:00:00.000 --> 00:00:05.000]   Hello world\n",
+            returncode=0,
+        )
+
+        result = _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, False, None, None, "auto")
+
+        self.assertEqual(result, "Hello world")
+        mock_run.assert_called_once()
+
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
+    @patch("subprocess.run")
+    def test_transcribe_with_language(self, mock_run, mock_model_path, mock_binary):
+        """Test transcription with language specified."""
+        from sys2txt.transcribe import _transcribe_whisper_cpp
+
+        mock_binary.return_value = "/path/to/whisper-cli"
+        mock_model_path.return_value = "/path/to/model.bin"
+        mock_run.return_value = MagicMock(
+            stdout="[00:00:00.000 --> 00:00:05.000]   Bonjour\n",
+            returncode=0,
+        )
+
+        _transcribe_whisper_cpp("/path/to/audio.wav", "small", "fr", False, None, None, "auto")
+
+        # Check -l fr is in the command
+        call_args = mock_run.call_args[0][0]
+        self.assertIn("-l", call_args)
+        self.assertIn("fr", call_args)
+
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
+    @patch("subprocess.run")
+    def test_transcribe_cpu_device(self, mock_run, mock_model_path, mock_binary):
+        """Test transcription with CPU device adds --no-gpu flag."""
+        from sys2txt.transcribe import _transcribe_whisper_cpp
+
+        mock_binary.return_value = "/path/to/whisper-cli"
+        mock_model_path.return_value = "/path/to/model.bin"
+        mock_run.return_value = MagicMock(
+            stdout="[00:00:00.000 --> 00:00:05.000]   Hello\n",
+            returncode=0,
+        )
+
+        _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, False, None, None, "cpu")
+
+        call_args = mock_run.call_args[0][0]
+        self.assertIn("--no-gpu", call_args)
+
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
+    @patch("subprocess.run")
+    def test_transcribe_vulkan_device(self, mock_run, mock_model_path, mock_binary):
+        """Test transcription with Vulkan device does not add --no-gpu."""
+        from sys2txt.transcribe import _transcribe_whisper_cpp
+
+        mock_binary.return_value = "/path/to/whisper-cli"
+        mock_model_path.return_value = "/path/to/model.bin"
+        mock_run.return_value = MagicMock(
+            stdout="[00:00:00.000 --> 00:00:05.000]   Hello\n",
+            returncode=0,
+        )
+
+        _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, False, None, None, "vulkan")
+
+        call_args = mock_run.call_args[0][0]
+        self.assertNotIn("--no-gpu", call_args)
+
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
+    @patch("subprocess.run")
+    def test_transcribe_failure(self, mock_run, mock_model_path, mock_binary):
+        """Test transcription failure raises RuntimeError."""
+        import subprocess
+
+        from sys2txt.transcribe import _transcribe_whisper_cpp
+
+        mock_binary.return_value = "/path/to/whisper-cli"
+        mock_model_path.return_value = "/path/to/model.bin"
+        mock_run.side_effect = subprocess.CalledProcessError(1, "whisper-cli", stderr="Error: model not found")
+
+        with self.assertRaises(RuntimeError) as cm:
+            _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, False, None, None, "auto")
+
+        self.assertIn("whisper-cli failed", str(cm.exception))
+
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
+    @patch("subprocess.run")
+    def test_transcribe_timeout_raises_runtime_error(self, mock_run, mock_model_path, mock_binary):
+        """Test that a hung whisper-cli process raises RuntimeError after timeout."""
+        import subprocess
+
+        from sys2txt.transcribe import _transcribe_whisper_cpp
+
+        mock_binary.return_value = "/path/to/whisper-cli"
+        mock_model_path.return_value = "/path/to/model.bin"
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="whisper-cli", timeout=300)
+
+        with self.assertRaises(RuntimeError) as cm:
+            _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, False, None, None, "auto")
+
+        self.assertIn("timed out", str(cm.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Fix freezing in live mode**: The segment monitor now skips the last (still-being-written) segment file while ffmpeg is running, only processing segments that have been finalized by the existence of a newer one. This prevents transcription of incomplete audio data that caused hangs.
- **Add whisper.cpp engine**: New `cpp` engine option uses the `whisper-cli` binary, supporting Vulkan GPU acceleration for AMD GPUs. Configurable via `--engine cpp`, `--whisper-cpp-path`, `--model-path`, and `--device` flags, or `SYS2TXT_WHISPER_CPP` / `SYS2TXT_WHISPER_CPP_MODELS` environment variables.
- **Add `--device` flag**: Unified device selection (`auto`, `cpu`, `vulkan`, `gpu`, `cuda`) across engines.

## Test plan

- [ ] Run `sys2txt live --model small` and confirm no freezing between segments
- [ ] Run `sys2txt once --engine cpp --model small` with a built whisper-cli binary and confirm transcription works

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/claude-code)