### PR TITLE
fix: default log level to WARNING to suppress engine INFO spam

### DIFF
--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -93,7 +93,7 @@ def _configure_logging(verbose: bool, quiet: bool) -> None:
     elif verbose:
         level = logging.DEBUG
     else:
-        level = logging.INFO
+        level = logging.WARNING
 
     handler = logging.StreamHandler(sys.stderr)
     fmt = "%(levelname)s: %(message)s"

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -292,9 +292,9 @@ class TestConfigureLogging(unittest.TestCase):
         _configure_logging(verbose=False, quiet=True)
         self.assertEqual(logging.getLogger().level, logging.WARNING)
 
-    def test_default_sets_info(self):
+    def test_default_sets_warning(self):
         _configure_logging(verbose=False, quiet=False)
-        self.assertEqual(logging.getLogger().level, logging.INFO)
+        self.assertEqual(logging.getLogger().level, logging.WARNING)
 
     def test_log_level_env_overrides_flags(self):
         with patch.dict(os.environ, {"LOG_LEVEL": "ERROR"}):


### PR DESCRIPTION
## Summary
- `sys2txt` configures the root logger, so third-party loggers (e.g. faster-whisper) propagate through it. This caused every transcription to print `INFO: Processing audio with duration ...` and `INFO: VAD filter removed ...` by default.
- Change the default log level from `INFO` to `WARNING` so these messages (and sys2txt's own INFO-level messages) are hidden unless `--verbose`/`-v` is passed or `LOG_LEVEL` is set explicitly.

## Test plan
- [x] `python -m unittest discover -s tests -p "test_*.py"` — all 84 tests pass (updated `test_default_sets_info` → `test_default_sets_warning` to match new default)
- [x] `ruff check src/ tests/` and `ruff format --check src/ tests/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)