### PR TITLE
Handle Ctrl-C gracefully and inform users how to stop live recording

### DIFF
--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -173,6 +173,18 @@ def main():
 
     _configure_logging(verbose=args.verbose, quiet=args.quiet)
 
+    try:
+        _run(args)
+    except RuntimeError as e:
+        logger.error("%s", e)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        logger.info("Interrupted. Exiting.")
+        sys.exit(130)
+
+
+def _run(args) -> None:
+    """Dispatch to the requested mode. Raises KeyboardInterrupt/RuntimeError to caller."""
     if args.engine not in ("cpp", "auto"):
         if args.model_path:
             logger.warning("--model-path is only used with --engine cpp")
@@ -210,6 +222,7 @@ def main():
         output_file = _resolve_output_path(args.output)
         config = _build_transcription_config(args)
         logger.info("Live transcript will be saved to: %s", output_file)
+        logger.info("Press Ctrl-C once to stop live capture and save the transcript.")
 
         def transcribe_segment(file_path: str, segment_index: int) -> str:
             """Transcribe a segment and format with optional timestamp prefix."""
@@ -233,10 +246,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except RuntimeError as e:
-        logger.error("%s", e)
-        sys.exit(1)
-    except KeyboardInterrupt:
-        pass
+    main()

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -195,6 +195,24 @@ class TestArgumentParsing(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 main()
 
+    @patch("sys2txt.__main__._configure_logging")
+    @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
+    @patch("sys2txt.__main__.record_once", side_effect=KeyboardInterrupt())
+    @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
+    def test_keyboard_interrupt_exits_cleanly(self, _res, mock_rec, _src, _log):
+        with patch("sys.argv", ["sys2txt", "once"]):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        self.assertEqual(ctx.exception.code, 130)
+
+    @patch("sys2txt.__main__._configure_logging")
+    @patch("sys2txt.__main__.get_default_monitor_source", side_effect=RuntimeError("boom"))
+    def test_runtime_error_exits_with_code_1(self, _src, _log):
+        with patch("sys.argv", ["sys2txt", "once"]):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        self.assertEqual(ctx.exception.code, 1)
+
 
 class TestListSources(unittest.TestCase):
     """Tests for --list-sources flag."""


### PR DESCRIPTION
## Summary
- The installed `sys2txt` console script (`pyproject.toml`) calls `main()` directly, bypassing the `if __name__ == "__main__":` guard that previously caught `KeyboardInterrupt`. Any interrupt not already handled inside `audio.py` (e.g. while transcription is running) surfaced as a raw Python traceback.
- Move interrupt/`RuntimeError` handling into `main()` itself so it applies regardless of entry point, and exit with code 130 (conventional SIGINT exit code) with a clean log message instead of a traceback.
- Print a clear hint when starting live mode: "Press Ctrl-C once to stop live capture and save the transcript."

## Test plan
- [x] `python -m unittest discover -s tests -p "test_*.py"` — 86 tests pass
- [x] `ruff format --check src/ tests/`
- [x] `ruff check src/ tests/`
- [x] Added tests asserting `KeyboardInterrupt` and `RuntimeError` raised during dispatch result in a clean `SystemExit` (130 and 1 respectively) instead of propagating a traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)