### PR TITLE
chore: add --version flag to CLI

### DIFF
--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -7,6 +7,7 @@ import os
 import sys
 import tempfile
 from datetime import datetime
+from importlib.metadata import version
 
 from .audio import record_once, segment_and_transcribe_live
 from .constants import WHISPER_MODEL
@@ -109,6 +110,7 @@ def _configure_logging(verbose: bool, quiet: bool) -> None:
 def main():
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(description="Record Ubuntu system audio and transcribe with Whisper.")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {version('sys2txt')}")
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose (debug) logging")
     parser.add_argument("--quiet", "-q", action="store_true", help="Suppress informational log messages")
     sub = parser.add_subparsers(dest="mode", required=True)


### PR DESCRIPTION
## Summary

- Adds `--version` flag to the `sys2txt` CLI using `importlib.metadata.version`
- Running `sys2txt --version` now prints the installed package version

## Test plan

- [x] Run `sys2txt --version` and confirm it prints the version (e.g. `sys2txt 0.x.y`)
- [ ] Confirm existing subcommands (`once`, `live`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)