### PR TITLE
Restrict path triggers for GitHub Actions workflows

### DIFF
--- a/src/sys2txt/transcribe.py
+++ b/src/sys2txt/transcribe.py
@@ -42,8 +42,10 @@ def transcribe_file(
     engine = engine.lower()
     if engine == "auto":
         try:
+            import faster_whisper  # noqa: F401
+
             engine = "faster"
-        except Exception:
+        except ImportError:
             engine = "whisper"
 
     if engine == "faster":

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -69,6 +69,16 @@ class TestTranscribeFile(unittest.TestCase):
             "vulkan",
         )
 
+    def test_transcribe_file_auto_falls_back_to_openai_whisper(self):
+        """Test transcribe_file() auto falls back to openai-whisper when faster-whisper is not installed."""
+        with patch.dict("sys.modules", {"faster_whisper": None}):
+            with patch("sys2txt.transcribe._transcribe_openai_whisper") as mock_transcribe:
+                mock_transcribe.return_value = "fallback transcript"
+                result = transcribe_file("/path/to/audio.wav", "auto", "small", None, False)
+
+        self.assertEqual(result, "fallback transcript")
+        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, False)
+
     def test_transcribe_file_invalid_engine(self):
         """Test transcribe_file() raises ValueError for invalid engine."""
         with self.assertRaises(ValueError) as cm:


### PR DESCRIPTION
## Summary
- Add path filters to CI and release-please workflow triggers so they only run when relevant files change (src/, tests/, pyproject.toml, etc.)
- Fix auto-engine detection to use explicit `import faster_whisper` with `ImportError` catch instead of a bare try/except

## Test plan
- [ ] Verify CI workflow runs on PRs that modify source/test files
- [ ] Verify CI workflow does not run on PRs that only modify docs
- [ ] Verify auto-engine fallback works when faster-whisper is not installed (new unit test added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)