### PR TITLE
ci: validate pyproject.toml in CI and publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Validate pyproject.toml
       run: |
-        pip install validate-pyproject
+        pip install "validate-pyproject[tomli]"
         validate-pyproject pyproject.toml
 
     - name: Install Python dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y ffmpeg pulseaudio
 
+    - name: Validate pyproject.toml
+      run: |
+        pip install validate-pyproject
+        validate-pyproject pyproject.toml
+
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,21 +2,21 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'requirements.txt'
-      - '.github/workflows/ci.yml'
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - ".github/workflows/ci.yml"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'requirements.txt'
-      - '.github/workflows/ci.yml'
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - ".github/workflows/ci.yml"
 
 permissions:
   contents: read
@@ -28,36 +28,36 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y ffmpeg pulseaudio
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg pulseaudio
 
-    - name: Validate pyproject.toml
-      run: |
-        pip install "validate-pyproject[tomli]"
-        validate-pyproject pyproject.toml
+      - name: Validate pyproject.toml
+        run: |
+          pip install "validate-pyproject[all]"
+          validate-pyproject pyproject.toml
 
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e ".[dev]"
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
 
-    - name: Run ruff format check
-      run: |
-        ruff format --check src/
+      - name: Run ruff format check
+        run: |
+          ruff format --check src/
 
-    - name: Run ruff linting
-      run: |
-        ruff check src/
+      - name: Run ruff linting
+        run: |
+          ruff check src/
 
-    - name: Run unit tests
-      run: |
-        python -m unittest discover -s tests -p "test_*.py" -v
+      - name: Run unit tests
+        run: |
+          python -m unittest discover -s tests -p "test_*.py" -v

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,6 +19,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
+    - name: Validate pyproject.toml
+      run: |
+        pip install validate-pyproject
+        validate-pyproject pyproject.toml
+
     - name: Install pypa/build
       run: python -m pip install build --user
     - name: Build a binary wheel and a source tarball

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,10 @@ name = "sys2txt"
 version = "0.2.0"
 description = "Record system audio and transcribe to text using AI"
 readme = "README.md"
-requires-python = ">=3.9"
-license = {text = "MIT"}
-authors = [
-    {name = "Joe Heffer", email = "jheffer@gmail.com"}
-]
+# https://devguide.python.org/versions/
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "Joe Heffer", email = "jheffer@gmail.com" }]
 dependencies = []
 
 [project.scripts]
@@ -21,9 +20,7 @@ sys2txt = "sys2txt.__main__:main"
 faster = ["faster-whisper>=1.0.0"]
 openai = ["openai-whisper>=20231117"]
 all = ["faster-whisper>=1.0.0", "openai-whisper>=20231117"]
-dev = [
-    "ruff>=0.8.0",
-]
+dev = ["ruff>=0.8.0"]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary

- Adds a `validate-pyproject` step to the CI workflow to catch `pyproject.toml` errors on every push/PR
- Adds the same validation step to the PyPI publish workflow so the build is verified before publishing
- Prevents build errors at publish time by failing fast with a clear validation error

Fixes #33

## Test plan

- [ ] Verify CI passes with valid `pyproject.toml`
- [ ] Confirm that an intentionally broken `pyproject.toml` would be caught by the new validation step before reaching the build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)