### PR TITLE
fix: use PAT for release-please to trigger downstream publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # A PAT is required (not the default GITHUB_TOKEN): GitHub does not
+          # trigger downstream workflows (e.g. publish-to-pypi's tag push
+          # trigger) for tags/releases created with the default token, to
+          # prevent recursive workflow runs.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- Release-please tags/releases created with the default `GITHUB_TOKEN` don't trigger downstream `on: push`/`on: release` workflows (GitHub's anti-recursion guard), which is why `publish-to-pypi.yml` never ran for tags `v0.3.1` through `v0.5.2`.
- Switches `release-please.yml` to use a `RELEASE_PLEASE_TOKEN` PAT secret instead, so the tags it creates will trigger the publish workflow.

## Required follow-up (not part of this PR)
- Create a fine-grained PAT with `contents: write` + `pull-requests: write` on this repo (or a GitHub App token) and add it as the `RELEASE_PLEASE_TOKEN` repo secret before merging, otherwise release-please will fail auth.

## Test plan
- [x] Add `RELEASE_PLEASE_TOKEN` secret
- [ ] Merge a release-please PR after this change and confirm `publish-to-pypi.yml` runs automatically on the resulting tag