### PR TITLE
tests: add CLI integration tests for __main__.py

### DIFF
--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -1,11 +1,18 @@
-"""Tests for helper functions in sys2txt.__main__."""
+"""Tests for sys2txt.__main__ module."""
 
+import logging
 import os
 import unittest
 from argparse import Namespace
 from unittest.mock import mock_open, patch
 
-from sys2txt.__main__ import _build_transcription_config, _resolve_output_path, _save_transcript
+from sys2txt.__main__ import (
+    _build_transcription_config,
+    _configure_logging,
+    _resolve_output_path,
+    _save_transcript,
+    main,
+)
 from sys2txt.transcribe import TranscriptionConfig
 
 
@@ -59,3 +66,234 @@ class TestSaveTranscript(unittest.TestCase):
         m.assert_called_once_with("/out/transcript.txt", "w", encoding="utf-8")
         m().write.assert_called_once_with("hello world\n")
         mock_logger.info.assert_called_once_with("Transcript saved to: %s", "/out/transcript.txt")
+
+
+class TestArgumentParsing(unittest.TestCase):
+    """Tests for CLI argument parsing."""
+
+    @patch("sys2txt.__main__._configure_logging")
+    @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
+    @patch("sys2txt.__main__.record_once")
+    @patch("sys2txt.__main__.transcribe_file", return_value="text")
+    @patch("sys2txt.__main__._save_transcript")
+    @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
+    def test_once_defaults(self, _res, _save, _trans, _rec, _src, _log):
+        with patch("sys.argv", ["sys2txt", "once"]):
+            main()
+        # record_once was called (no --input), meaning mode dispatched correctly
+        _rec.assert_called_once()
+
+    @patch("sys2txt.__main__._configure_logging")
+    @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
+    @patch("sys2txt.__main__.segment_and_transcribe_live")
+    @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
+    def test_live_defaults(self, _res, _live, _src, _log):
+        with patch("sys.argv", ["sys2txt", "live"]):
+            main()
+        _live.assert_called_once()
+        call_kwargs = _live.call_args
+        self.assertEqual(call_kwargs[1]["segment_seconds"], 8)
+        self.assertEqual(call_kwargs[1]["silence_timeout"], 0)
+
+    @patch("sys2txt.__main__._configure_logging")
+    @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
+    @patch("sys2txt.__main__.transcribe_file", return_value="text")
+    @patch("sys2txt.__main__._save_transcript")
+    @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
+    def test_once_with_input_skips_recording(self, _res, _save, _trans, _src, _log):
+        with (
+            patch("sys.argv", ["sys2txt", "once", "--input", "/tmp/audio.wav"]),
+            patch("sys2txt.__main__.record_once") as mock_rec,
+        ):
+            main()
+        mock_rec.assert_not_called()
+        _trans.assert_called_once_with("/tmp/audio.wav", unittest.mock.ANY)
+
+    @patch("sys2txt.__main__._configure_logging")
+    @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
+    @patch("sys2txt.__main__.record_once")
+    @patch("sys2txt.__main__.transcribe_file", return_value="text")
+    @patch("sys2txt.__main__._save_transcript")
+    @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
+    def test_once_all_flags(self, _res, _save, _trans, _rec, _src, _log):
+        with patch(
+            "sys.argv",
+            [
+                "sys2txt",
+                "--verbose",
+                "once",
+                "--source",
+                "my.monitor",
+                "--model",
+                "large-v2",
+                "--engine",
+                "faster",
+                "--language",
+                "en",
+                "--timestamps",
+                "--device",
+                "cuda",
+                "--duration",
+                "30",
+                "--output",
+                "/tmp/my.txt",
+            ],
+        ):
+            main()
+        # Source should be the explicit one, not the default
+        _src.assert_not_called()
+        call_args = _rec.call_args
+        self.assertEqual(call_args[1]["source"], "my.monitor")
+        self.assertEqual(call_args[1]["duration"], 30)
+        # Output was explicitly provided so _resolve_output_path gets it
+        _res.assert_called_once_with("/tmp/my.txt")
+
+    @patch("sys2txt.__main__._configure_logging")
+    @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
+    @patch("sys2txt.__main__.segment_and_transcribe_live")
+    @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
+    def test_live_all_flags(self, _res, _live, _src, _log):
+        with patch(
+            "sys.argv",
+            [
+                "sys2txt",
+                "--quiet",
+                "live",
+                "--source",
+                "my.monitor",
+                "--model",
+                "tiny",
+                "--engine",
+                "cpp",
+                "--language",
+                "fr",
+                "--timestamps",
+                "--device",
+                "vulkan",
+                "--model-path",
+                "/models/ggml.bin",
+                "--whisper-cpp-path",
+                "/usr/bin/whisper-cli",
+                "--segment-seconds",
+                "15",
+                "--output",
+                "/tmp/live.txt",
+                "--silence-timeout",
+                "30",
+            ],
+        ):
+            main()
+        _live.assert_called_once()
+        call_kwargs = _live.call_args[1]
+        self.assertEqual(call_kwargs["source"], "my.monitor")
+        self.assertEqual(call_kwargs["segment_seconds"], 15)
+        self.assertEqual(call_kwargs["silence_timeout"], 30)
+        self.assertEqual(call_kwargs["output_path"], "/tmp/out.txt")
+
+    def test_missing_subcommand_exits(self):
+        with patch("sys.argv", ["sys2txt"]):
+            with self.assertRaises(SystemExit):
+                main()
+
+
+class TestListSources(unittest.TestCase):
+    """Tests for --list-sources flag."""
+
+    @patch("sys2txt.__main__._configure_logging")
+    @patch("sys2txt.__main__.list_pulse_sources", return_value=[("source1", "desc1"), ("source2", "desc2")])
+    def test_list_sources_prints_and_returns(self, _sources, _log):
+        with (
+            patch("sys.argv", ["sys2txt", "once", "--list-sources"]),
+            patch("builtins.print") as mock_print,
+        ):
+            main()
+        mock_print.assert_any_call("Available PulseAudio sources:")
+        mock_print.assert_any_call("  ", "source1")
+        mock_print.assert_any_call("  ", "source2")
+
+    @patch("sys2txt.__main__._configure_logging")
+    @patch("sys2txt.__main__.list_pulse_sources", return_value=[])
+    def test_list_sources_empty_exits(self, _sources, _log):
+        with patch("sys.argv", ["sys2txt", "once", "--list-sources"]):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+            self.assertEqual(ctx.exception.code, 1)
+
+
+class TestModeDispatchOnce(unittest.TestCase):
+    """Tests for once mode dispatch logic."""
+
+    @patch("sys2txt.__main__._configure_logging")
+    @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
+    @patch("sys2txt.__main__.record_once")
+    @patch("sys2txt.__main__.transcribe_file", return_value="hello world")
+    @patch("sys2txt.__main__._save_transcript")
+    @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
+    def test_once_records_then_transcribes(self, _res, mock_save, mock_trans, mock_rec, _src, _log):
+        with patch("sys.argv", ["sys2txt", "once"]):
+            main()
+        mock_rec.assert_called_once()
+        mock_trans.assert_called_once()
+        mock_save.assert_called_once_with("hello world", "/tmp/out.txt")
+
+    @patch("sys2txt.__main__._configure_logging")
+    @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
+    @patch("sys2txt.__main__.transcribe_file", return_value="from file")
+    @patch("sys2txt.__main__._save_transcript")
+    @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
+    def test_once_input_skips_recording(self, _res, mock_save, mock_trans, _src, _log):
+        with patch("sys.argv", ["sys2txt", "once", "--input", "/audio.wav"]):
+            main()
+        mock_trans.assert_called_once()
+        self.assertEqual(mock_trans.call_args[0][0], "/audio.wav")
+        mock_save.assert_called_once_with("from file", "/tmp/out.txt")
+
+
+class TestModeDispatchLive(unittest.TestCase):
+    """Tests for live mode dispatch logic."""
+
+    @patch("sys2txt.__main__._configure_logging")
+    @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
+    @patch("sys2txt.__main__.segment_and_transcribe_live")
+    @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
+    def test_live_calls_segment_and_transcribe(self, _res, mock_live, _src, _log):
+        with patch("sys.argv", ["sys2txt", "live"]):
+            main()
+        mock_live.assert_called_once()
+        kwargs = mock_live.call_args[1]
+        self.assertEqual(kwargs["source"], "default.monitor")
+        self.assertEqual(kwargs["sample_rate"], 16000)
+        self.assertEqual(kwargs["channels"], 1)
+        self.assertEqual(kwargs["segment_seconds"], 8)
+        self.assertEqual(kwargs["output_path"], "/tmp/out.txt")
+        self.assertEqual(kwargs["silence_timeout"], 0)
+        self.assertTrue(callable(kwargs["transcribe_callback"]))
+
+
+class TestConfigureLogging(unittest.TestCase):
+    """Tests for _configure_logging()."""
+
+    @patch("sys2txt.__main__.logging.basicConfig")
+    def test_verbose_sets_debug(self, mock_config):
+        _configure_logging(verbose=True, quiet=False)
+        mock_config.assert_called_once()
+        self.assertEqual(mock_config.call_args[1]["level"], logging.DEBUG)
+
+    @patch("sys2txt.__main__.logging.basicConfig")
+    def test_quiet_sets_warning(self, mock_config):
+        _configure_logging(verbose=False, quiet=True)
+        mock_config.assert_called_once()
+        self.assertEqual(mock_config.call_args[1]["level"], logging.WARNING)
+
+    @patch("sys2txt.__main__.logging.basicConfig")
+    def test_default_sets_info(self, mock_config):
+        _configure_logging(verbose=False, quiet=False)
+        mock_config.assert_called_once()
+        self.assertEqual(mock_config.call_args[1]["level"], logging.INFO)
+
+    @patch("sys2txt.__main__.logging.basicConfig")
+    def test_log_level_env_overrides_flags(self, mock_config):
+        with patch.dict(os.environ, {"LOG_LEVEL": "ERROR"}):
+            _configure_logging(verbose=True, quiet=False)
+        mock_config.assert_called_once()
+        self.assertEqual(mock_config.call_args[1]["level"], logging.ERROR)


### PR DESCRIPTION
## Summary

- Add `TestArgumentParsing` covering `once`/`live` defaults and all flags
- Add `TestListSources` for `--list-sources` flag (success and empty case)
- Add `TestModeDispatchOnce` / `TestModeDispatchLive` verifying full dispatch flow
- Add `TestConfigureLogging` for verbose/quiet/default/env-override cases

## Test plan

- [x] All 19 tests pass locally (`python -m unittest tests/test___main__.py`)
- [x] CI will run full matrix on Python 3.10–3.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)