### PR TITLE
ci: update Python version matrix to 3.10–3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Drop Python 3.9 (reached end-of-life October 2025)
- Add Python 3.13 and 3.14 to the CI test matrix
- Matrix now covers: 3.10, 3.11, 3.12, 3.13, 3.14

## Test plan
- [x] Verify CI passes on all five Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)