### PR TITLE
fix: always request timestamps from whisper-cli to fix empty transcripts

### DIFF
--- a/src/sys2txt/transcribe.py
+++ b/src/sys2txt/transcribe.py
@@ -319,9 +319,6 @@ def _transcribe_whisper_cpp(
     if language:
         cmd.extend(["-l", language])
 
-    if not timestamps:
-        cmd.append("--no-timestamps")
-
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=300)
     except subprocess.TimeoutExpired as e:

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -559,6 +559,31 @@ class TestTranscribeWhisperCpp(unittest.TestCase):
     @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
     @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
     @patch("subprocess.run")
+    def test_transcribe_no_timestamps_does_not_pass_no_timestamps_flag(self, mock_run, mock_model_path, mock_binary):
+        """Regression test for #42: --no-timestamps must never be passed to whisper-cli.
+
+        whisper-cli only emits bracketed timestamp lines when timestamps are enabled;
+        with --no-timestamps its plain-text output doesn't match the parser's regex,
+        so the transcript would silently come back empty.
+        """
+        from sys2txt.transcribe import _transcribe_whisper_cpp
+
+        mock_binary.return_value = "/path/to/whisper-cli"
+        mock_model_path.return_value = "/path/to/model.bin"
+        mock_run.return_value = MagicMock(
+            stdout="[00:00:00.000 --> 00:00:05.000]   Hello world\n",
+            returncode=0,
+        )
+
+        result = _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, False, None, None, "auto")
+
+        call_args = mock_run.call_args[0][0]
+        self.assertNotIn("--no-timestamps", call_args)
+        self.assertEqual(result, "Hello world")
+
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
+    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
+    @patch("subprocess.run")
     def test_transcribe_failure(self, mock_run, mock_model_path, mock_binary):
         """Test transcription failure raises RuntimeError."""
         import subprocess


### PR DESCRIPTION
## Summary
- `_transcribe_whisper_cpp()` passed `--no-timestamps` to `whisper-cli` whenever the `--timestamps` CLI flag was not set.
- With `--no-timestamps`, `whisper-cli` emits plain text lines with no bracketed `[HH:MM:SS.mmm --> HH:MM:SS.mmm]` prefix.
- `_parse_whisper_cpp_output()` only extracts text from lines matching the bracketed-timestamp regex, so every line was silently dropped and the transcript came back empty (with no error raised).
- Fix: never pass `--no-timestamps` to `whisper-cli` — always request timestamped output, and let `_parse_whisper_cpp_output()` (which already correctly handles both `timestamps=True` and `timestamps=False`) do the formatting locally. This brings the `cpp` engine in line with how `faster-whisper` and `openai-whisper` already work — they format segment data locally rather than relying on the underlying tool's own text formatting.

## Test plan
- [x] Added a regression test (`test_transcribe_no_timestamps_does_not_pass_no_timestamps_flag`) asserting `--no-timestamps` is never passed to `whisper-cli` and that a non-empty transcript is produced when `timestamps=False`.
- [x] `ruff format --check src/` and `ruff check src/` pass.
- [x] `python -m unittest discover -s tests -p "test_*.py" -v` — all 84 tests pass.

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135XQHpm5dezPj4td6mUiiq

---
_Generated by [Claude Code](https://claude.ai/code/session_0135XQHpm5dezPj4td6mUiiq)_