### PR TITLE
feat: make whisper engines optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,18 @@ sudo apt install -y ffmpeg python3-venv python3-pip
 cd sys2txt
 python3 -m venv .venv
 source .venv/bin/activate
-pip install sys2txt
 ```
 
-This installs both faster-whisper (for speed) and openai-whisper (reference implementation). The tool auto-selects faster-whisper when available or falls back to openai-whisper.
+Install with your preferred engine:
+
+```bash
+pip install sys2txt[faster]   # faster-whisper (recommended, best for CPU and NVIDIA)
+pip install sys2txt[openai]   # openai-whisper (reference implementation)
+pip install sys2txt[all]      # install both engines
+pip install sys2txt           # no Python engine (use whisper.cpp instead)
+```
+
+The tool auto-selects `faster-whisper` when available, falls back to `openai-whisper`, then falls back to `whisper.cpp`.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,15 @@ license = {text = "MIT"}
 authors = [
     {name = "Joe Heffer", email = "jheffer@gmail.com"}
 ]
-dependencies = [
-    "faster-whisper>=1.0.0",
-    "openai-whisper>=20231117",
-]
+dependencies = []
 
 [project.scripts]
 sys2txt = "sys2txt.__main__:main"
 
 [project.optional-dependencies]
+faster = ["faster-whisper>=1.0.0"]
+openai = ["openai-whisper>=20231117"]
+all = ["faster-whisper>=1.0.0", "openai-whisper>=20231117"]
 dev = [
     "ruff>=0.8.0",
 ]

--- a/src/sys2txt/transcribe.py
+++ b/src/sys2txt/transcribe.py
@@ -48,7 +48,12 @@ def transcribe_file(path: str, config: TranscriptionConfig) -> str:
 
             engine = "faster"
         except ImportError:
-            engine = "whisper"
+            try:
+                import whisper  # noqa: F401
+
+                engine = "whisper"
+            except ImportError:
+                engine = "cpp"
 
     if engine == "faster":
         return _transcribe_faster_whisper(path, config.model, config.language, config.timestamps, config.device)

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -81,6 +81,17 @@ class TestTranscribeFile(unittest.TestCase):
         self.assertEqual(result, "fallback transcript")
         mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, False)
 
+    def test_transcribe_file_auto_falls_back_to_cpp(self):
+        """Test transcribe_file() auto falls back to whisper.cpp when neither Python engine is installed."""
+        with patch.dict("sys.modules", {"faster_whisper": None, "whisper": None}):
+            with patch("sys2txt.transcribe._transcribe_whisper_cpp") as mock_transcribe:
+                mock_transcribe.return_value = "cpp fallback transcript"
+                config = TranscriptionConfig()
+                result = transcribe_file("/path/to/audio.wav", config)
+
+        self.assertEqual(result, "cpp fallback transcript")
+        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, False, None, None, "auto")
+
     def test_transcribe_file_invalid_engine(self):
         """Test transcribe_file() raises ValueError for invalid engine."""
         with self.assertRaises(ValueError) as cm:

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,6 +1,7 @@
 """Tests for sys2txt.transcribe module."""
 
 import os
+import sys
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -13,11 +14,10 @@ class TestTranscribeFile(unittest.TestCase):
 
     def test_transcribe_file_auto_selects_faster_whisper(self):
         """Test transcribe_file() auto-selects faster-whisper when available."""
-        # Mock faster_whisper import being successful
-        with patch("sys2txt.transcribe._transcribe_faster_whisper") as mock_transcribe:
-            mock_transcribe.return_value = "test transcript"
-            # The actual import will succeed since faster_whisper is installed
-            result = transcribe_file("/path/to/audio.wav", TranscriptionConfig())
+        with patch.dict("sys.modules", {"faster_whisper": MagicMock()}):
+            with patch("sys2txt.transcribe._transcribe_faster_whisper") as mock_transcribe:
+                mock_transcribe.return_value = "test transcript"
+                result = transcribe_file("/path/to/audio.wav", TranscriptionConfig())
 
         self.assertEqual(result, "test transcript")
         mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, False, "auto")
@@ -73,7 +73,7 @@ class TestTranscribeFile(unittest.TestCase):
 
     def test_transcribe_file_auto_falls_back_to_openai_whisper(self):
         """Test transcribe_file() auto falls back to openai-whisper when faster-whisper is not installed."""
-        with patch.dict("sys.modules", {"faster_whisper": None}):
+        with patch.dict("sys.modules", {"faster_whisper": None, "whisper": MagicMock()}):
             with patch("sys2txt.transcribe._transcribe_openai_whisper") as mock_transcribe:
                 mock_transcribe.return_value = "fallback transcript"
                 result = transcribe_file("/path/to/audio.wav", TranscriptionConfig())
@@ -110,6 +110,11 @@ class TestTranscribeFasterWhisper(unittest.TestCase):
 
         t._faster_whisper_model = None
         t._faster_whisper_model_key = None
+
+        if "faster_whisper" not in sys.modules:
+            patcher = patch.dict("sys.modules", {"faster_whisper": MagicMock()})
+            patcher.start()
+            self.addCleanup(patcher.stop)
 
     @patch("faster_whisper.WhisperModel")
     def test_transcribe_faster_whisper_no_timestamps(self, mock_model_class):
@@ -218,6 +223,11 @@ class TestTranscribeOpenAIWhisper(unittest.TestCase):
 
         t._openai_whisper_model = None
         t._openai_whisper_model_key = None
+
+        if "whisper" not in sys.modules:
+            patcher = patch.dict("sys.modules", {"whisper": MagicMock()})
+            patcher.start()
+            self.addCleanup(patcher.stop)
 
     @patch("whisper.load_model")
     def test_transcribe_openai_whisper_no_timestamps(self, mock_load_model):
@@ -592,6 +602,11 @@ class TestModelCacheThreadSafety(unittest.TestCase):
 
         t._faster_whisper_model = None
         t._faster_whisper_model_key = None
+
+        if "faster_whisper" not in sys.modules:
+            patcher = patch.dict("sys.modules", {"faster_whisper": MagicMock()})
+            patcher.start()
+            self.addCleanup(patcher.stop)
 
     @patch("faster_whisper.WhisperModel")
     def test_concurrent_calls_load_model_once(self, mock_model_class):


### PR DESCRIPTION
## Summary

- Move `faster-whisper` and `openai-whisper` from required to optional dependencies
- Add `pip install sys2txt[faster]`, `sys2txt[openai]`, and `sys2txt[all]` extras
- Auto-detection now falls back: faster-whisper → openai-whisper → whisper.cpp
- Updated README installation instructions to reflect new install options
- Added test for auto-fallback to whisper.cpp when neither Python engine is installed

## Test plan

- [x] `python -m unittest tests/test_transcribe.py` passes
- [ ] `pip install -e .` installs with no Whisper engines by default
- [ ] `pip install -e ".[faster]"` installs only faster-whisper
- [ ] `pip install -e ".[all]"` installs both engines
- [ ] Auto-selection works correctly when engines are/aren't installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)