### PR TITLE
fix: replace bare except clauses with specific exception types

### DIFF
--- a/src/sys2txt/audio.py
+++ b/src/sys2txt/audio.py
@@ -53,7 +53,7 @@ def record_once(source: str, out_wav: str, sample_rate: int, channels: int, dura
     except KeyboardInterrupt:
         try:
             proc.send_signal(signal.SIGINT)
-        except Exception:
+        except OSError:
             pass
         proc.wait()
     print("Recording finished.")
@@ -67,7 +67,7 @@ def _process_segment_file(f, tmp, processed, transcribe_callback, output_path, e
     processed.add(f)
     try:
         idx = int(os.path.splitext(f)[0].split("_")[-1])
-    except Exception:
+    except (ValueError, IndexError):
         idx = 0
     if executor and timeout:
         future = executor.submit(transcribe_callback, full, idx)
@@ -177,6 +177,6 @@ def segment_and_transcribe_live(
                     # If it doesn't finish in time, terminate it
                     proc.terminate()
                     proc.wait()
-            except Exception:
+            except OSError:
                 pass
             print("Stopped live capture.")

--- a/src/sys2txt/pulse.py
+++ b/src/sys2txt/pulse.py
@@ -43,6 +43,6 @@ def get_default_monitor_source() -> str:
         for s, _ in list_pulse_sources():
             if s.endswith(".monitor"):
                 return s
-    except Exception:
+    except (FileNotFoundError, RuntimeError):
         pass
     return "default"

--- a/src/sys2txt/transcribe.py
+++ b/src/sys2txt/transcribe.py
@@ -64,7 +64,7 @@ def _transcribe_faster_whisper(
     """Transcribe using faster-whisper (ctranslate2 backend)."""
     try:
         from faster_whisper import WhisperModel  # type: ignore
-    except Exception as e:
+    except ImportError as e:
         raise RuntimeError("faster-whisper is not installed. pip install faster-whisper") from e
 
     # Device selection: CLI arg > env var > default (cpu)
@@ -100,7 +100,7 @@ def _transcribe_openai_whisper(path: str, model_size: str, language: Optional[st
     """Transcribe using openai-whisper (reference implementation)."""
     try:
         import whisper  # type: ignore
-    except Exception as e:
+    except ImportError as e:
         raise RuntimeError("openai-whisper is not installed. pip install openai-whisper") from e
 
     global _openai_whisper_model, _openai_whisper_model_key

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -121,7 +121,7 @@ class TestGetDefaultMonitorSource(unittest.TestCase):
     @patch("sys2txt.pulse.run_command")
     def test_get_default_monitor_source_exception(self, mock_run, mock_list):
         """Test get_default_monitor_source() handles exceptions gracefully."""
-        mock_run.side_effect = Exception("Unexpected error")
+        mock_run.side_effect = RuntimeError("Unexpected error")
         mock_list.return_value = []
 
         source = get_default_monitor_source()


### PR DESCRIPTION
## Summary

- Replace `except Exception` with specific types (`OSError`, `ImportError`, `ValueError`, `IndexError`) in `audio.py`, `pulse.py`, and `transcribe.py`
- Update `test_pulse.py` to use `RuntimeError` instead of `Exception` as the mock side effect

## Test plan

- [ ] Run `python -m unittest discover -s tests -p "test_*.py"` and verify all tests pass
- [ ] Run `ruff check src/` and verify no linting errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)