### PR TITLE
refactor: reduce transcribe_file() parameter count with TranscriptionConfig dataclass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,8 @@ The codebase is organized into focused modules by functionality:
 - `run_command()`: Helper for running system commands
 
 **transcribe.py** - Whisper transcription:
-- `transcribe_file()`: Main entry point, dispatches to appropriate engine
+- `TranscriptionConfig`: Dataclass bundling engine, model, device, language, timestamps, model_path, and whisper_cpp_path
+- `transcribe_file(path, config)`: Main entry point, takes a file path and `TranscriptionConfig`, dispatches to appropriate engine
 - `_transcribe_faster_whisper()`: Uses faster_whisper.WhisperModel with VAD filter
 - `_transcribe_openai_whisper()`: Uses whisper.load_model() and model.transcribe()
 - `_transcribe_whisper_cpp()`: Runs whisper-cli subprocess with GPU/CPU support

--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from .audio import record_once, segment_and_transcribe_live
 from .constants import WHISPER_MODEL
 from .pulse import get_default_monitor_source, list_pulse_sources
-from .transcribe import transcribe_file
+from .transcribe import TranscriptionConfig, transcribe_file
 
 
 def get_timestamp_filename() -> str:
@@ -43,11 +43,11 @@ def _resolve_output_path(output_arg: str | None) -> str:
     return output_arg if output_arg else os.path.join(output_dir, get_timestamp_filename())
 
 
-def _build_transcribe_kwargs(args) -> dict:
-    """Build the common keyword arguments for transcribe_file() from parsed args."""
-    return dict(
+def _build_transcription_config(args) -> TranscriptionConfig:
+    """Build a TranscriptionConfig from parsed CLI args."""
+    return TranscriptionConfig(
         engine=args.engine,
-        model_size=args.model_size,
+        model=args.model_size,
         language=args.language,
         timestamps=args.timestamps,
         model_path=args.model_path,
@@ -164,26 +164,26 @@ def main():
 
     if args.mode == "once":
         output_file = _resolve_output_path(args.output)
-        transcribe_kwargs = _build_transcribe_kwargs(args)
+        config = _build_transcription_config(args)
 
         if args.input:
-            text = transcribe_file(args.input, **transcribe_kwargs)
+            text = transcribe_file(args.input, config)
         else:
             with tempfile.TemporaryDirectory(prefix="sys2txt_") as tmp:
                 wav = os.path.join(tmp, "capture.wav")
                 record_once(source=source, out_wav=wav, sample_rate=16000, channels=1, duration=args.duration)
-                text = transcribe_file(wav, **transcribe_kwargs)
+                text = transcribe_file(wav, config)
 
         _save_transcript(text, output_file)
 
     elif args.mode == "live":
         output_file = _resolve_output_path(args.output)
-        transcribe_kwargs = _build_transcribe_kwargs(args)
+        config = _build_transcription_config(args)
         logger.info("Live transcript will be saved to: %s", output_file)
 
         def transcribe_segment(file_path: str, segment_index: int) -> str:
             """Transcribe a segment and format with optional timestamp prefix."""
-            text = transcribe_file(file_path, **transcribe_kwargs)
+            text = transcribe_file(file_path, config)
             if args.timestamps:
                 start = segment_index * args.segment_seconds
                 end = start + args.segment_seconds

--- a/src/sys2txt/transcribe.py
+++ b/src/sys2txt/transcribe.py
@@ -5,8 +5,23 @@ import re
 import shutil
 import subprocess
 import threading
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+
+
+@dataclass
+class TranscriptionConfig:
+    """Configuration for transcription that stays constant across calls."""
+
+    engine: str = "auto"
+    model: str = "small"
+    device: str = "auto"
+    language: Optional[str] = None
+    timestamps: bool = False
+    model_path: Optional[str] = None
+    whisper_cpp_path: Optional[str] = None
+
 
 # Cached model instances to avoid expensive reloads on every segment
 _faster_whisper_model = None
@@ -16,32 +31,17 @@ _openai_whisper_model_key: Optional[str] = None
 _model_cache_lock = threading.Lock()
 
 
-def transcribe_file(
-    path: str,
-    engine: str,
-    model_size: str,
-    language: Optional[str],
-    timestamps: bool,
-    model_path: Optional[str] = None,
-    whisper_cpp_path: Optional[str] = None,
-    device: str = "auto",
-) -> str:
+def transcribe_file(path: str, config: TranscriptionConfig) -> str:
     """Transcribe an audio file using the specified Whisper engine.
 
     Args:
         path: Path to audio file
-        engine: Engine to use ("auto", "faster", "whisper", or "cpp")
-        model_size: Whisper model size (tiny, base, small, medium, large-v2)
-        language: Optional language code (e.g., "en"). If None, auto-detect.
-        timestamps: Whether to include timestamps in output
-        model_path: Path to whisper.cpp model file (for cpp engine)
-        whisper_cpp_path: Path to whisper-cli binary (for cpp engine)
-        device: Device to use ("auto", "cpu", "vulkan", "gpu", "cuda")
+        config: Transcription configuration
 
     Returns:
         Transcribed text
     """
-    engine = engine.lower()
+    engine = config.engine.lower()
     if engine == "auto":
         try:
             import faster_whisper  # noqa: F401
@@ -51,11 +51,19 @@ def transcribe_file(
             engine = "whisper"
 
     if engine == "faster":
-        return _transcribe_faster_whisper(path, model_size, language, timestamps, device)
+        return _transcribe_faster_whisper(path, config.model, config.language, config.timestamps, config.device)
     elif engine == "whisper":
-        return _transcribe_openai_whisper(path, model_size, language, timestamps)
+        return _transcribe_openai_whisper(path, config.model, config.language, config.timestamps)
     elif engine == "cpp":
-        return _transcribe_whisper_cpp(path, model_size, language, timestamps, model_path, whisper_cpp_path, device)
+        return _transcribe_whisper_cpp(
+            path,
+            config.model,
+            config.language,
+            config.timestamps,
+            config.model_path,
+            config.whisper_cpp_path,
+            config.device,
+        )
     else:
         raise ValueError(f"Unknown engine: {engine}")
 

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -5,7 +5,8 @@ import unittest
 from argparse import Namespace
 from unittest.mock import mock_open, patch
 
-from sys2txt.__main__ import _build_transcribe_kwargs, _resolve_output_path, _save_transcript
+from sys2txt.__main__ import _build_transcription_config, _resolve_output_path, _save_transcript
+from sys2txt.transcribe import TranscriptionConfig
 
 
 class TestResolveOutputPath(unittest.TestCase):
@@ -22,8 +23,8 @@ class TestResolveOutputPath(unittest.TestCase):
         self.assertEqual(result, os.path.join("/out", "2024-01-01_00-00-00.txt"))
 
 
-class TestBuildTranscribeKwargs(unittest.TestCase):
-    def test_all_keys_present_with_correct_values(self):
+class TestBuildTranscriptionConfig(unittest.TestCase):
+    def test_returns_config_with_correct_values(self):
         args = Namespace(
             engine="faster",
             model_size="small",
@@ -33,19 +34,15 @@ class TestBuildTranscribeKwargs(unittest.TestCase):
             whisper_cpp_path="/usr/local/bin/whisper-cli",
             device="cpu",
         )
-        kwargs = _build_transcribe_kwargs(args)
-        self.assertEqual(
-            kwargs,
-            {
-                "engine": "faster",
-                "model_size": "small",
-                "language": "en",
-                "timestamps": True,
-                "model_path": "/models/ggml.bin",
-                "whisper_cpp_path": "/usr/local/bin/whisper-cli",
-                "device": "cpu",
-            },
-        )
+        config = _build_transcription_config(args)
+        self.assertIsInstance(config, TranscriptionConfig)
+        self.assertEqual(config.engine, "faster")
+        self.assertEqual(config.model, "small")
+        self.assertEqual(config.language, "en")
+        self.assertTrue(config.timestamps)
+        self.assertEqual(config.model_path, "/models/ggml.bin")
+        self.assertEqual(config.whisper_cpp_path, "/usr/local/bin/whisper-cli")
+        self.assertEqual(config.device, "cpu")
 
 
 class TestSaveTranscript(unittest.TestCase):

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -5,7 +5,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from sys2txt.transcribe import transcribe_file
+from sys2txt.transcribe import TranscriptionConfig, transcribe_file
 
 
 class TestTranscribeFile(unittest.TestCase):
@@ -17,7 +17,7 @@ class TestTranscribeFile(unittest.TestCase):
         with patch("sys2txt.transcribe._transcribe_faster_whisper") as mock_transcribe:
             mock_transcribe.return_value = "test transcript"
             # The actual import will succeed since faster_whisper is installed
-            result = transcribe_file("/path/to/audio.wav", "auto", "small", None, False)
+            result = transcribe_file("/path/to/audio.wav", TranscriptionConfig())
 
         self.assertEqual(result, "test transcript")
         mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, False, "auto")
@@ -27,7 +27,8 @@ class TestTranscribeFile(unittest.TestCase):
         """Test transcribe_file() with explicit faster engine."""
         mock_transcribe.return_value = "faster transcript"
 
-        result = transcribe_file("/path/to/audio.wav", "faster", "base", "en", True)
+        config = TranscriptionConfig(engine="faster", model="base", language="en", timestamps=True)
+        result = transcribe_file("/path/to/audio.wav", config)
 
         self.assertEqual(result, "faster transcript")
         mock_transcribe.assert_called_once_with("/path/to/audio.wav", "base", "en", True, "auto")
@@ -37,7 +38,8 @@ class TestTranscribeFile(unittest.TestCase):
         """Test transcribe_file() with explicit whisper engine."""
         mock_transcribe.return_value = "whisper transcript"
 
-        result = transcribe_file("/path/to/audio.wav", "whisper", "medium", "fr", False)
+        config = TranscriptionConfig(engine="whisper", model="medium", language="fr")
+        result = transcribe_file("/path/to/audio.wav", config)
 
         self.assertEqual(result, "whisper transcript")
         mock_transcribe.assert_called_once_with("/path/to/audio.wav", "medium", "fr", False)
@@ -47,16 +49,16 @@ class TestTranscribeFile(unittest.TestCase):
         """Test transcribe_file() with cpp engine."""
         mock_transcribe.return_value = "cpp transcript"
 
-        result = transcribe_file(
-            "/path/to/audio.wav",
-            "cpp",
-            "small",
-            "en",
-            True,
+        config = TranscriptionConfig(
+            engine="cpp",
+            model="small",
+            language="en",
+            timestamps=True,
             model_path="/path/to/model.bin",
             whisper_cpp_path="/path/to/whisper-cli",
             device="vulkan",
         )
+        result = transcribe_file("/path/to/audio.wav", config)
 
         self.assertEqual(result, "cpp transcript")
         mock_transcribe.assert_called_once_with(
@@ -74,7 +76,7 @@ class TestTranscribeFile(unittest.TestCase):
         with patch.dict("sys.modules", {"faster_whisper": None}):
             with patch("sys2txt.transcribe._transcribe_openai_whisper") as mock_transcribe:
                 mock_transcribe.return_value = "fallback transcript"
-                result = transcribe_file("/path/to/audio.wav", "auto", "small", None, False)
+                result = transcribe_file("/path/to/audio.wav", TranscriptionConfig())
 
         self.assertEqual(result, "fallback transcript")
         mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, False)
@@ -82,7 +84,7 @@ class TestTranscribeFile(unittest.TestCase):
     def test_transcribe_file_invalid_engine(self):
         """Test transcribe_file() raises ValueError for invalid engine."""
         with self.assertRaises(ValueError) as cm:
-            transcribe_file("/path/to/audio.wav", "invalid", "small", None, False)
+            transcribe_file("/path/to/audio.wav", TranscriptionConfig(engine="invalid"))
 
         self.assertIn("Unknown engine", str(cm.exception))
         self.assertIn("invalid", str(cm.exception))


### PR DESCRIPTION
## Summary

- Added `TranscriptionConfig` dataclass in `transcribe.py` to bundle engine, model, device, language, timestamps, model_path, and whisper_cpp_path
- Simplified `transcribe_file()` signature from 8 parameters to `(path, config)`, removing the need for `**kwargs` unpacking at call sites
- Replaced `_build_transcribe_kwargs()` in `__main__.py` with `_build_transcription_config()` returning a `TranscriptionConfig`
- Updated 6 tests in `TestTranscribeFile` to construct and pass `TranscriptionConfig`
- Renamed test class and updated assertions in `test___main__.py` to verify `TranscriptionConfig` fields
- Updated CLAUDE.md architecture docs to document the new dataclass and signature

## Test plan

- [ ] `python -m unittest discover -s tests -p "test_*.py"` passes
- [ ] `ruff format --check src/` passes
- [ ] `ruff check src/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)