### PR TITLE
feat: auto-stop live mode after a period of silence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Common flags:
 - `--output <path>`: Write transcript to file
 - `--duration <seconds>`: (once mode) Fixed recording duration
 - `--segment-seconds <n>`: (live mode) Segment length (default: 8)
+- `--silence-timeout <seconds>`: (live mode) Auto-stop after N consecutive seconds of silence (0=disabled, default: 0)
 - `--timestamps`: Include timestamps in output
 - `--model-path <path>`: Path to whisper.cpp model file (for cpp engine)
 - `--whisper-cpp-path <path>`: Path to whisper-cli binary (for cpp engine)

--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -132,6 +132,12 @@ def main():
     live = sub.add_parser("live", parents=[common], help="Segmented live transcription")
     live.add_argument("--segment-seconds", type=int, default=8, help="Segment length in seconds (default: 8)")
     live.add_argument("--output", default=None, help="Append live transcript to this file as it's produced")
+    live.add_argument(
+        "--silence-timeout",
+        type=int,
+        default=0,
+        help="Auto-stop after N consecutive seconds of silence (0=disabled, default: 0)",
+    )
 
     args = parser.parse_args()
 
@@ -192,6 +198,7 @@ def main():
             segment_seconds=args.segment_seconds,
             transcribe_callback=transcribe_segment,
             output_path=output_file,
+            silence_timeout=args.silence_timeout,
         )
 
 

--- a/src/sys2txt/audio.py
+++ b/src/sys2txt/audio.py
@@ -15,6 +15,27 @@ from .utils import which
 logger = logging.getLogger(__name__)
 
 
+class _SilenceTimeout(Exception):
+    """Raised internally when consecutive silence exceeds the timeout."""
+
+
+def _stop_ffmpeg(proc, executor):
+    """Gracefully stop ffmpeg and shut down the transcription executor."""
+    executor.shutdown(wait=False)
+    try:
+        if proc.stdin:
+            proc.stdin.write(b"q")
+            proc.stdin.flush()
+            proc.stdin.close()
+        try:
+            proc.wait(timeout=3.0)
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            proc.wait()
+    except OSError:
+        pass
+
+
 def record_once(source: str, out_wav: str, sample_rate: int, channels: int, duration: Optional[int]) -> None:
     """Record audio once from a PulseAudio source to a WAV file.
 
@@ -69,7 +90,7 @@ def _process_segment_file(f, tmp, processed, transcribe_callback, output_path, e
     """Process a single finalized segment file: transcribe and print/write output."""
     full = os.path.join(tmp, f)
     if os.path.getsize(full) < 64:
-        return
+        return ""
     processed.add(f)
     try:
         idx = int(os.path.splitext(f)[0].split("_")[-1])
@@ -81,16 +102,17 @@ def _process_segment_file(f, tmp, processed, transcribe_callback, output_path, e
             text = future.result(timeout=timeout)
         except FuturesTimeoutError:
             logger.warning("Segment %s transcription timed out, skipping", f)
-            return
+            return ""
         except Exception as e:
             logger.warning("Segment %s transcription failed: %s", f, e)
-            return
+            return ""
     else:
         text = transcribe_callback(full, idx)
     print(text, flush=True)
     if output_path:
         with open(output_path, "a", encoding="utf-8") as w:
             w.write(text + "\n")
+    return text
 
 
 def segment_and_transcribe_live(
@@ -100,6 +122,7 @@ def segment_and_transcribe_live(
     segment_seconds: int,
     transcribe_callback,
     output_path: Optional[str],
+    silence_timeout: int = 0,
 ) -> None:
     """Record audio in segments and transcribe each segment as it's created.
 
@@ -110,6 +133,7 @@ def segment_and_transcribe_live(
         segment_seconds: Length of each segment in seconds
         transcribe_callback: Function to call for each segment. Should accept (file_path, segment_index) and return text
         output_path: Optional file path to append transcripts to
+        silence_timeout: Auto-stop after this many consecutive seconds of silence (0 = disabled)
     """
     ffmpeg = which("ffmpeg")
     with tempfile.TemporaryDirectory(prefix="sys2txt_") as tmp:
@@ -142,6 +166,7 @@ def segment_and_transcribe_live(
         # Timeout: allow generous time but prevent indefinite hangs
         transcribe_timeout = max(segment_seconds * 5, 60)
         executor = ThreadPoolExecutor(max_workers=1)
+        consecutive_silent_seconds = 0
         try:
             while True:
                 # sorted ensures we process in chronological order
@@ -152,9 +177,16 @@ def segment_and_transcribe_live(
                 safe_to_process = files[:-1] if len(files) > 1 else []
                 new_files = [f for f in safe_to_process if f not in processed]
                 for f in new_files:
-                    _process_segment_file(
+                    text = _process_segment_file(
                         f, tmp, processed, transcribe_callback, output_path, executor, transcribe_timeout
                     )
+                    if silence_timeout > 0:
+                        if not text or not text.strip():
+                            consecutive_silent_seconds += segment_seconds
+                        else:
+                            consecutive_silent_seconds = 0
+                        if consecutive_silent_seconds >= silence_timeout:
+                            raise _SilenceTimeout()
 
                 # If ffmpeg has exited and no new files pending, break
                 ret = proc.poll()
@@ -168,21 +200,12 @@ def segment_and_transcribe_live(
                     break
                 time.sleep(0.3)
         except KeyboardInterrupt:
-            executor.shutdown(wait=False)
             logger.info("Stopping live capture...")
-            try:
-                # Send 'q' command to ffmpeg to quit gracefully
-                if proc.stdin:
-                    proc.stdin.write(b"q")
-                    proc.stdin.flush()
-                    proc.stdin.close()
-                # Give ffmpeg time to finish the current segment
-                try:
-                    proc.wait(timeout=3.0)
-                except subprocess.TimeoutExpired:
-                    # If it doesn't finish in time, terminate it
-                    proc.terminate()
-                    proc.wait()
-            except OSError:
-                pass
+            _stop_ffmpeg(proc, executor)
             logger.info("Stopped live capture.")
+        except _SilenceTimeout:
+            logger.info(
+                "No speech detected for %d seconds, stopping automatically.",
+                consecutive_silent_seconds,
+            )
+            _stop_ffmpeg(proc, executor)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -270,6 +270,111 @@ class TestSegmentAndTranscribeLive(unittest.TestCase):
         call_path = transcribe_callback.call_args_list[0][0][0]
         self.assertIn("seg_00000", call_path)
 
+    @patch("sys2txt.audio.which")
+    @patch("sys2txt.audio.subprocess.Popen")
+    @patch("sys2txt.audio.time.sleep")
+    @patch("sys2txt.audio.os.listdir")
+    @patch("sys2txt.audio.os.path.getsize")
+    def test_silence_timeout_triggers_shutdown(self, mock_getsize, mock_listdir, mock_sleep, mock_popen, mock_which):
+        """Test that silence_timeout stops live mode after enough consecutive silent segments."""
+        mock_which.return_value = "/usr/bin/ffmpeg"
+        mock_proc = MagicMock()
+        # ffmpeg keeps running; silence timeout should stop it
+        mock_proc.poll.return_value = None
+        mock_proc.stdin = MagicMock()
+        mock_proc.wait.return_value = None
+        mock_popen.return_value = mock_proc
+
+        # Two segments processed, both silent — with segment_seconds=8 and silence_timeout=16
+        mock_listdir.side_effect = [
+            ["seg_00000.wav", "seg_00001.wav"],  # seg_00000 safe
+            ["seg_00000.wav", "seg_00001.wav", "seg_00002.wav"],  # seg_00001 safe
+        ]
+        mock_getsize.return_value = 1024
+
+        transcribe_callback = MagicMock(return_value="")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
+                mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None, silence_timeout=16)
+
+        # Verify graceful shutdown — 'q' sent to ffmpeg
+        mock_proc.stdin.write.assert_called_once_with(b"q")
+        mock_proc.stdin.flush.assert_called_once()
+        mock_proc.stdin.close.assert_called_once()
+
+    @patch("sys2txt.audio.which")
+    @patch("sys2txt.audio.subprocess.Popen")
+    @patch("sys2txt.audio.time.sleep")
+    @patch("sys2txt.audio.os.listdir")
+    @patch("sys2txt.audio.os.path.getsize")
+    def test_silence_timeout_resets_on_speech(self, mock_getsize, mock_listdir, mock_sleep, mock_popen, mock_which):
+        """Test that the silence counter resets when speech is detected."""
+        mock_which.return_value = "/usr/bin/ffmpeg"
+        mock_proc = MagicMock()
+        # ffmpeg exits after processing all segments
+        mock_proc.poll.side_effect = [None, None, None, 0]
+        mock_proc.stdin = MagicMock()
+        mock_popen.return_value = mock_proc
+
+        # Three segments: silent, speech, silent — should NOT trigger timeout at 16s
+        all_files = ["seg_00000.wav", "seg_00001.wav", "seg_00002.wav", "seg_00003.wav"]
+        mock_listdir.side_effect = [
+            all_files[:2],  # iter 1: seg_00000 safe (silent)
+            all_files[:3],  # iter 2: seg_00001 safe (speech)
+            all_files[:4],  # iter 3: seg_00002 safe (silent)
+            all_files[:4],  # iter 4: nothing new safe, poll returns 0
+            all_files[:4],  # flush path: seg_00003
+        ]
+        mock_getsize.return_value = 1024
+
+        transcribe_callback = MagicMock(side_effect=["", "hello world", "", ""])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
+                mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None, silence_timeout=16)
+
+        # All 4 segments were transcribed (no premature shutdown)
+        self.assertEqual(transcribe_callback.call_count, 4)
+        # ffmpeg was NOT sent 'q' — it exited naturally
+        mock_proc.stdin.write.assert_not_called()
+
+    @patch("sys2txt.audio.which")
+    @patch("sys2txt.audio.subprocess.Popen")
+    @patch("sys2txt.audio.time.sleep")
+    @patch("sys2txt.audio.os.listdir")
+    @patch("sys2txt.audio.os.path.getsize")
+    def test_silence_timeout_disabled_by_default(self, mock_getsize, mock_listdir, mock_sleep, mock_popen, mock_which):
+        """Test that silence_timeout=0 (default) does not trigger auto-stop."""
+        mock_which.return_value = "/usr/bin/ffmpeg"
+        mock_proc = MagicMock()
+        mock_proc.poll.side_effect = [None, None, 0]
+        mock_proc.stdin = MagicMock()
+        mock_popen.return_value = mock_proc
+
+        # Three silent segments — should NOT trigger timeout when disabled
+        all_files = ["seg_00000.wav", "seg_00001.wav", "seg_00002.wav"]
+        mock_listdir.side_effect = [
+            all_files[:2],  # iter 1: seg_00000 safe
+            all_files[:3],  # iter 2: seg_00001 safe
+            all_files[:3],  # iter 3: nothing new, poll returns 0
+            all_files[:3],  # flush: seg_00002
+        ]
+        mock_getsize.return_value = 1024
+
+        transcribe_callback = MagicMock(return_value="")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
+                mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None, silence_timeout=0)
+
+        # All segments processed, no premature shutdown
+        self.assertEqual(transcribe_callback.call_count, 3)
+        mock_proc.stdin.write.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds `--silence-timeout <seconds>` flag to `live` mode that automatically stops recording after N consecutive seconds without detected speech (0 = disabled, which is the default)
- Refactors the duplicated ffmpeg shutdown logic from the `KeyboardInterrupt` handler into a `_stop_ffmpeg()` helper, reused by both the interrupt and silence-timeout paths
- `_process_segment_file()` now returns the transcript text so the caller can detect silent segments

## Test plan

- [ ] `test_silence_timeout_triggers_shutdown` — two silent segments at `silence_timeout=16` causes graceful ffmpeg shutdown via `'q'` on stdin
- [ ] `test_silence_timeout_resets_on_speech` — counter resets when a non-empty transcript is returned; no premature shutdown
- [ ] `test_silence_timeout_disabled_by_default` — `silence_timeout=0` processes all segments without stopping early

```bash
python -m unittest tests/test_audio.py -v
```

Manual smoke test:
```bash
sys2txt live --model small --segment-seconds 8 --silence-timeout 16
```

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)