### PR TITLE
feat: restrict workflow triggers with path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'requirements.txt'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'requirements.txt'
+      - '.github/workflows/ci.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'pyproject.toml'
+      - 'release-please-config.json'
+      - '.release-please-manifest.json'
+      - '.github/workflows/release-please.yml'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Add `paths` filters to `ci.yml` so the CI pipeline only runs when source code, tests, dependencies, or the workflow itself changes
- Add `paths` filters to `release-please.yml` so it only runs when source, package config, or release-please config changes

## Test plan

- [ ] Verify CI does not trigger on doc-only changes (e.g. README edits)
- [ ] Verify CI triggers on changes to `src/**`, `tests/**`, `pyproject.toml`, `requirements.txt`
- [ ] Verify release-please triggers on `src/**` and config file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)