### PR TITLE
feat: thread-safe model caching in transcribe.py

### DIFF
--- a/src/sys2txt/transcribe.py
+++ b/src/sys2txt/transcribe.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 from typing import Optional
 
@@ -12,6 +13,7 @@ _faster_whisper_model = None
 _faster_whisper_model_key: Optional[tuple] = None
 _openai_whisper_model = None
 _openai_whisper_model_key: Optional[str] = None
+_model_cache_lock = threading.Lock()
 
 
 def transcribe_file(
@@ -80,10 +82,11 @@ def _transcribe_faster_whisper(
 
     global _faster_whisper_model, _faster_whisper_model_key
     key = (model_size, fw_device, compute_type)
-    if _faster_whisper_model_key != key:
-        _faster_whisper_model = WhisperModel(model_size, device=fw_device, compute_type=compute_type)
-        _faster_whisper_model_key = key
-    model = _faster_whisper_model
+    with _model_cache_lock:
+        if _faster_whisper_model_key != key:
+            _faster_whisper_model = WhisperModel(model_size, device=fw_device, compute_type=compute_type)
+            _faster_whisper_model_key = key
+        model = _faster_whisper_model
     segments, info = model.transcribe(path, vad_filter=True, language=language)
     if timestamps:
         lines = []
@@ -104,10 +107,11 @@ def _transcribe_openai_whisper(path: str, model_size: str, language: Optional[st
         raise RuntimeError("openai-whisper is not installed. pip install openai-whisper") from e
 
     global _openai_whisper_model, _openai_whisper_model_key
-    if _openai_whisper_model_key != model_size:
-        _openai_whisper_model = whisper.load_model(model_size)
-        _openai_whisper_model_key = model_size
-    model = _openai_whisper_model
+    with _model_cache_lock:
+        if _openai_whisper_model_key != model_size:
+            _openai_whisper_model = whisper.load_model(model_size)
+            _openai_whisper_model_key = model_size
+        model = _openai_whisper_model
     result = model.transcribe(path, language=language)
     if timestamps and "segments" in result:
         lines = []

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -570,5 +570,50 @@ class TestTranscribeWhisperCpp(unittest.TestCase):
         self.assertIn("timed out", str(cm.exception))
 
 
+class TestModelCacheThreadSafety(unittest.TestCase):
+    """Tests that model caching is thread-safe."""
+
+    def setUp(self):
+        """Reset cached model between tests."""
+        import sys2txt.transcribe as t
+
+        t._faster_whisper_model = None
+        t._faster_whisper_model_key = None
+
+    @patch("faster_whisper.WhisperModel")
+    def test_concurrent_calls_load_model_once(self, mock_model_class):
+        """Concurrent transcriptions with same params should only load the model once."""
+        import threading
+
+        from sys2txt.transcribe import _transcribe_faster_whisper
+
+        seg = MagicMock()
+        seg.text = " Hello "
+        seg.start = 0.0
+        seg.end = 1.0
+
+        mock_model = mock_model_class.return_value
+        mock_model.transcribe.return_value = ([seg], None)
+
+        barrier = threading.Barrier(4)
+        errors = []
+
+        def worker():
+            try:
+                barrier.wait(timeout=5)
+                _transcribe_faster_whisper("/path/to/audio.wav", "small", None, False, device="cpu")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        self.assertEqual(errors, [])
+        mock_model_class.assert_called_once_with("small", device="cpu", compute_type="int8")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add a `threading.Lock` (`_model_cache_lock`) to protect the model cache globals in `transcribe.py`
- Wrap model cache reads/writes in both `_transcribe_faster_whisper` and `_transcribe_openai_whisper` with the lock to prevent race conditions under concurrent calls
- Add `TestModelCacheThreadSafety` test class verifying that 4 concurrent threads with the same params only load the model once

🤖 Generated with [Claude Code](https://claude.com/claude-code)