### PR TITLE
feat: replace print statements with logging

### DIFF
--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -2,6 +2,7 @@
 """Main entry point for sys2txt CLI."""
 
 import argparse
+import logging
 import os
 import sys
 import tempfile
@@ -33,9 +34,28 @@ def ensure_output_dir() -> str:
     return output_dir
 
 
+logger = logging.getLogger(__name__)
+
+
+def _configure_logging(verbose: bool, quiet: bool) -> None:
+    """Configure logging based on CLI flags and LOG_LEVEL environment variable."""
+    level_name = os.environ.get("LOG_LEVEL", "").upper()
+    if level_name and hasattr(logging, level_name):
+        level = getattr(logging, level_name)
+    elif quiet:
+        level = logging.WARNING
+    elif verbose:
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s", stream=sys.stderr)
+
+
 def main():
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(description="Record Ubuntu system audio and transcribe with Whisper.")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose (debug) logging")
+    parser.add_argument("--quiet", "-q", action="store_true", help="Suppress informational log messages")
     sub = parser.add_subparsers(dest="mode", required=True)
 
     common = argparse.ArgumentParser(add_help=False)
@@ -88,16 +108,18 @@ def main():
 
     args = parser.parse_args()
 
+    _configure_logging(verbose=args.verbose, quiet=args.quiet)
+
     if args.engine not in ("cpp", "auto"):
         if args.model_path:
-            print("Warning: --model-path is only used with --engine cpp", file=sys.stderr)
+            logger.warning("--model-path is only used with --engine cpp")
         if args.whisper_cpp_path:
-            print("Warning: --whisper-cpp-path is only used with --engine cpp", file=sys.stderr)
+            logger.warning("--whisper-cpp-path is only used with --engine cpp")
 
     if args.list_sources:
         sources = list_pulse_sources()
         if not sources:
-            print("No PulseAudio sources found. Is PulseAudio/PipeWire running?", file=sys.stderr)
+            logger.error("No PulseAudio sources found. Is PulseAudio/PipeWire running?")
             sys.exit(1)
         print("Available PulseAudio sources:")
         for name, _ in sources:
@@ -138,7 +160,7 @@ def main():
                 print(text)
                 with open(output_file, "w", encoding="utf-8") as w:
                     w.write(text + "\n")
-                print(f"Transcript saved to: {output_file}")
+                logger.info("Transcript saved to: %s", output_file)
                 return
         # If input provided, just transcribe it
         text = transcribe_file(
@@ -154,7 +176,7 @@ def main():
         print(text)
         with open(output_file, "w", encoding="utf-8") as w:
             w.write(text + "\n")
-        print(f"Transcript saved to: {output_file}")
+        logger.info("Transcript saved to: %s", output_file)
 
     elif args.mode == "live":
         # Determine output file path
@@ -166,7 +188,7 @@ def main():
             # Generate timestamp-based filename in output/ directory
             output_file = os.path.join(output_dir, get_timestamp_filename())
 
-        print(f"Live transcript will be saved to: {output_file}")
+        logger.info("Live transcript will be saved to: %s", output_file)
 
         def transcribe_segment(file_path: str, segment_index: int) -> str:
             """Transcribe a segment and format with optional timestamp prefix."""
@@ -203,7 +225,7 @@ if __name__ == "__main__":
     try:
         main()
     except RuntimeError as e:
-        print(f"Error: {e}", file=sys.stderr)
+        logger.error("%s", e)
         sys.exit(1)
     except KeyboardInterrupt:
         pass

--- a/src/sys2txt/audio.py
+++ b/src/sys2txt/audio.py
@@ -1,5 +1,6 @@
 """Audio recording functionality using ffmpeg and PulseAudio/PipeWire."""
 
+import logging
 import os
 import signal
 import subprocess
@@ -10,6 +11,8 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Optional
 
 from .utils import which
+
+logger = logging.getLogger(__name__)
 
 
 def record_once(source: str, out_wav: str, sample_rate: int, channels: int, duration: Optional[int]) -> None:
@@ -44,8 +47,11 @@ def record_once(source: str, out_wav: str, sample_rate: int, channels: int, dura
         args.extend(["-t", str(duration)])
     args.append(out_wav)
 
-    print(f"Recording system audio from source '{source}' at {sample_rate} Hz, mono -> {out_wav}")
-    print("Press Ctrl-C to stop early..." if duration is None else f"Recording for {duration} seconds...")
+    logger.info("Recording system audio from source '%s' at %d Hz, mono -> %s", source, sample_rate, out_wav)
+    if duration is None:
+        logger.info("Press Ctrl-C to stop early...")
+    else:
+        logger.info("Recording for %d seconds...", duration)
 
     proc = subprocess.Popen(args)
     try:
@@ -56,7 +62,7 @@ def record_once(source: str, out_wav: str, sample_rate: int, channels: int, dura
         except OSError:
             pass
         proc.wait()
-    print("Recording finished.")
+    logger.info("Recording finished.")
 
 
 def _process_segment_file(f, tmp, processed, transcribe_callback, output_path, executor, timeout):
@@ -74,10 +80,10 @@ def _process_segment_file(f, tmp, processed, transcribe_callback, output_path, e
         try:
             text = future.result(timeout=timeout)
         except FuturesTimeoutError:
-            print(f"[Warning] Segment {f} transcription timed out, skipping", flush=True)
+            logger.warning("Segment %s transcription timed out, skipping", f)
             return
         except Exception as e:
-            print(f"[Warning] Segment {f} transcription failed: {e}", flush=True)
+            logger.warning("Segment %s transcription failed: %s", f, e)
             return
     else:
         text = transcribe_callback(full, idx)
@@ -130,7 +136,7 @@ def segment_and_transcribe_live(
             pattern,
         ]
 
-        print(f"Live mode: segmenting every {segment_seconds}s from '{source}'. Press Ctrl-C to stop.")
+        logger.info("Live mode: segmenting every %ds from '%s'. Press Ctrl-C to stop.", segment_seconds, source)
         proc = subprocess.Popen(args, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
         processed: set[str] = set()
         # Timeout: allow generous time but prevent indefinite hangs
@@ -163,7 +169,7 @@ def segment_and_transcribe_live(
                 time.sleep(0.3)
         except KeyboardInterrupt:
             executor.shutdown(wait=False)
-            print("\nStopping live capture...")
+            logger.info("Stopping live capture...")
             try:
                 # Send 'q' command to ffmpeg to quit gracefully
                 if proc.stdin:
@@ -179,4 +185,4 @@ def segment_and_transcribe_live(
                     proc.wait()
             except OSError:
                 pass
-            print("Stopped live capture.")
+            logger.info("Stopped live capture.")


### PR DESCRIPTION
## Summary

- Add `logging` module to `__main__.py` and `audio.py`, replacing all `print()` calls with structured log calls
- Add `--verbose` / `-v` and `--quiet` / `-q` CLI flags to control log level
- Support `LOG_LEVEL` environment variable for log level override
- Logging output goes to stderr; transcript text output remains on stdout

## Test plan

- [ ] `sys2txt once --model small` still shows informational messages
- [ ] `sys2txt once --quiet --model small` suppresses info messages
- [ ] `sys2txt once --verbose --model small` shows debug output
- [ ] `LOG_LEVEL=DEBUG sys2txt once --model small` enables debug logging
- [ ] Existing unit tests pass: `python -m unittest discover -s tests -p "test_*.py"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)