### PR TITLE
feat: colorized log output when stderr is a TTY

### DIFF
--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -64,6 +64,24 @@ def _save_transcript(text: str, output_file: str) -> None:
     logger.info("Transcript saved to: %s", output_file)
 
 
+class _ColorFormatter(logging.Formatter):
+    """Logging formatter that colorizes the level name using ANSI codes."""
+
+    COLORS = {
+        logging.DEBUG: "\033[2m",  # dim
+        logging.INFO: "\033[32m",  # green
+        logging.WARNING: "\033[33m",  # yellow
+        logging.ERROR: "\033[31m",  # red
+        logging.CRITICAL: "\033[1;31m",  # bold red
+    }
+    RESET = "\033[0m"
+
+    def format(self, record):
+        color = self.COLORS.get(record.levelno, "")
+        record.levelname = f"{color}{record.levelname}{self.RESET}"
+        return super().format(record)
+
+
 def _configure_logging(verbose: bool, quiet: bool) -> None:
     """Configure logging based on CLI flags and LOG_LEVEL environment variable."""
     level_name = os.environ.get("LOG_LEVEL", "").upper()
@@ -75,7 +93,17 @@ def _configure_logging(verbose: bool, quiet: bool) -> None:
         level = logging.DEBUG
     else:
         level = logging.INFO
-    logging.basicConfig(level=level, format="%(levelname)s: %(message)s", stream=sys.stderr)
+
+    handler = logging.StreamHandler(sys.stderr)
+    fmt = "%(levelname)s: %(message)s"
+    if sys.stderr.isatty():
+        handler.setFormatter(_ColorFormatter(fmt))
+    else:
+        handler.setFormatter(logging.Formatter(fmt))
+
+    root = logging.getLogger()
+    root.setLevel(level)
+    root.addHandler(handler)
 
 
 def main():

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -273,27 +273,30 @@ class TestModeDispatchLive(unittest.TestCase):
 class TestConfigureLogging(unittest.TestCase):
     """Tests for _configure_logging()."""
 
-    @patch("sys2txt.__main__.logging.basicConfig")
-    def test_verbose_sets_debug(self, mock_config):
+    def setUp(self):
+        """Remove handlers added by _configure_logging between tests."""
+        root = logging.getLogger()
+        self._original_handlers = root.handlers[:]
+        self._original_level = root.level
+
+    def tearDown(self):
+        root = logging.getLogger()
+        root.handlers = self._original_handlers
+        root.level = self._original_level
+
+    def test_verbose_sets_debug(self):
         _configure_logging(verbose=True, quiet=False)
-        mock_config.assert_called_once()
-        self.assertEqual(mock_config.call_args[1]["level"], logging.DEBUG)
+        self.assertEqual(logging.getLogger().level, logging.DEBUG)
 
-    @patch("sys2txt.__main__.logging.basicConfig")
-    def test_quiet_sets_warning(self, mock_config):
+    def test_quiet_sets_warning(self):
         _configure_logging(verbose=False, quiet=True)
-        mock_config.assert_called_once()
-        self.assertEqual(mock_config.call_args[1]["level"], logging.WARNING)
+        self.assertEqual(logging.getLogger().level, logging.WARNING)
 
-    @patch("sys2txt.__main__.logging.basicConfig")
-    def test_default_sets_info(self, mock_config):
+    def test_default_sets_info(self):
         _configure_logging(verbose=False, quiet=False)
-        mock_config.assert_called_once()
-        self.assertEqual(mock_config.call_args[1]["level"], logging.INFO)
+        self.assertEqual(logging.getLogger().level, logging.INFO)
 
-    @patch("sys2txt.__main__.logging.basicConfig")
-    def test_log_level_env_overrides_flags(self, mock_config):
+    def test_log_level_env_overrides_flags(self):
         with patch.dict(os.environ, {"LOG_LEVEL": "ERROR"}):
             _configure_logging(verbose=True, quiet=False)
-        mock_config.assert_called_once()
-        self.assertEqual(mock_config.call_args[1]["level"], logging.ERROR)
+        self.assertEqual(logging.getLogger().level, logging.ERROR)


### PR DESCRIPTION
## Summary

- Adds `_ColorFormatter` class that applies ANSI color codes to log level names (debug=dim, info=green, warning=yellow, error=red, critical=bold red)
- Only applies color formatting when `stderr` is a TTY; falls back to plain formatting for piped/redirected output
- Updates tests to verify log level directly on the root logger instead of mocking `logging.basicConfig`

## Test plan

- [x] Run `python -m unittest tests/test___main__.py` — all logging tests pass
- [ ] Run `sys2txt once --list-sources` in a terminal — log output is colorized
- [ ] Run `sys2txt once --list-sources 2>/dev/null` — no ANSI escape codes in redirected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)