### PR TITLE
ci: trigger PyPI publish on tag push instead of release event

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,8 +3,9 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'sys2txt-v*'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Changes the `publish-to-pypi` workflow trigger from `release: types: [published]` to `push: tags: sys2txt-v*`

## Why

Release Please uses `GITHUB_TOKEN` to create GitHub releases. GitHub intentionally suppresses downstream workflow triggers for events created by `GITHUB_TOKEN` (to prevent infinite loops), so the `release: published` event never fired the publish workflow. This is why `sys2txt-v0.3.0` (and `v0.2.0`) were never published to PyPI automatically.

Tag push events are not subject to this restriction — they fire normally even when the tag is created by `GITHUB_TOKEN`.

## Test plan

- [ ] Verify the next release-please tag (`sys2txt-v*`) triggers the Publish to PyPI workflow run
- [ ] Confirm the package appears on PyPI after the workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)