### PR TITLE
feat: add a public library API and make live capture a generator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,9 +74,15 @@ The codebase is organized into focused modules by functionality:
 
 ### Core Modules
 
-**audio.py** - Audio recording functionality:
-- `record_once()`: Spawns ffmpeg subprocess to record from PulseAudio/PipeWire source to WAV file at 16 kHz mono
-- `segment_and_transcribe_live()`: Spawns ffmpeg with segment muxer to create sequential WAV files, monitors temporary directory for new segments, and calls transcribe callback for each. Uses stdin 'q' command for graceful ffmpeg shutdown on Ctrl-C.
+**audio.py** - Audio recording, and nothing else:
+- `AudioSegment`: Frozen dataclass of `(index, path)` for one finalized chunk of recorded audio
+- `record_once()`: Spawns ffmpeg subprocess to record from PulseAudio/PipeWire source to WAV file. `sample_rate`/`channels` are keyword-only and default to the constants.
+- `iter_audio_segments()`: Generator. Spawns ffmpeg with the segment muxer, polls the temporary directory for finalized segments, and yields an `AudioSegment` for each. Indices are tracked by a counter (a segment holding no audio is skipped but still consumes its index). A consumer that breaks out of the loop or closes the generator triggers the `finally` that sends `q` to ffmpeg and removes the temporary directory. No transcription, no printing, no file writing.
+
+**pipeline.py** - Recording and transcription combined:
+- `TranscriptSegment`: Frozen dataclass of `(index, text, start, end)`
+- `transcribe_live()`: Generator over `iter_audio_segments()`, transcribing each segment on a single-worker `ThreadPoolExecutor` with a timeout. A segment that fails or times out is yielded with empty text and logged as a warning.
+- `transcribe_once()`: Records to a temporary WAV and returns its transcript
 
 **pulse.py** - PulseAudio/PipeWire integration:
 - `list_pulse_sources()`: Uses `pactl list short sources` to enumerate audio sources
@@ -94,13 +100,17 @@ The codebase is organized into focused modules by functionality:
 - `_parse_whisper_cpp_output()`: Parses whisper.cpp output format
 - All engines support timestamps flag for per-segment timing output
 
+**constants.py** - Configuration shared by library and CLI: default model, capture `SAMPLE_RATE`/`CHANNELS`, segment length and poll interval, minimum segment size, ffmpeg shutdown grace, transcription timeouts.
+
 **utils.py** - Utility functions:
 - `which()`: Find command in PATH or raise RuntimeError
 
-**__main__.py** - CLI entry point:
-- argparse with subcommands: `once` and `live`
-- Common parent parser for shared arguments
-- Mode dispatch logic and transcribe callback creation for live mode
+**__init__.py** - The public API. Exports `AudioSegment`, `TranscriptSegment`, `TranscriptionConfig`, `get_default_monitor_source`, `iter_audio_segments`, `list_pulse_sources`, `record_once`, `transcribe_file`, `transcribe_live`, `transcribe_once` and `__version__`. Engine imports stay lazy so importing the package is cheap.
+
+**__main__.py** - CLI entry point, and the only module that prints:
+- argparse with subcommands: `once` and `live`, built by `_build_parser()`
+- `Options`: Frozen dataclass; `_build_options(args)` converts the argparse `Namespace` once and validates it (missing `--input` file, non-positive `--duration`/`--segment-seconds`, `--silence-timeout` shorter than a segment), raising `ValueError` that `main()` turns into a usage error (exit 2)
+- `_run_live()`: Consumes `transcribe_live()`, formatting, printing and appending each segment, and applying the silence-timeout policy by breaking out of the loop
 
 ### Key Dependencies
 - **ffmpeg**: System command for audio recording (checked via shutil.which)
@@ -197,17 +207,23 @@ ruff check --fix src/
 ```
 
 ## File Structure
-- `src/sys2txt/__main__.py`: CLI entry point (~130 lines)
+- `src/sys2txt/__main__.py`: CLI entry point: parsing, validation, printing, output files, stop policy
 - `src/sys2txt/audio.py`: Audio recording with ffmpeg
+- `src/sys2txt/pipeline.py`: Recording and transcription combined (`transcribe_live`, `transcribe_once`)
 - `src/sys2txt/transcribe.py`: Whisper transcription engines
 - `src/sys2txt/pulse.py`: PulseAudio/PipeWire source management
+- `src/sys2txt/constants.py`: Shared configuration values
 - `src/sys2txt/utils.py`: Utility functions
-- `src/sys2txt/__init__.py`: Empty package marker
+- `src/sys2txt/__init__.py`: Public API re-exports and `__version__`
+- `src/sys2txt/py.typed`: Type-hint marker (PEP 561)
 - `tests/`: Unit tests for all modules (using unittest framework)
   - `tests/test_utils.py`: Tests for utility functions
   - `tests/test_pulse.py`: Tests for PulseAudio integration
   - `tests/test_transcribe.py`: Tests for transcription engines
   - `tests/test_audio.py`: Tests for audio recording
+  - `tests/test_pipeline.py`: Tests for the recording/transcription pipeline
+  - `tests/test___main__.py`: Tests for the CLI
+  - `tests/test_init.py`: Tests for the public API surface
 - `.github/workflows/`:
   - `ci.yml`: CI workflow (tests, linting, formatting)
   - `publish-to-pypi.yml`: Publish to PyPI on release

--- a/README.md
+++ b/README.md
@@ -136,6 +136,45 @@ Transcribe with openai-whisper CLI:
 whisper out.wav --model small --task transcribe --language en
 ```
 
+## Use as a Python library
+
+`sys2txt` is importable as well as runnable. The library records and transcribes; printing, saving
+and when to stop are yours.
+
+Transcribe a fixed recording:
+
+```python
+from sys2txt import TranscriptionConfig, get_default_monitor_source, transcribe_once
+
+config = TranscriptionConfig(model="small.en")
+text = transcribe_once(get_default_monitor_source(), config, duration=30)
+```
+
+Consume a live recording segment by segment. `transcribe_live()` is a generator: it records until you
+stop iterating, and breaking out of the loop shuts ffmpeg down and cleans up its temporary files.
+
+```python
+from sys2txt import TranscriptionConfig, get_default_monitor_source, transcribe_live
+
+config = TranscriptionConfig(model="small.en")
+for segment in transcribe_live(get_default_monitor_source(), config, segment_seconds=8):
+    print(f"[{segment.start:.0f}s] {segment.text}")
+    if "goodbye" in segment.text.lower():
+        break
+```
+
+A segment whose transcription fails or times out is yielded with empty `text` and logged as a warning,
+so a failure never stops the stream.
+
+To handle the audio yourself, `iter_audio_segments()` yields `AudioSegment(index, path)` values without
+transcribing them, and `transcribe_file(path, config)` transcribes any audio file. Nothing in the library
+prints or writes files, and every module logs through the standard `logging` module under the `sys2txt`
+logger.
+
+The full public API is `AudioSegment`, `TranscriptSegment`, `TranscriptionConfig`,
+`get_default_monitor_source`, `iter_audio_segments`, `list_pulse_sources`, `record_once`,
+`transcribe_file`, `transcribe_live` and `transcribe_once`. The package ships type hints (`py.typed`).
+
 ## Whisper.cpp with Vulkan GPU
 
 For AMD GPUs (or other GPUs not supported by CUDA), you can use whisper.cpp with Vulkan acceleration for ~8x speedup over CPU.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dev = ["ruff>=0.8.0"]
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+sys2txt = ["py.typed"]
+
 [tool.ruff]
 line-length = 120
 target-version = "py39"

--- a/src/sys2txt/__init__.py
+++ b/src/sys2txt/__init__.py
@@ -1,1 +1,39 @@
+"""Record system audio and transcribe it to text.
 
+The public API is small: enumerate sources with :func:`list_pulse_sources` or
+:func:`get_default_monitor_source`, then either transcribe a single recording with
+:func:`transcribe_once` or consume a live recording segment by segment with
+:func:`transcribe_live`.
+
+    from sys2txt import TranscriptionConfig, get_default_monitor_source, transcribe_live
+
+    config = TranscriptionConfig(model="small.en")
+    for segment in transcribe_live(get_default_monitor_source(), config):
+        print(segment.start, segment.text)
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+from .audio import AudioSegment, iter_audio_segments, record_once
+from .pipeline import TranscriptSegment, transcribe_live, transcribe_once
+from .pulse import get_default_monitor_source, list_pulse_sources
+from .transcribe import TranscriptionConfig, transcribe_file
+
+try:
+    __version__ = version("sys2txt")
+except PackageNotFoundError:  # running from a source tree without an installed distribution
+    __version__ = "0.0.0+unknown"
+
+__all__ = [
+    "AudioSegment",
+    "TranscriptSegment",
+    "TranscriptionConfig",
+    "__version__",
+    "get_default_monitor_source",
+    "iter_audio_segments",
+    "list_pulse_sources",
+    "record_once",
+    "transcribe_file",
+    "transcribe_live",
+    "transcribe_once",
+]

--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -2,17 +2,42 @@
 """Main entry point for sys2txt CLI."""
 
 import argparse
+import contextlib
 import logging
 import os
 import sys
-import tempfile
+from dataclasses import dataclass
 from datetime import datetime
-from importlib.metadata import version
+from typing import Optional
 
-from .audio import record_once, segment_and_transcribe_live
-from .constants import WHISPER_MODEL
+from . import __version__
+from .constants import DEFAULT_SEGMENT_SECONDS, WHISPER_MODEL
+from .pipeline import TranscriptSegment, transcribe_live, transcribe_once
 from .pulse import get_default_monitor_source, list_pulse_sources
 from .transcribe import TranscriptionConfig, transcribe_file
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Options:
+    """Validated CLI options. The boundary between argument parsing and behaviour."""
+
+    mode: str
+    source: Optional[str] = None
+    model: str = WHISPER_MODEL
+    engine: str = "auto"
+    device: str = "auto"
+    language: Optional[str] = None
+    timestamps: bool = False
+    list_sources: bool = False
+    model_path: Optional[str] = None
+    whisper_cpp_path: Optional[str] = None
+    output: Optional[str] = None
+    duration: Optional[int] = None
+    input_path: Optional[str] = None
+    segment_seconds: int = DEFAULT_SEGMENT_SECONDS
+    silence_timeout: int = 0
 
 
 def get_timestamp_filename() -> str:
@@ -35,25 +60,72 @@ def ensure_output_dir() -> str:
     return output_dir
 
 
-logger = logging.getLogger(__name__)
-
-
-def _resolve_output_path(output_arg: str | None) -> str:
+def _resolve_output_path(output_arg: Optional[str]) -> str:
     """Return the output file path, generating a timestamped name if none given."""
     output_dir = ensure_output_dir()
     return output_arg if output_arg else os.path.join(output_dir, get_timestamp_filename())
 
 
-def _build_transcription_config(args) -> TranscriptionConfig:
-    """Build a TranscriptionConfig from parsed CLI args."""
-    return TranscriptionConfig(
-        engine=args.engine,
+def _build_options(args: argparse.Namespace) -> Options:
+    """Convert parsed arguments into validated Options.
+
+    Raises:
+        ValueError: If the arguments are inconsistent or refer to a missing file
+    """
+    input_path = getattr(args, "input", None)
+    duration = getattr(args, "duration", None)
+    segment_seconds = getattr(args, "segment_seconds", DEFAULT_SEGMENT_SECONDS)
+    silence_timeout = getattr(args, "silence_timeout", 0)
+
+    if input_path and not os.path.isfile(input_path):
+        raise ValueError(f"--input file not found: {input_path}")
+    if duration is not None and duration <= 0:
+        raise ValueError(f"--duration must be a positive number of seconds, got {duration}")
+    if segment_seconds <= 0:
+        raise ValueError(f"--segment-seconds must be a positive number of seconds, got {segment_seconds}")
+    if silence_timeout < 0:
+        raise ValueError(f"--silence-timeout must not be negative, got {silence_timeout}")
+    if 0 < silence_timeout < segment_seconds:
+        raise ValueError(
+            f"--silence-timeout ({silence_timeout}s) must be at least --segment-seconds "
+            f"({segment_seconds}s), since silence is only measured a whole segment at a time"
+        )
+
+    if args.engine not in ("cpp", "auto"):
+        if args.model_path:
+            logger.warning("--model-path is only used with --engine cpp")
+        if args.whisper_cpp_path:
+            logger.warning("--whisper-cpp-path is only used with --engine cpp")
+
+    return Options(
+        mode=args.mode,
+        source=args.source,
         model=args.model_size,
+        engine=args.engine,
+        device=args.device,
         language=args.language,
         timestamps=args.timestamps,
+        list_sources=args.list_sources,
         model_path=args.model_path,
         whisper_cpp_path=args.whisper_cpp_path,
-        device=args.device,
+        output=args.output,
+        duration=duration,
+        input_path=input_path,
+        segment_seconds=segment_seconds,
+        silence_timeout=silence_timeout,
+    )
+
+
+def _build_transcription_config(options: Options) -> TranscriptionConfig:
+    """Build a TranscriptionConfig from validated CLI options."""
+    return TranscriptionConfig(
+        engine=options.engine,
+        model=options.model,
+        language=options.language,
+        timestamps=options.timestamps,
+        model_path=options.model_path,
+        whisper_cpp_path=options.whisper_cpp_path,
+        device=options.device,
     )
 
 
@@ -63,6 +135,14 @@ def _save_transcript(text: str, output_file: str) -> None:
     with open(output_file, "w", encoding="utf-8") as w:
         w.write(text + "\n")
     logger.info("Transcript saved to: %s", output_file)
+
+
+def _format_segment(segment: TranscriptSegment, timestamps: bool) -> str:
+    """Render a live transcript segment as a single line of output."""
+    text = segment.text.strip()
+    if timestamps:
+        return f"[{int(segment.start):>5d}-{int(segment.end):>5d}s] {text}"
+    return text
 
 
 class _ColorFormatter(logging.Formatter):
@@ -107,10 +187,10 @@ def _configure_logging(verbose: bool, quiet: bool) -> None:
     root.addHandler(handler)
 
 
-def main():
-    """Main CLI entry point."""
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
     parser = argparse.ArgumentParser(description="Record Ubuntu system audio and transcribe with Whisper.")
-    parser.add_argument("--version", action="version", version=f"%(prog)s {version('sys2txt')}")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose (debug) logging")
     parser.add_argument("--quiet", "-q", action="store_true", help="Suppress informational log messages")
     sub = parser.add_subparsers(dest="mode", required=True)
@@ -160,7 +240,12 @@ def main():
     once.add_argument("--input", default=None, help="Skip recording and transcribe this existing audio file")
 
     live = sub.add_parser("live", parents=[common], help="Segmented live transcription")
-    live.add_argument("--segment-seconds", type=int, default=8, help="Segment length in seconds (default: 8)")
+    live.add_argument(
+        "--segment-seconds",
+        type=int,
+        default=DEFAULT_SEGMENT_SECONDS,
+        help=f"Segment length in seconds (default: {DEFAULT_SEGMENT_SECONDS})",
+    )
     live.add_argument("--output", default=None, help="Append live transcript to this file as it's produced")
     live.add_argument(
         "--silence-timeout",
@@ -169,12 +254,23 @@ def main():
         help="Auto-stop after N consecutive seconds of silence (0=disabled, default: 0)",
     )
 
+    return parser
+
+
+def main():
+    """Main CLI entry point."""
+    parser = _build_parser()
     args = parser.parse_args()
 
     _configure_logging(verbose=args.verbose, quiet=args.quiet)
 
     try:
-        _run(args)
+        options = _build_options(args)
+    except ValueError as e:
+        parser.error(str(e))
+
+    try:
+        _run(options)
     except RuntimeError as e:
         logger.error("%s", e)
         sys.exit(1)
@@ -183,66 +279,73 @@ def main():
         sys.exit(130)
 
 
-def _run(args) -> None:
-    """Dispatch to the requested mode. Raises KeyboardInterrupt/RuntimeError to caller."""
-    if args.engine not in ("cpp", "auto"):
-        if args.model_path:
-            logger.warning("--model-path is only used with --engine cpp")
-        if args.whisper_cpp_path:
-            logger.warning("--whisper-cpp-path is only used with --engine cpp")
+def _list_sources() -> None:
+    """Print the available PulseAudio sources, or exit if there are none."""
+    sources = list_pulse_sources()
+    if not sources:
+        logger.error("No PulseAudio sources found. Is PulseAudio/PipeWire running?")
+        sys.exit(1)
+    print("Available PulseAudio sources:")
+    for name, _ in sources:
+        print("  ", name)
 
-    if args.list_sources:
-        sources = list_pulse_sources()
-        if not sources:
-            logger.error("No PulseAudio sources found. Is PulseAudio/PipeWire running?")
-            sys.exit(1)
-        print("Available PulseAudio sources:")
-        for name, _ in sources:
-            print("  ", name)
+
+def _run_once(options: Options, source: str) -> None:
+    """Record (or read) a single audio file, transcribe it, and save the transcript."""
+    output_file = _resolve_output_path(options.output)
+    config = _build_transcription_config(options)
+
+    if options.input_path:
+        text = transcribe_file(options.input_path, config)
+    else:
+        text = transcribe_once(source, config, options.duration)
+
+    _save_transcript(text, output_file)
+
+
+def _run_live(options: Options, source: str) -> None:
+    """Consume live transcript segments, printing and saving each one as it arrives."""
+    output_file = _resolve_output_path(options.output)
+    config = _build_transcription_config(options)
+    logger.info("Live transcript will be saved to: %s", output_file)
+    logger.info("Press Ctrl-C once to stop live capture and save the transcript.")
+
+    segments = transcribe_live(source, config, segment_seconds=options.segment_seconds)
+    silent_seconds = 0
+    with open(output_file, "a", encoding="utf-8") as handle:
+        try:
+            with contextlib.closing(segments):
+                for segment in segments:
+                    line = _format_segment(segment, options.timestamps)
+                    print(line, flush=True)
+                    handle.write(line + "\n")
+                    handle.flush()
+
+                    if segment.text.strip():
+                        silent_seconds = 0
+                    else:
+                        silent_seconds += options.segment_seconds
+                    if 0 < options.silence_timeout <= silent_seconds:
+                        logger.info("No speech detected for %d seconds, stopping automatically.", silent_seconds)
+                        break
+        except KeyboardInterrupt:
+            logger.info("Stopping live capture...")
+
+    logger.info("Transcript saved to: %s", output_file)
+
+
+def _run(options: Options) -> None:
+    """Dispatch to the requested mode. Raises KeyboardInterrupt/RuntimeError to caller."""
+    if options.list_sources:
+        _list_sources()
         return
 
-    # Determine source
-    source = args.source or get_default_monitor_source()
+    source = options.source or get_default_monitor_source()
 
-    if args.mode == "once":
-        output_file = _resolve_output_path(args.output)
-        config = _build_transcription_config(args)
-
-        if args.input:
-            text = transcribe_file(args.input, config)
-        else:
-            with tempfile.TemporaryDirectory(prefix="sys2txt_") as tmp:
-                wav = os.path.join(tmp, "capture.wav")
-                record_once(source=source, out_wav=wav, sample_rate=16000, channels=1, duration=args.duration)
-                text = transcribe_file(wav, config)
-
-        _save_transcript(text, output_file)
-
-    elif args.mode == "live":
-        output_file = _resolve_output_path(args.output)
-        config = _build_transcription_config(args)
-        logger.info("Live transcript will be saved to: %s", output_file)
-        logger.info("Press Ctrl-C once to stop live capture and save the transcript.")
-
-        def transcribe_segment(file_path: str, segment_index: int) -> str:
-            """Transcribe a segment and format with optional timestamp prefix."""
-            text = transcribe_file(file_path, config)
-            if args.timestamps:
-                start = segment_index * args.segment_seconds
-                end = start + args.segment_seconds
-                prefix = f"[{start:>5d}-{end:>5d}s] "
-                return prefix + text.strip()
-            return text.strip()
-
-        segment_and_transcribe_live(
-            source=source,
-            sample_rate=16000,
-            channels=1,
-            segment_seconds=args.segment_seconds,
-            transcribe_callback=transcribe_segment,
-            output_path=output_file,
-            silence_timeout=args.silence_timeout,
-        )
+    if options.mode == "once":
+        _run_once(options, source)
+    elif options.mode == "live":
+        _run_live(options, source)
 
 
 if __name__ == "__main__":

--- a/src/sys2txt/audio.py
+++ b/src/sys2txt/audio.py
@@ -6,29 +6,47 @@ import signal
 import subprocess
 import tempfile
 import time
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import TimeoutError as FuturesTimeoutError
-from typing import Optional
+from dataclasses import dataclass
+from typing import Iterator, List, Optional
 
+from .constants import (
+    CHANNELS,
+    DEFAULT_SEGMENT_SECONDS,
+    FFMPEG_SHUTDOWN_GRACE,
+    MIN_SEGMENT_BYTES,
+    SAMPLE_RATE,
+    SEGMENT_POLL_INTERVAL,
+)
 from .utils import which
 
 logger = logging.getLogger(__name__)
 
 
-class _SilenceTimeout(Exception):
-    """Raised internally when consecutive silence exceeds the timeout."""
+@dataclass(frozen=True)
+class AudioSegment:
+    """A finalized chunk of recorded audio.
+
+    Attributes:
+        index: Position of the segment in the recording, counting from 0
+        path: Path to the segment's WAV file. It lives in a temporary directory that is
+            removed once the producing generator is closed, so copy it if you need it later.
+    """
+
+    index: int
+    path: str
 
 
-def _stop_ffmpeg(proc, executor):
-    """Gracefully stop ffmpeg and shut down the transcription executor."""
-    executor.shutdown(wait=False)
+def _stop_ffmpeg(proc: subprocess.Popen) -> None:
+    """Ask ffmpeg to quit, then terminate it if it does not exit in time."""
     try:
+        if proc.poll() is not None:
+            return
         if proc.stdin:
             proc.stdin.write(b"q")
             proc.stdin.flush()
             proc.stdin.close()
         try:
-            proc.wait(timeout=3.0)
+            proc.wait(timeout=FFMPEG_SHUTDOWN_GRACE)
         except subprocess.TimeoutExpired:
             proc.terminate()
             proc.wait()
@@ -36,15 +54,22 @@ def _stop_ffmpeg(proc, executor):
         pass
 
 
-def record_once(source: str, out_wav: str, sample_rate: int, channels: int, duration: Optional[int]) -> None:
+def record_once(
+    source: str,
+    out_wav: str,
+    duration: Optional[int] = None,
+    *,
+    sample_rate: int = SAMPLE_RATE,
+    channels: int = CHANNELS,
+) -> None:
     """Record audio once from a PulseAudio source to a WAV file.
 
     Args:
         source: PulseAudio source name (e.g., "sink.monitor")
         out_wav: Output WAV file path
-        sample_rate: Sample rate in Hz (e.g., 16000)
-        channels: Number of audio channels (1 for mono, 2 for stereo)
         duration: Optional recording duration in seconds. If None, records until interrupted.
+        sample_rate: Sample rate in Hz
+        channels: Number of audio channels (1 for mono, 2 for stereo)
     """
     ffmpeg = which("ffmpeg")
     args = [
@@ -86,54 +111,34 @@ def record_once(source: str, out_wav: str, sample_rate: int, channels: int, dura
     logger.info("Recording finished.")
 
 
-def _process_segment_file(f, tmp, processed, transcribe_callback, output_path, executor, timeout):
-    """Process a single finalized segment file: transcribe and print/write output."""
-    full = os.path.join(tmp, f)
-    if os.path.getsize(full) < 64:
-        return ""
-    processed.add(f)
-    try:
-        idx = int(os.path.splitext(f)[0].split("_")[-1])
-    except (ValueError, IndexError):
-        idx = 0
-    if executor and timeout:
-        future = executor.submit(transcribe_callback, full, idx)
-        try:
-            text = future.result(timeout=timeout)
-        except FuturesTimeoutError:
-            logger.warning("Segment %s transcription timed out, skipping", f)
-            return ""
-        except Exception as e:
-            logger.warning("Segment %s transcription failed: %s", f, e)
-            return ""
-    else:
-        text = transcribe_callback(full, idx)
-    print(text, flush=True)
-    if output_path:
-        with open(output_path, "a", encoding="utf-8") as w:
-            w.write(text + "\n")
-    return text
+def _segment_files(directory: str) -> List[str]:
+    """Return the segment filenames in chronological order."""
+    return sorted(f for f in os.listdir(directory) if f.startswith("seg_") and f.endswith(".wav"))
 
 
-def segment_and_transcribe_live(
+def iter_audio_segments(
     source: str,
-    sample_rate: int,
-    channels: int,
-    segment_seconds: int,
-    transcribe_callback,
-    output_path: Optional[str],
-    silence_timeout: int = 0,
-) -> None:
-    """Record audio in segments and transcribe each segment as it's created.
+    segment_seconds: int = DEFAULT_SEGMENT_SECONDS,
+    *,
+    sample_rate: int = SAMPLE_RATE,
+    channels: int = CHANNELS,
+) -> Iterator[AudioSegment]:
+    """Record continuously and yield each segment of audio as ffmpeg finalizes it.
+
+    Recording runs until the consumer stops iterating: breaking out of the loop, closing the
+    generator, or letting it be garbage collected shuts ffmpeg down gracefully and removes the
+    temporary directory holding the segments.
 
     Args:
         source: PulseAudio source name
+        segment_seconds: Length of each segment in seconds
         sample_rate: Sample rate in Hz
         channels: Number of audio channels
-        segment_seconds: Length of each segment in seconds
-        transcribe_callback: Function to call for each segment. Should accept (file_path, segment_index) and return text
-        output_path: Optional file path to append transcripts to
-        silence_timeout: Auto-stop after this many consecutive seconds of silence (0 = disabled)
+
+    Yields:
+        AudioSegment values in chronological order. Segment files that hold no audio are
+        skipped, but their index is still consumed so an index always maps to the same
+        position on the recording's timeline.
     """
     ffmpeg = which("ffmpeg")
     with tempfile.TemporaryDirectory(prefix="sys2txt_") as tmp:
@@ -160,52 +165,39 @@ def segment_and_transcribe_live(
             pattern,
         ]
 
-        logger.info("Live mode: segmenting every %ds from '%s'. Press Ctrl-C to stop.", segment_seconds, source)
+        logger.info("Live mode: segmenting every %ds from '%s'.", segment_seconds, source)
         proc = subprocess.Popen(args, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-        processed: set[str] = set()
-        # Timeout: allow generous time but prevent indefinite hangs
-        transcribe_timeout = max(segment_seconds * 5, 60)
-        executor = ThreadPoolExecutor(max_workers=1)
-        consecutive_silent_seconds = 0
+        seen: set[str] = set()
+        next_index = 0
+
+        def emit(names):
+            """Yield an AudioSegment for each name not seen before."""
+            nonlocal next_index
+            for name in names:
+                if name in seen:
+                    continue
+                seen.add(name)
+                index = next_index
+                next_index += 1
+                path = os.path.join(tmp, name)
+                if os.path.getsize(path) < MIN_SEGMENT_BYTES:
+                    logger.debug("Segment %s holds no audio, skipping", name)
+                    continue
+                yield AudioSegment(index=index, path=path)
+
         try:
             while True:
-                # sorted ensures we process in chronological order
-                files = sorted(f for f in os.listdir(tmp) if f.startswith("seg_") and f.endswith(".wav"))
+                files = _segment_files(tmp)
                 # While ffmpeg is running, the last file is always the one currently
                 # being written. Only process files that have been finalized, which is
                 # guaranteed when a newer segment exists after them.
-                safe_to_process = files[:-1] if len(files) > 1 else []
-                new_files = [f for f in safe_to_process if f not in processed]
-                for f in new_files:
-                    text = _process_segment_file(
-                        f, tmp, processed, transcribe_callback, output_path, executor, transcribe_timeout
-                    )
-                    if silence_timeout > 0:
-                        if not text or not text.strip():
-                            consecutive_silent_seconds += segment_seconds
-                        else:
-                            consecutive_silent_seconds = 0
-                        if consecutive_silent_seconds >= silence_timeout:
-                            raise _SilenceTimeout()
+                yield from emit(files[:-1] if len(files) > 1 else [])
 
-                # If ffmpeg has exited and no new files pending, break
-                ret = proc.poll()
-                if ret is not None:
-                    # flush remaining unprocessed files (including the last segment)
-                    files = sorted(f for f in os.listdir(tmp) if f.startswith("seg_") and f.endswith(".wav"))
-                    for f in [f for f in files if f not in processed]:
-                        _process_segment_file(
-                            f, tmp, processed, transcribe_callback, output_path, executor, transcribe_timeout
-                        )
+                if proc.poll() is not None:
+                    # ffmpeg has exited, so every remaining file is finalized
+                    yield from emit(_segment_files(tmp))
                     break
-                time.sleep(0.3)
-        except KeyboardInterrupt:
-            logger.info("Stopping live capture...")
-            _stop_ffmpeg(proc, executor)
+                time.sleep(SEGMENT_POLL_INTERVAL)
+        finally:
+            _stop_ffmpeg(proc)
             logger.info("Stopped live capture.")
-        except _SilenceTimeout:
-            logger.info(
-                "No speech detected for %d seconds, stopping automatically.",
-                consecutive_silent_seconds,
-            )
-            _stop_ffmpeg(proc, executor)

--- a/src/sys2txt/constants.py
+++ b/src/sys2txt/constants.py
@@ -1,4 +1,33 @@
+"""Configuration values shared by the library and the CLI."""
+
 import os
 
 WHISPER_MODEL = os.getenv("WHISPER_MODEL", "small.en")
 "Default Whisper model"
+
+SAMPLE_RATE = 16000
+"Capture sample rate in Hz. Whisper models expect 16 kHz audio."
+
+CHANNELS = 1
+"Number of capture channels. Whisper models expect mono audio."
+
+DEFAULT_SEGMENT_SECONDS = 8
+"Default length of a live-mode segment in seconds"
+
+MIN_SEGMENT_BYTES = 64
+"Segments smaller than this are header-only and hold no audio"
+
+SEGMENT_POLL_INTERVAL = 0.3
+"Seconds to wait between scans of the segment directory"
+
+FFMPEG_SHUTDOWN_GRACE = 3.0
+"Seconds to wait for ffmpeg to exit after asking it to quit, before terminating it"
+
+TRANSCRIBE_TIMEOUT_FACTOR = 5
+"Segment transcription is allowed this multiple of the segment length"
+
+MIN_TRANSCRIBE_TIMEOUT = 60
+"Lower bound in seconds for the per-segment transcription timeout"
+
+WHISPER_CPP_TIMEOUT = 300
+"Seconds to wait for whisper-cli before assuming a GPU hang or malformed audio"

--- a/src/sys2txt/pipeline.py
+++ b/src/sys2txt/pipeline.py
@@ -1,0 +1,121 @@
+"""Recording and transcription combined into reusable pipelines."""
+
+import contextlib
+import logging
+import os
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from dataclasses import dataclass
+from typing import Iterator, Optional
+
+from .audio import iter_audio_segments, record_once
+from .constants import (
+    CHANNELS,
+    DEFAULT_SEGMENT_SECONDS,
+    MIN_TRANSCRIBE_TIMEOUT,
+    SAMPLE_RATE,
+    TRANSCRIBE_TIMEOUT_FACTOR,
+)
+from .transcribe import TranscriptionConfig, transcribe_file
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TranscriptSegment:
+    """The transcript of one segment of a live recording.
+
+    Attributes:
+        index: Position of the segment in the recording, counting from 0
+        text: Transcribed text, empty when the segment held no speech or transcription failed
+        start: Start of the segment in seconds from the beginning of the recording
+        end: End of the segment in seconds from the beginning of the recording
+    """
+
+    index: int
+    text: str
+    start: float
+    end: float
+
+
+def _segment_timeout(segment_seconds: int) -> float:
+    """Allow generous time to transcribe a segment while preventing indefinite hangs."""
+    return max(segment_seconds * TRANSCRIBE_TIMEOUT_FACTOR, MIN_TRANSCRIBE_TIMEOUT)
+
+
+def transcribe_live(
+    source: str,
+    config: TranscriptionConfig,
+    *,
+    segment_seconds: int = DEFAULT_SEGMENT_SECONDS,
+    sample_rate: int = SAMPLE_RATE,
+    channels: int = CHANNELS,
+) -> Iterator[TranscriptSegment]:
+    """Record continuously and yield the transcript of each segment as it becomes available.
+
+    Recording runs until the consumer stops iterating, so a caller decides when to stop by
+    breaking out of the loop or closing the generator. Transcription of a segment blocks the
+    generator, but ffmpeg keeps recording in the background while it runs.
+
+    Args:
+        source: PulseAudio source name
+        config: Transcription configuration
+        segment_seconds: Length of each segment in seconds
+        sample_rate: Sample rate in Hz
+        channels: Number of audio channels
+
+    Yields:
+        TranscriptSegment values in chronological order. A segment whose transcription times
+        out or fails is yielded with empty text and logged as a warning.
+    """
+    timeout = _segment_timeout(segment_seconds)
+    segments = iter_audio_segments(source, segment_seconds, sample_rate=sample_rate, channels=channels)
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        with contextlib.closing(segments):
+            for segment in segments:
+                future = executor.submit(transcribe_file, segment.path, config)
+                try:
+                    text = future.result(timeout=timeout)
+                except FuturesTimeoutError:
+                    logger.warning("Segment %d transcription timed out, skipping", segment.index)
+                    text = ""
+                except Exception as e:
+                    logger.warning("Segment %d transcription failed: %s", segment.index, e)
+                    text = ""
+                start = segment.index * segment_seconds
+                yield TranscriptSegment(
+                    index=segment.index,
+                    text=text,
+                    start=float(start),
+                    end=float(start + segment_seconds),
+                )
+    finally:
+        executor.shutdown(wait=False)
+
+
+def transcribe_once(
+    source: str,
+    config: TranscriptionConfig,
+    duration: Optional[int] = None,
+    *,
+    sample_rate: int = SAMPLE_RATE,
+    channels: int = CHANNELS,
+) -> str:
+    """Record audio once and return its transcript.
+
+    Args:
+        source: PulseAudio source name
+        config: Transcription configuration
+        duration: Recording duration in seconds. If None, records until interrupted.
+        sample_rate: Sample rate in Hz
+        channels: Number of audio channels
+
+    Returns:
+        Transcribed text
+    """
+    with tempfile.TemporaryDirectory(prefix="sys2txt_") as tmp:
+        wav = os.path.join(tmp, "capture.wav")
+        record_once(source, wav, duration, sample_rate=sample_rate, channels=channels)
+        return transcribe_file(wav, config)

--- a/src/sys2txt/pulse.py
+++ b/src/sys2txt/pulse.py
@@ -1,7 +1,10 @@
 """PulseAudio/PipeWire integration for source enumeration and selection."""
 
+import logging
 import subprocess
 from typing import List, Tuple
+
+logger = logging.getLogger(__name__)
 
 
 def run_command(cmd: List[str]) -> Tuple[int, str, str]:
@@ -14,8 +17,9 @@ def run_command(cmd: List[str]) -> Tuple[int, str, str]:
 def list_pulse_sources() -> List[Tuple[str, str]]:
     """Return list of (name, description) for PulseAudio sources."""
     try:
-        code, out, _ = run_command(["pactl", "list", "short", "sources"])
+        code, out, err = run_command(["pactl", "list", "short", "sources"])
         if code != 0:
+            logger.warning("pactl exited with code %d: %s", code, err.strip())
             return []
         items: List[Tuple[str, str]] = []
         for line in out.splitlines():
@@ -26,6 +30,7 @@ def list_pulse_sources() -> List[Tuple[str, str]]:
                 items.append((name, name))
         return items
     except FileNotFoundError:
+        logger.warning("pactl not found. Is PulseAudio/PipeWire installed?")
         return []
 
 
@@ -42,7 +47,9 @@ def get_default_monitor_source() -> str:
         # fallback: first *.monitor source
         for s, _ in list_pulse_sources():
             if s.endswith(".monitor"):
+                logger.debug("Default sink has no monitor source, falling back to '%s'", s)
                 return s
-    except (FileNotFoundError, RuntimeError):
-        pass
+    except (FileNotFoundError, RuntimeError) as e:
+        logger.debug("Could not query PulseAudio for a monitor source: %s", e)
+    logger.debug("No monitor source found, falling back to 'default'")
     return "default"

--- a/src/sys2txt/transcribe.py
+++ b/src/sys2txt/transcribe.py
@@ -1,5 +1,6 @@
 """Transcription functionality using Whisper models."""
 
+import logging
 import os
 import re
 import shutil
@@ -8,6 +9,10 @@ import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+
+from .constants import WHISPER_CPP_TIMEOUT
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -54,6 +59,9 @@ def transcribe_file(path: str, config: TranscriptionConfig) -> str:
                 engine = "whisper"
             except ImportError:
                 engine = "cpp"
+        logger.debug("Auto-selected transcription engine: %s", engine)
+
+    logger.debug("Transcribing %s with engine '%s', model '%s'", path, engine, config.model)
 
     if engine == "faster":
         return _transcribe_faster_whisper(path, config.model, config.language, config.timestamps, config.device)
@@ -97,6 +105,7 @@ def _transcribe_faster_whisper(
     key = (model_size, fw_device, compute_type)
     with _model_cache_lock:
         if _faster_whisper_model_key != key:
+            logger.info("Loading faster-whisper model '%s' on %s (%s)", model_size, fw_device, compute_type)
             _faster_whisper_model = WhisperModel(model_size, device=fw_device, compute_type=compute_type)
             _faster_whisper_model_key = key
         model = _faster_whisper_model
@@ -122,6 +131,7 @@ def _transcribe_openai_whisper(path: str, model_size: str, language: Optional[st
     global _openai_whisper_model, _openai_whisper_model_key
     with _model_cache_lock:
         if _openai_whisper_model_key != model_size:
+            logger.info("Loading openai-whisper model '%s'", model_size)
             _openai_whisper_model = whisper.load_model(model_size)
             _openai_whisper_model_key = model_size
         model = _openai_whisper_model
@@ -319,11 +329,13 @@ def _transcribe_whisper_cpp(
     if language:
         cmd.extend(["-l", language])
 
+    logger.debug("Running whisper-cli: %s", " ".join(cmd))
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=300)
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=WHISPER_CPP_TIMEOUT)
     except subprocess.TimeoutExpired as e:
         raise RuntimeError(
-            f"whisper-cli timed out after 300 seconds (possible GPU hang or malformed audio): {binary}"
+            f"whisper-cli timed out after {WHISPER_CPP_TIMEOUT} seconds "
+            f"(possible GPU hang or malformed audio): {binary}"
         ) from e
     except subprocess.CalledProcessError as e:
         stderr = e.stderr.strip() if e.stderr else "No error output"

--- a/src/sys2txt/utils.py
+++ b/src/sys2txt/utils.py
@@ -1,6 +1,9 @@
 """Utility functions."""
 
+import logging
 import shutil
+
+logger = logging.getLogger(__name__)
 
 
 def which(cmd: str) -> str:
@@ -8,4 +11,5 @@ def which(cmd: str) -> str:
     path = shutil.which(cmd)
     if not path:
         raise RuntimeError(f"Required command not found: {cmd}. Please install it and try again.")
+    logger.debug("Resolved command '%s' to %s", cmd, path)
     return path

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -2,18 +2,51 @@
 
 import logging
 import os
+import tempfile
 import unittest
 from argparse import Namespace
 from unittest.mock import mock_open, patch
 
 from sys2txt.__main__ import (
+    Options,
+    _build_options,
     _build_transcription_config,
     _configure_logging,
+    _format_segment,
     _resolve_output_path,
     _save_transcript,
     main,
 )
+from sys2txt.pipeline import TranscriptSegment
 from sys2txt.transcribe import TranscriptionConfig
+
+
+def make_args(**overrides):
+    """Build a parsed-argument namespace with the CLI's defaults."""
+    values = dict(
+        mode="live",
+        source=None,
+        model_size="small",
+        engine="auto",
+        device="auto",
+        language=None,
+        timestamps=False,
+        list_sources=False,
+        model_path=None,
+        whisper_cpp_path=None,
+        output=None,
+        segment_seconds=8,
+        silence_timeout=0,
+    )
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def live_segments(*texts, segment_seconds=8):
+    """Yield TranscriptSegment values the way transcribe_live does."""
+    for index, text in enumerate(texts):
+        start = index * segment_seconds
+        yield TranscriptSegment(index=index, text=text, start=float(start), end=float(start + segment_seconds))
 
 
 class TestResolveOutputPath(unittest.TestCase):
@@ -30,18 +63,92 @@ class TestResolveOutputPath(unittest.TestCase):
         self.assertEqual(result, os.path.join("/out", "2024-01-01_00-00-00.txt"))
 
 
+class TestBuildOptions(unittest.TestCase):
+    """Tests for the parsing/behaviour boundary."""
+
+    def test_copies_arguments_onto_options(self):
+        args = make_args(
+            mode="once",
+            source="my.monitor",
+            model_size="large-v2",
+            engine="cpp",
+            device="cuda",
+            language="en",
+            timestamps=True,
+            model_path="/models/ggml.bin",
+            whisper_cpp_path="/usr/local/bin/whisper-cli",
+            output="/tmp/out.txt",
+            duration=30,
+            input=None,
+        )
+        options = _build_options(args)
+        self.assertIsInstance(options, Options)
+        self.assertEqual(options.mode, "once")
+        self.assertEqual(options.source, "my.monitor")
+        self.assertEqual(options.model, "large-v2")
+        self.assertEqual(options.engine, "cpp")
+        self.assertEqual(options.device, "cuda")
+        self.assertEqual(options.language, "en")
+        self.assertTrue(options.timestamps)
+        self.assertEqual(options.model_path, "/models/ggml.bin")
+        self.assertEqual(options.whisper_cpp_path, "/usr/local/bin/whisper-cli")
+        self.assertEqual(options.output, "/tmp/out.txt")
+        self.assertEqual(options.duration, 30)
+
+    def test_missing_input_file_is_rejected(self):
+        args = make_args(mode="once", duration=None, input="/does/not/exist.wav")
+        with self.assertRaises(ValueError) as ctx:
+            _build_options(args)
+        self.assertIn("--input", str(ctx.exception))
+
+    def test_existing_input_file_is_accepted(self):
+        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+            args = make_args(mode="once", duration=None, input=f.name)
+            options = _build_options(args)
+        self.assertEqual(options.input_path, f.name)
+
+    def test_non_positive_duration_is_rejected(self):
+        args = make_args(mode="once", duration=0, input=None)
+        with self.assertRaises(ValueError):
+            _build_options(args)
+
+    def test_non_positive_segment_seconds_is_rejected(self):
+        with self.assertRaises(ValueError):
+            _build_options(make_args(segment_seconds=0))
+
+    def test_negative_silence_timeout_is_rejected(self):
+        with self.assertRaises(ValueError):
+            _build_options(make_args(silence_timeout=-1))
+
+    def test_silence_timeout_shorter_than_a_segment_is_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            _build_options(make_args(segment_seconds=8, silence_timeout=3))
+        self.assertIn("--silence-timeout", str(ctx.exception))
+
+    def test_silence_timeout_equal_to_segment_length_is_accepted(self):
+        options = _build_options(make_args(segment_seconds=8, silence_timeout=8))
+        self.assertEqual(options.silence_timeout, 8)
+
+    def test_warns_about_cpp_only_flags(self):
+        args = make_args(engine="faster", model_path="/m.bin", whisper_cpp_path="/w")
+        with self.assertLogs("sys2txt.__main__", level="WARNING") as logs:
+            _build_options(args)
+        self.assertEqual(len(logs.output), 2)
+
+
 class TestBuildTranscriptionConfig(unittest.TestCase):
     def test_returns_config_with_correct_values(self):
-        args = Namespace(
+        options = Options(
+            mode="once",
             engine="faster",
-            model_size="small",
+            model="small",
             language="en",
             timestamps=True,
             model_path="/models/ggml.bin",
             whisper_cpp_path="/usr/local/bin/whisper-cli",
             device="cpu",
         )
-        config = _build_transcription_config(args)
+        config = _build_transcription_config(options)
         self.assertIsInstance(config, TranscriptionConfig)
         self.assertEqual(config.engine, "faster")
         self.assertEqual(config.model, "small")
@@ -50,6 +157,18 @@ class TestBuildTranscriptionConfig(unittest.TestCase):
         self.assertEqual(config.model_path, "/models/ggml.bin")
         self.assertEqual(config.whisper_cpp_path, "/usr/local/bin/whisper-cli")
         self.assertEqual(config.device, "cpu")
+
+
+class TestFormatSegment(unittest.TestCase):
+    """Tests for live output formatting."""
+
+    def test_plain_text_without_timestamps(self):
+        segment = TranscriptSegment(index=1, text="  hello  ", start=8.0, end=16.0)
+        self.assertEqual(_format_segment(segment, timestamps=False), "hello")
+
+    def test_timestamp_prefix(self):
+        segment = TranscriptSegment(index=1, text="hello", start=8.0, end=16.0)
+        self.assertEqual(_format_segment(segment, timestamps=True), "[    8-   16s] hello")
 
 
 class TestSaveTranscript(unittest.TestCase):
@@ -73,49 +192,50 @@ class TestArgumentParsing(unittest.TestCase):
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
-    @patch("sys2txt.__main__.record_once")
-    @patch("sys2txt.__main__.transcribe_file", return_value="text")
+    @patch("sys2txt.__main__.transcribe_once", return_value="text")
     @patch("sys2txt.__main__._save_transcript")
     @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
-    def test_once_defaults(self, _res, _save, _trans, _rec, _src, _log):
+    def test_once_defaults(self, _res, _save, mock_once, _src, _log):
         with patch("sys.argv", ["sys2txt", "once"]):
             main()
-        # record_once was called (no --input), meaning mode dispatched correctly
-        _rec.assert_called_once()
+        mock_once.assert_called_once()
+        self.assertEqual(mock_once.call_args[0][0], "default.monitor")
+        self.assertIsNone(mock_once.call_args[0][2])
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
-    @patch("sys2txt.__main__.segment_and_transcribe_live")
-    @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
-    def test_live_defaults(self, _res, _live, _src, _log):
-        with patch("sys.argv", ["sys2txt", "live"]):
-            main()
-        _live.assert_called_once()
-        call_kwargs = _live.call_args
-        self.assertEqual(call_kwargs[1]["segment_seconds"], 8)
-        self.assertEqual(call_kwargs[1]["silence_timeout"], 0)
+    @patch("sys2txt.__main__.transcribe_live", return_value=iter(()))
+    @patch("sys2txt.__main__._resolve_output_path")
+    def test_live_defaults(self, mock_res, mock_live, _src, _log):
+        with tempfile.TemporaryDirectory() as tmp:
+            mock_res.return_value = os.path.join(tmp, "out.txt")
+            mock_live.return_value = live_segments()
+            with patch("sys.argv", ["sys2txt", "live"]):
+                main()
+        mock_live.assert_called_once()
+        self.assertEqual(mock_live.call_args[1]["segment_seconds"], 8)
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
     @patch("sys2txt.__main__.transcribe_file", return_value="text")
     @patch("sys2txt.__main__._save_transcript")
     @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
-    def test_once_with_input_skips_recording(self, _res, _save, _trans, _src, _log):
-        with (
-            patch("sys.argv", ["sys2txt", "once", "--input", "/tmp/audio.wav"]),
-            patch("sys2txt.__main__.record_once") as mock_rec,
-        ):
-            main()
-        mock_rec.assert_not_called()
-        _trans.assert_called_once_with("/tmp/audio.wav", unittest.mock.ANY)
+    def test_once_with_input_skips_recording(self, _res, _save, mock_trans, _src, _log):
+        with tempfile.NamedTemporaryFile(suffix=".wav") as audio:
+            with (
+                patch("sys.argv", ["sys2txt", "once", "--input", audio.name]),
+                patch("sys2txt.__main__.transcribe_once") as mock_once,
+            ):
+                main()
+            mock_once.assert_not_called()
+            mock_trans.assert_called_once_with(audio.name, unittest.mock.ANY)
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
-    @patch("sys2txt.__main__.record_once")
-    @patch("sys2txt.__main__.transcribe_file", return_value="text")
+    @patch("sys2txt.__main__.transcribe_once", return_value="text")
     @patch("sys2txt.__main__._save_transcript")
     @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
-    def test_once_all_flags(self, _res, _save, _trans, _rec, _src, _log):
+    def test_once_all_flags(self, _res, _save, mock_once, _src, _log):
         with patch(
             "sys.argv",
             [
@@ -142,53 +262,55 @@ class TestArgumentParsing(unittest.TestCase):
             main()
         # Source should be the explicit one, not the default
         _src.assert_not_called()
-        call_args = _rec.call_args
-        self.assertEqual(call_args[1]["source"], "my.monitor")
-        self.assertEqual(call_args[1]["duration"], 30)
+        self.assertEqual(mock_once.call_args[0][0], "my.monitor")
+        self.assertEqual(mock_once.call_args[0][2], 30)
         # Output was explicitly provided so _resolve_output_path gets it
         _res.assert_called_once_with("/tmp/my.txt")
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
-    @patch("sys2txt.__main__.segment_and_transcribe_live")
-    @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
-    def test_live_all_flags(self, _res, _live, _src, _log):
-        with patch(
-            "sys.argv",
-            [
-                "sys2txt",
-                "--quiet",
-                "live",
-                "--source",
-                "my.monitor",
-                "--model",
-                "tiny",
-                "--engine",
-                "cpp",
-                "--language",
-                "fr",
-                "--timestamps",
-                "--device",
-                "vulkan",
-                "--model-path",
-                "/models/ggml.bin",
-                "--whisper-cpp-path",
-                "/usr/bin/whisper-cli",
-                "--segment-seconds",
-                "15",
-                "--output",
-                "/tmp/live.txt",
-                "--silence-timeout",
-                "30",
-            ],
-        ):
-            main()
-        _live.assert_called_once()
-        call_kwargs = _live.call_args[1]
-        self.assertEqual(call_kwargs["source"], "my.monitor")
-        self.assertEqual(call_kwargs["segment_seconds"], 15)
-        self.assertEqual(call_kwargs["silence_timeout"], 30)
-        self.assertEqual(call_kwargs["output_path"], "/tmp/out.txt")
+    @patch("sys2txt.__main__.transcribe_live")
+    @patch("sys2txt.__main__._resolve_output_path")
+    def test_live_all_flags(self, mock_res, mock_live, _src, _log):
+        with tempfile.TemporaryDirectory() as tmp:
+            mock_res.return_value = os.path.join(tmp, "out.txt")
+            mock_live.return_value = live_segments()
+            with patch(
+                "sys.argv",
+                [
+                    "sys2txt",
+                    "--quiet",
+                    "live",
+                    "--source",
+                    "my.monitor",
+                    "--model",
+                    "tiny",
+                    "--engine",
+                    "cpp",
+                    "--language",
+                    "fr",
+                    "--timestamps",
+                    "--device",
+                    "vulkan",
+                    "--model-path",
+                    "/models/ggml.bin",
+                    "--whisper-cpp-path",
+                    "/usr/bin/whisper-cli",
+                    "--segment-seconds",
+                    "15",
+                    "--output",
+                    "/tmp/live.txt",
+                    "--silence-timeout",
+                    "30",
+                ],
+            ):
+                main()
+        mock_live.assert_called_once()
+        self.assertEqual(mock_live.call_args[0][0], "my.monitor")
+        self.assertEqual(mock_live.call_args[1]["segment_seconds"], 15)
+        config = mock_live.call_args[0][1]
+        self.assertEqual(config.model, "tiny")
+        self.assertEqual(config.engine, "cpp")
 
     def test_missing_subcommand_exits(self):
         with patch("sys.argv", ["sys2txt"]):
@@ -197,9 +319,9 @@ class TestArgumentParsing(unittest.TestCase):
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
-    @patch("sys2txt.__main__.record_once", side_effect=KeyboardInterrupt())
+    @patch("sys2txt.__main__.transcribe_once", side_effect=KeyboardInterrupt())
     @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
-    def test_keyboard_interrupt_exits_cleanly(self, _res, mock_rec, _src, _log):
+    def test_keyboard_interrupt_exits_cleanly(self, _res, _once, _src, _log):
         with patch("sys.argv", ["sys2txt", "once"]):
             with self.assertRaises(SystemExit) as ctx:
                 main()
@@ -212,6 +334,29 @@ class TestArgumentParsing(unittest.TestCase):
             with self.assertRaises(SystemExit) as ctx:
                 main()
         self.assertEqual(ctx.exception.code, 1)
+
+
+class TestInvalidArguments(unittest.TestCase):
+    """Invalid flag combinations fail fast with a usage error."""
+
+    def _assert_usage_error(self, argv):
+        with patch("sys2txt.__main__._configure_logging"):
+            with patch("sys.argv", argv):
+                with self.assertRaises(SystemExit) as ctx:
+                    main()
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_missing_input_file(self):
+        self._assert_usage_error(["sys2txt", "once", "--input", "/does/not/exist.wav"])
+
+    def test_non_positive_duration(self):
+        self._assert_usage_error(["sys2txt", "once", "--duration", "0"])
+
+    def test_non_positive_segment_seconds(self):
+        self._assert_usage_error(["sys2txt", "live", "--segment-seconds", "0"])
+
+    def test_silence_timeout_shorter_than_segment(self):
+        self._assert_usage_error(["sys2txt", "live", "--segment-seconds", "8", "--silence-timeout", "3"])
 
 
 class TestListSources(unittest.TestCase):
@@ -243,15 +388,13 @@ class TestModeDispatchOnce(unittest.TestCase):
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
-    @patch("sys2txt.__main__.record_once")
-    @patch("sys2txt.__main__.transcribe_file", return_value="hello world")
+    @patch("sys2txt.__main__.transcribe_once", return_value="hello world")
     @patch("sys2txt.__main__._save_transcript")
     @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
-    def test_once_records_then_transcribes(self, _res, mock_save, mock_trans, mock_rec, _src, _log):
+    def test_once_records_then_transcribes(self, _res, mock_save, mock_once, _src, _log):
         with patch("sys.argv", ["sys2txt", "once"]):
             main()
-        mock_rec.assert_called_once()
-        mock_trans.assert_called_once()
+        mock_once.assert_called_once()
         mock_save.assert_called_once_with("hello world", "/tmp/out.txt")
 
     @patch("sys2txt.__main__._configure_logging")
@@ -260,32 +403,109 @@ class TestModeDispatchOnce(unittest.TestCase):
     @patch("sys2txt.__main__._save_transcript")
     @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
     def test_once_input_skips_recording(self, _res, mock_save, mock_trans, _src, _log):
-        with patch("sys.argv", ["sys2txt", "once", "--input", "/audio.wav"]):
-            main()
-        mock_trans.assert_called_once()
-        self.assertEqual(mock_trans.call_args[0][0], "/audio.wav")
+        with tempfile.NamedTemporaryFile(suffix=".wav") as audio:
+            with patch("sys.argv", ["sys2txt", "once", "--input", audio.name]):
+                main()
+            self.assertEqual(mock_trans.call_args[0][0], audio.name)
         mock_save.assert_called_once_with("from file", "/tmp/out.txt")
 
 
 class TestModeDispatchLive(unittest.TestCase):
-    """Tests for live mode dispatch logic."""
+    """Tests for live mode consumption of the transcript stream."""
 
-    @patch("sys2txt.__main__._configure_logging")
-    @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
-    @patch("sys2txt.__main__.segment_and_transcribe_live")
-    @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
-    def test_live_calls_segment_and_transcribe(self, _res, mock_live, _src, _log):
-        with patch("sys.argv", ["sys2txt", "live"]):
-            main()
-        mock_live.assert_called_once()
-        kwargs = mock_live.call_args[1]
-        self.assertEqual(kwargs["source"], "default.monitor")
-        self.assertEqual(kwargs["sample_rate"], 16000)
-        self.assertEqual(kwargs["channels"], 1)
-        self.assertEqual(kwargs["segment_seconds"], 8)
-        self.assertEqual(kwargs["output_path"], "/tmp/out.txt")
-        self.assertEqual(kwargs["silence_timeout"], 0)
-        self.assertTrue(callable(kwargs["transcribe_callback"]))
+    def _run_live(self, argv, segments):
+        """Run the CLI in live mode against a canned segment stream, returning the transcript file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_file = os.path.join(tmp, "out.txt")
+            with (
+                patch("sys2txt.__main__._configure_logging"),
+                patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor"),
+                patch("sys2txt.__main__._resolve_output_path", return_value=output_file),
+                patch("sys2txt.__main__.transcribe_live", return_value=segments) as mock_live,
+                patch("builtins.print") as mock_print,
+                patch("sys.argv", argv),
+            ):
+                main()
+            with open(output_file, encoding="utf-8") as f:
+                written = f.read()
+        return mock_live, mock_print, written
+
+    def test_prints_and_saves_each_segment(self):
+        _, mock_print, written = self._run_live(
+            ["sys2txt", "live"],
+            live_segments("hello", "world"),
+        )
+        mock_print.assert_any_call("hello", flush=True)
+        mock_print.assert_any_call("world", flush=True)
+        self.assertEqual(written, "hello\nworld\n")
+
+    def test_timestamps_prefix_each_line(self):
+        _, _, written = self._run_live(
+            ["sys2txt", "live", "--timestamps"],
+            live_segments("hello", "world"),
+        )
+        self.assertEqual(written, "[    0-    8s] hello\n[    8-   16s] world\n")
+
+    def test_silence_timeout_stops_consuming(self):
+        segments = live_segments("", "", "should never be reached")
+        _, mock_print, written = self._run_live(
+            ["sys2txt", "live", "--silence-timeout", "16"],
+            segments,
+        )
+        self.assertEqual(written, "\n\n")
+        self.assertEqual(mock_print.call_count, 2)
+
+    def test_silence_counter_resets_on_speech(self):
+        segments = live_segments("", "hello", "", "")
+        _, mock_print, written = self._run_live(
+            ["sys2txt", "live", "--silence-timeout", "16"],
+            segments,
+        )
+        # Silence resets at "hello", so all four segments are consumed
+        self.assertEqual(written, "\nhello\n\n\n")
+        self.assertEqual(mock_print.call_count, 4)
+
+    def test_silence_timeout_disabled_by_default(self):
+        _, mock_print, written = self._run_live(
+            ["sys2txt", "live"],
+            live_segments("", "", ""),
+        )
+        self.assertEqual(mock_print.call_count, 3)
+        self.assertEqual(written, "\n\n\n")
+
+    def test_keyboard_interrupt_saves_what_was_transcribed(self):
+        def segments():
+            yield from live_segments("hello")
+            raise KeyboardInterrupt()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_file = os.path.join(tmp, "out.txt")
+            with (
+                patch("sys2txt.__main__._configure_logging"),
+                patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor"),
+                patch("sys2txt.__main__._resolve_output_path", return_value=output_file),
+                patch("sys2txt.__main__.transcribe_live", return_value=segments()),
+                patch("builtins.print"),
+                patch("sys.argv", ["sys2txt", "live"]),
+            ):
+                main()  # exits normally, not with code 130
+            with open(output_file, encoding="utf-8") as f:
+                self.assertEqual(f.read(), "hello\n")
+
+    def test_closes_the_transcript_stream_when_stopping_early(self):
+        segments = live_segments("", "", "unreachable")
+        with tempfile.TemporaryDirectory() as tmp:
+            with (
+                patch("sys2txt.__main__._configure_logging"),
+                patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor"),
+                patch("sys2txt.__main__._resolve_output_path", return_value=os.path.join(tmp, "out.txt")),
+                patch("sys2txt.__main__.transcribe_live", return_value=segments),
+                patch("builtins.print"),
+                patch("sys.argv", ["sys2txt", "live", "--silence-timeout", "16"]),
+            ):
+                main()
+        with self.assertRaises(StopIteration):
+            next(segments)
 
 
 class TestConfigureLogging(unittest.TestCase):
@@ -318,3 +538,7 @@ class TestConfigureLogging(unittest.TestCase):
         with patch.dict(os.environ, {"LOG_LEVEL": "ERROR"}):
             _configure_logging(verbose=True, quiet=False)
         self.assertEqual(logging.getLogger().level, logging.ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-from sys2txt.audio import record_once, segment_and_transcribe_live
+from sys2txt.audio import AudioSegment, iter_audio_segments, record_once
 
 
 class TestRecordOnce(unittest.TestCase):
@@ -21,7 +21,7 @@ class TestRecordOnce(unittest.TestCase):
         mock_proc.wait.return_value = None
         mock_popen.return_value = mock_proc
 
-        record_once("test.monitor", "/tmp/test.wav", 16000, 1, 30)
+        record_once("test.monitor", "/tmp/test.wav", 30)
 
         mock_which.assert_called_once_with("ffmpeg")
         mock_popen.assert_called_once()
@@ -42,11 +42,24 @@ class TestRecordOnce(unittest.TestCase):
         mock_proc.wait.return_value = None
         mock_popen.return_value = mock_proc
 
-        record_once("test.monitor", "/tmp/test.wav", 16000, 1, None)
+        record_once("test.monitor", "/tmp/test.wav")
 
         args = mock_popen.call_args[0][0]
         self.assertNotIn("-t", args)
         mock_proc.wait.assert_called_once()
+
+    @patch("sys2txt.audio.which")
+    @patch("sys2txt.audio.subprocess.Popen")
+    def test_record_once_uses_default_sample_rate_and_channels(self, mock_popen, mock_which):
+        """Sample rate and channels default to the Whisper-compatible constants."""
+        mock_which.return_value = "/usr/bin/ffmpeg"
+        mock_popen.return_value = MagicMock()
+
+        record_once("test.monitor", "/tmp/test.wav")
+
+        args = mock_popen.call_args[0][0]
+        self.assertEqual(args[args.index("-ar") + 1], "16000")
+        self.assertEqual(args[args.index("-ac") + 1], "1")
 
     @patch("sys2txt.audio.which")
     @patch("sys2txt.audio.subprocess.Popen")
@@ -57,323 +70,145 @@ class TestRecordOnce(unittest.TestCase):
         mock_proc.wait.side_effect = [KeyboardInterrupt(), None]
         mock_popen.return_value = mock_proc
 
-        record_once("test.monitor", "/tmp/test.wav", 16000, 1, None)
+        record_once("test.monitor", "/tmp/test.wav")
 
         mock_proc.send_signal.assert_called_once_with(signal.SIGINT)
         self.assertEqual(mock_proc.wait.call_count, 2)
 
 
-class TestSegmentAndTranscribeLive(unittest.TestCase):
-    """Tests for the segment_and_transcribe_live() function."""
+class TestIterAudioSegments(unittest.TestCase):
+    """Tests for the iter_audio_segments() generator."""
+
+    def _ffmpeg_proc(self, poll_results=None, poll_return=None):
+        """Build a mock ffmpeg process."""
+        proc = MagicMock()
+        if poll_results is not None:
+            proc.poll.side_effect = poll_results
+        else:
+            proc.poll.return_value = poll_return
+        proc.stdin = MagicMock()
+        proc.wait.return_value = None
+        return proc
 
     @patch("sys2txt.audio.which")
     @patch("sys2txt.audio.subprocess.Popen")
     @patch("sys2txt.audio.time.sleep")
     @patch("sys2txt.audio.os.listdir")
     @patch("sys2txt.audio.os.path.getsize")
-    def test_segment_and_transcribe_live_basic(self, mock_getsize, mock_listdir, mock_sleep, mock_popen, mock_which):
-        """Test segment_and_transcribe_live() basic functionality."""
+    def test_yields_finalized_segments_in_order(self, mock_getsize, mock_listdir, _sleep, mock_popen, mock_which):
+        """Segments are yielded in order, the newest deferred until ffmpeg exits."""
         mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_proc = MagicMock()
-        mock_proc.poll.side_effect = [None, None, 0]  # ffmpeg exits after 3 checks
-        mock_proc.stdin = MagicMock()
-        mock_popen.return_value = mock_proc
-
-        # Simulate two segments being created. The flush-path listdir call must also
-        # return both files so the second segment is picked up after ffmpeg exits.
+        # Three loop polls plus one from the shutdown helper
+        mock_popen.return_value = self._ffmpeg_proc(poll_results=[None, None, 0, 0])
         mock_listdir.side_effect = [
             [],
-            ["seg_00000.wav"],
-            ["seg_00000.wav", "seg_00001.wav"],
-            ["seg_00000.wav", "seg_00001.wav"],  # flush path: seg_00001 not yet processed
+            ["seg_00000.wav"],  # only one file: still being written
+            ["seg_00000.wav", "seg_00001.wav"],  # seg_00000 is finalized
+            ["seg_00000.wav", "seg_00001.wav"],  # flush path picks up seg_00001
         ]
-        mock_getsize.return_value = 1024  # Files have content
-
-        transcribe_callback = MagicMock(side_effect=["transcript 1", "transcript 2"])
+        mock_getsize.return_value = 1024
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
                 mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                segments = list(iter_audio_segments("test.monitor", 8))
 
-                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None)
+        self.assertEqual([s.index for s in segments], [0, 1])
+        self.assertTrue(segments[0].path.endswith("seg_00000.wav"))
+        self.assertTrue(segments[1].path.endswith("seg_00001.wav"))
+        self.assertIsInstance(segments[0], AudioSegment)
 
-        # Verify ffmpeg was called with correct args
-        mock_which.assert_called_once_with("ffmpeg")
         args = mock_popen.call_args[0][0]
         self.assertIn("/usr/bin/ffmpeg", args)
         self.assertIn("test.monitor", args)
-        self.assertIn("-segment_time", args)
-        self.assertIn("8", args)
-
-        # Verify transcribe callback was called for both segments
-        self.assertEqual(transcribe_callback.call_count, 2)
+        self.assertEqual(args[args.index("-segment_time") + 1], "8")
 
     @patch("sys2txt.audio.which")
     @patch("sys2txt.audio.subprocess.Popen")
     @patch("sys2txt.audio.time.sleep")
-    def test_segment_and_transcribe_live_with_output(self, mock_sleep, mock_popen, mock_which):
-        """Test segment_and_transcribe_live() writes to output file."""
+    def test_skips_empty_segments_but_keeps_index_on_the_timeline(self, _sleep, mock_popen, mock_which):
+        """A segment holding no audio is skipped, but still consumes its index."""
         mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_proc = MagicMock()
-        mock_proc.poll.side_effect = [None, 0]
-        mock_proc.stdin = MagicMock()
-        mock_popen.return_value = mock_proc
-
-        transcribe_callback = MagicMock(return_value="test transcript")
-
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
-            output_path = f.name
-
-        try:
-            with tempfile.TemporaryDirectory() as tmpdir:
-                # Create a test segment file
-                seg_file = os.path.join(tmpdir, "seg_00000.wav")
-                with open(seg_file, "wb") as f:
-                    f.write(b"x" * 1024)  # Create a file with content
-
-                with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
-                    mock_tmpdir.return_value.__enter__.return_value = tmpdir
-
-                    segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, output_path)
-
-            # Verify output was written
-            with open(output_path, "r") as f:
-                content = f.read()
-                self.assertIn("test transcript", content)
-        finally:
-            os.unlink(output_path)
-
-    @patch("sys2txt.audio.which")
-    @patch("sys2txt.audio.subprocess.Popen")
-    @patch("sys2txt.audio.time.sleep")
-    @patch("sys2txt.audio.os.listdir")
-    def test_segment_and_transcribe_live_keyboard_interrupt(self, mock_listdir, mock_sleep, mock_popen, mock_which):
-        """Test segment_and_transcribe_live() handles KeyboardInterrupt gracefully."""
-        mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_proc = MagicMock()
-        mock_proc.stdin = MagicMock()
-        mock_proc.wait.return_value = None
-        mock_popen.return_value = mock_proc
-
-        # Simulate KeyboardInterrupt during processing
-        mock_listdir.side_effect = KeyboardInterrupt()
-
-        transcribe_callback = MagicMock()
+        mock_popen.return_value = self._ffmpeg_proc(poll_results=[None, 0, 0])
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
-                mock_tmpdir.return_value.__enter__.return_value = tmpdir
-
-                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None)
-
-        # Verify graceful shutdown - 'q' sent to ffmpeg stdin
-        mock_proc.stdin.write.assert_called_once_with(b"q")
-        mock_proc.stdin.flush.assert_called_once()
-        mock_proc.stdin.close.assert_called_once()
-        mock_proc.wait.assert_called()
-
-    @patch("sys2txt.audio.which")
-    @patch("sys2txt.audio.subprocess.Popen")
-    @patch("sys2txt.audio.time.sleep")
-    def test_segment_and_transcribe_live_skips_small_files(self, mock_sleep, mock_popen, mock_which):
-        """Test segment_and_transcribe_live() skips files smaller than 64 bytes."""
-        mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_proc = MagicMock()
-        mock_proc.poll.side_effect = [None, 0]
-        mock_proc.stdin = MagicMock()
-        mock_popen.return_value = mock_proc
-
-        transcribe_callback = MagicMock()
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create a small test segment file (less than 64 bytes)
-            seg_file = os.path.join(tmpdir, "seg_00000.wav")
-            with open(seg_file, "wb") as f:
-                f.write(b"x" * 32)  # File too small
+            with open(os.path.join(tmpdir, "seg_00000.wav"), "wb") as f:
+                f.write(b"x" * 32)  # below MIN_SEGMENT_BYTES
+            with open(os.path.join(tmpdir, "seg_00001.wav"), "wb") as f:
+                f.write(b"x" * 1024)
 
             with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
                 mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                segments = list(iter_audio_segments("test.monitor", 8))
 
-                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None)
+        self.assertEqual([s.index for s in segments], [1])
 
-        # Verify callback was NOT called for small file
-        transcribe_callback.assert_not_called()
+    @patch("sys2txt.audio.which")
+    @patch("sys2txt.audio.subprocess.Popen")
+    @patch("sys2txt.audio.time.sleep")
+    def test_no_segments_when_all_files_are_empty(self, _sleep, mock_popen, mock_which):
+        """Nothing is yielded when every segment file is header-only."""
+        mock_which.return_value = "/usr/bin/ffmpeg"
+        mock_popen.return_value = self._ffmpeg_proc(poll_results=[0, 0])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "seg_00000.wav"), "wb") as f:
+                f.write(b"x" * 32)
+
+            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
+                mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                segments = list(iter_audio_segments("test.monitor", 8))
+
+        self.assertEqual(segments, [])
 
     @patch("sys2txt.audio.which")
     @patch("sys2txt.audio.subprocess.Popen")
     @patch("sys2txt.audio.time.sleep")
     @patch("sys2txt.audio.os.listdir")
     @patch("sys2txt.audio.os.path.getsize")
-    def test_live_skips_last_segment_while_ffmpeg_running(
-        self, mock_getsize, mock_listdir, mock_sleep, mock_popen, mock_which
+    def test_closing_the_generator_stops_ffmpeg(self, mock_getsize, mock_listdir, _sleep, mock_popen, mock_which):
+        """A consumer that stops iterating shuts ffmpeg down gracefully."""
+        mock_which.return_value = "/usr/bin/ffmpeg"
+        proc = self._ffmpeg_proc(poll_return=None)  # ffmpeg keeps running
+        mock_popen.return_value = proc
+        mock_listdir.return_value = ["seg_00000.wav", "seg_00001.wav"]
+        mock_getsize.return_value = 1024
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
+                mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                segments = iter_audio_segments("test.monitor", 8)
+                first = next(segments)
+                segments.close()
+
+        self.assertEqual(first.index, 0)
+        proc.stdin.write.assert_called_once_with(b"q")
+        proc.stdin.flush.assert_called_once()
+        proc.stdin.close.assert_called_once()
+        proc.wait.assert_called()
+
+    @patch("sys2txt.audio.which")
+    @patch("sys2txt.audio.subprocess.Popen")
+    @patch("sys2txt.audio.time.sleep")
+    @patch("sys2txt.audio.os.listdir")
+    @patch("sys2txt.audio.os.path.getsize")
+    def test_no_quit_sent_when_ffmpeg_exits_on_its_own(
+        self, mock_getsize, mock_listdir, _sleep, mock_popen, mock_which
     ):
-        """While ffmpeg is running, the newest segment (still being written) is not transcribed."""
+        """ffmpeg that has already exited is not asked to quit again."""
         mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_proc = MagicMock()
-        # ffmpeg running on first poll, exits on second
-        mock_proc.poll.side_effect = [None, 0]
-        mock_proc.stdin = MagicMock()
-        mock_popen.return_value = mock_proc
-
-        mock_listdir.side_effect = [
-            ["seg_00000.wav", "seg_00001.wav"],  # live iter 1: seg_00000 safe, seg_00001 skipped
-            ["seg_00000.wav", "seg_00001.wav"],  # live iter 2: nothing new safe
-            ["seg_00000.wav", "seg_00001.wav"],  # flush path: seg_00001 now processed
-        ]
+        proc = self._ffmpeg_proc(poll_return=0)
+        mock_popen.return_value = proc
+        mock_listdir.return_value = ["seg_00000.wav"]
         mock_getsize.return_value = 1024
-
-        transcribe_callback = MagicMock(side_effect=["transcript 0", "transcript 1"])
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
                 mock_tmpdir.return_value.__enter__.return_value = tmpdir
-                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None)
+                segments = list(iter_audio_segments("test.monitor", 8))
 
-        # Both segments transcribed: seg_00000 in live loop, seg_00001 in flush path
-        self.assertEqual(transcribe_callback.call_count, 2)
-        first_call_path = transcribe_callback.call_args_list[0][0][0]
-        second_call_path = transcribe_callback.call_args_list[1][0][0]
-        self.assertIn("seg_00000", first_call_path)
-        self.assertIn("seg_00001", second_call_path)
-
-    @patch("sys2txt.audio.which")
-    @patch("sys2txt.audio.subprocess.Popen")
-    @patch("sys2txt.audio.time.sleep")
-    @patch("sys2txt.audio.os.listdir")
-    @patch("sys2txt.audio.os.path.getsize")
-    def test_live_processes_last_segment_in_flush_path(
-        self, mock_getsize, mock_listdir, mock_sleep, mock_popen, mock_which
-    ):
-        """After ffmpeg exits, the last segment (deferred during live polling) is transcribed."""
-        mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_proc = MagicMock()
-        # ffmpeg exits immediately on first poll; single file only visible during flush
-        mock_proc.poll.side_effect = [0]
-        mock_proc.stdin = MagicMock()
-        mock_popen.return_value = mock_proc
-
-        mock_listdir.side_effect = [
-            ["seg_00000.wav"],  # live iter 1: one file, not safe (it's the active one) → skipped
-            ["seg_00000.wav"],  # flush path: ffmpeg closed it, now process it
-        ]
-        mock_getsize.return_value = 1024
-
-        transcribe_callback = MagicMock(return_value="transcript 0")
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
-                mock_tmpdir.return_value.__enter__.return_value = tmpdir
-                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None)
-
-        # Segment must have been transcribed (in the flush path, not the live loop)
-        transcribe_callback.assert_called_once()
-        call_path = transcribe_callback.call_args_list[0][0][0]
-        self.assertIn("seg_00000", call_path)
-
-    @patch("sys2txt.audio.which")
-    @patch("sys2txt.audio.subprocess.Popen")
-    @patch("sys2txt.audio.time.sleep")
-    @patch("sys2txt.audio.os.listdir")
-    @patch("sys2txt.audio.os.path.getsize")
-    def test_silence_timeout_triggers_shutdown(self, mock_getsize, mock_listdir, mock_sleep, mock_popen, mock_which):
-        """Test that silence_timeout stops live mode after enough consecutive silent segments."""
-        mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_proc = MagicMock()
-        # ffmpeg keeps running; silence timeout should stop it
-        mock_proc.poll.return_value = None
-        mock_proc.stdin = MagicMock()
-        mock_proc.wait.return_value = None
-        mock_popen.return_value = mock_proc
-
-        # Two segments processed, both silent — with segment_seconds=8 and silence_timeout=16
-        mock_listdir.side_effect = [
-            ["seg_00000.wav", "seg_00001.wav"],  # seg_00000 safe
-            ["seg_00000.wav", "seg_00001.wav", "seg_00002.wav"],  # seg_00001 safe
-        ]
-        mock_getsize.return_value = 1024
-
-        transcribe_callback = MagicMock(return_value="")
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
-                mock_tmpdir.return_value.__enter__.return_value = tmpdir
-                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None, silence_timeout=16)
-
-        # Verify graceful shutdown — 'q' sent to ffmpeg
-        mock_proc.stdin.write.assert_called_once_with(b"q")
-        mock_proc.stdin.flush.assert_called_once()
-        mock_proc.stdin.close.assert_called_once()
-
-    @patch("sys2txt.audio.which")
-    @patch("sys2txt.audio.subprocess.Popen")
-    @patch("sys2txt.audio.time.sleep")
-    @patch("sys2txt.audio.os.listdir")
-    @patch("sys2txt.audio.os.path.getsize")
-    def test_silence_timeout_resets_on_speech(self, mock_getsize, mock_listdir, mock_sleep, mock_popen, mock_which):
-        """Test that the silence counter resets when speech is detected."""
-        mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_proc = MagicMock()
-        # ffmpeg exits after processing all segments
-        mock_proc.poll.side_effect = [None, None, None, 0]
-        mock_proc.stdin = MagicMock()
-        mock_popen.return_value = mock_proc
-
-        # Three segments: silent, speech, silent — should NOT trigger timeout at 16s
-        all_files = ["seg_00000.wav", "seg_00001.wav", "seg_00002.wav", "seg_00003.wav"]
-        mock_listdir.side_effect = [
-            all_files[:2],  # iter 1: seg_00000 safe (silent)
-            all_files[:3],  # iter 2: seg_00001 safe (speech)
-            all_files[:4],  # iter 3: seg_00002 safe (silent)
-            all_files[:4],  # iter 4: nothing new safe, poll returns 0
-            all_files[:4],  # flush path: seg_00003
-        ]
-        mock_getsize.return_value = 1024
-
-        transcribe_callback = MagicMock(side_effect=["", "hello world", "", ""])
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
-                mock_tmpdir.return_value.__enter__.return_value = tmpdir
-                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None, silence_timeout=16)
-
-        # All 4 segments were transcribed (no premature shutdown)
-        self.assertEqual(transcribe_callback.call_count, 4)
-        # ffmpeg was NOT sent 'q' — it exited naturally
-        mock_proc.stdin.write.assert_not_called()
-
-    @patch("sys2txt.audio.which")
-    @patch("sys2txt.audio.subprocess.Popen")
-    @patch("sys2txt.audio.time.sleep")
-    @patch("sys2txt.audio.os.listdir")
-    @patch("sys2txt.audio.os.path.getsize")
-    def test_silence_timeout_disabled_by_default(self, mock_getsize, mock_listdir, mock_sleep, mock_popen, mock_which):
-        """Test that silence_timeout=0 (default) does not trigger auto-stop."""
-        mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_proc = MagicMock()
-        mock_proc.poll.side_effect = [None, None, 0]
-        mock_proc.stdin = MagicMock()
-        mock_popen.return_value = mock_proc
-
-        # Three silent segments — should NOT trigger timeout when disabled
-        all_files = ["seg_00000.wav", "seg_00001.wav", "seg_00002.wav"]
-        mock_listdir.side_effect = [
-            all_files[:2],  # iter 1: seg_00000 safe
-            all_files[:3],  # iter 2: seg_00001 safe
-            all_files[:3],  # iter 3: nothing new, poll returns 0
-            all_files[:3],  # flush: seg_00002
-        ]
-        mock_getsize.return_value = 1024
-
-        transcribe_callback = MagicMock(return_value="")
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
-                mock_tmpdir.return_value.__enter__.return_value = tmpdir
-                segment_and_transcribe_live("test.monitor", 16000, 1, 8, transcribe_callback, None, silence_timeout=0)
-
-        # All segments processed, no premature shutdown
-        self.assertEqual(transcribe_callback.call_count, 3)
-        mock_proc.stdin.write.assert_not_called()
+        self.assertEqual([s.index for s in segments], [0])
+        proc.stdin.write.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,47 @@
+"""Tests for the sys2txt public API."""
+
+import unittest
+
+import sys2txt
+
+
+class TestPublicApi(unittest.TestCase):
+    """The package exports a usable API, not just a console script."""
+
+    def test_every_exported_name_exists(self):
+        for name in sys2txt.__all__:
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(sys2txt, name), f"{name} is in __all__ but not importable")
+
+    def test_version_is_a_string(self):
+        self.assertIsInstance(sys2txt.__version__, str)
+        self.assertIn("__version__", sys2txt.__all__)
+
+    def test_exports_the_expected_surface(self):
+        self.assertEqual(
+            sorted(sys2txt.__all__),
+            [
+                "AudioSegment",
+                "TranscriptSegment",
+                "TranscriptionConfig",
+                "__version__",
+                "get_default_monitor_source",
+                "iter_audio_segments",
+                "list_pulse_sources",
+                "record_once",
+                "transcribe_file",
+                "transcribe_live",
+                "transcribe_once",
+            ],
+        )
+
+    def test_importing_the_package_does_not_load_an_engine(self):
+        """Whisper engines stay lazily imported so `import sys2txt` is cheap."""
+        import sys
+
+        self.assertNotIn("faster_whisper", sys.modules)
+        self.assertNotIn("whisper", sys.modules)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,147 @@
+"""Tests for sys2txt.pipeline module."""
+
+import unittest
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from unittest.mock import MagicMock, patch
+
+from sys2txt.audio import AudioSegment
+from sys2txt.pipeline import TranscriptSegment, _segment_timeout, transcribe_live, transcribe_once
+from sys2txt.transcribe import TranscriptionConfig
+
+
+def make_segments(count, start=0):
+    """Yield AudioSegment values the way iter_audio_segments does."""
+    for i in range(start, start + count):
+        yield AudioSegment(index=i, path=f"/tmp/seg_{i:05d}.wav")
+
+
+class ClosableSegments:
+    """An audio segment source that records whether it was closed."""
+
+    def __init__(self, segments):
+        self._segments = iter(segments)
+        self.closed = False
+
+    def __iter__(self):
+        return self._segments
+
+    def close(self):
+        self.closed = True
+
+
+class TestSegmentTimeout(unittest.TestCase):
+    """Tests for the per-segment transcription timeout."""
+
+    def test_scales_with_segment_length(self):
+        self.assertEqual(_segment_timeout(30), 150)
+
+    def test_has_a_lower_bound(self):
+        self.assertEqual(_segment_timeout(4), 60)
+
+
+class TestTranscribeLive(unittest.TestCase):
+    """Tests for the transcribe_live() generator."""
+
+    def setUp(self):
+        self.config = TranscriptionConfig(model="tiny")
+
+    @patch("sys2txt.pipeline.transcribe_file")
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_yields_a_transcript_per_segment(self, mock_iter, mock_transcribe):
+        """Each audio segment becomes a TranscriptSegment with its position on the timeline."""
+        mock_iter.return_value = make_segments(2)
+        mock_transcribe.side_effect = ["hello", "world"]
+
+        segments = list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+        self.assertEqual(segments[0], TranscriptSegment(index=0, text="hello", start=0.0, end=8.0))
+        self.assertEqual(segments[1], TranscriptSegment(index=1, text="world", start=8.0, end=16.0))
+        mock_iter.assert_called_once_with("test.monitor", 8, sample_rate=16000, channels=1)
+        self.assertEqual(mock_transcribe.call_args_list[0][0], ("/tmp/seg_00000.wav", self.config))
+
+    @patch("sys2txt.pipeline.transcribe_file")
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_failed_segment_yields_empty_text(self, mock_iter, mock_transcribe):
+        """A segment that fails to transcribe is yielded with empty text and a warning."""
+        mock_iter.return_value = make_segments(2)
+        mock_transcribe.side_effect = [RuntimeError("engine exploded"), "recovered"]
+
+        with self.assertLogs("sys2txt.pipeline", level="WARNING") as logs:
+            segments = list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+        self.assertEqual([s.text for s in segments], ["", "recovered"])
+        self.assertIn("engine exploded", logs.output[0])
+
+    @patch("sys2txt.pipeline.ThreadPoolExecutor")
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_timed_out_segment_yields_empty_text(self, mock_iter, mock_executor_cls):
+        """A segment whose transcription times out is yielded with empty text and a warning."""
+        mock_iter.return_value = make_segments(1)
+        future = MagicMock()
+        future.result.side_effect = FuturesTimeoutError()
+        executor = mock_executor_cls.return_value
+        executor.submit.return_value = future
+
+        with self.assertLogs("sys2txt.pipeline", level="WARNING") as logs:
+            segments = list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+        self.assertEqual([s.text for s in segments], [""])
+        self.assertIn("timed out", logs.output[0])
+        future.result.assert_called_once_with(timeout=60)
+        executor.shutdown.assert_called_once_with(wait=False)
+
+    @patch("sys2txt.pipeline.transcribe_file", return_value="hello")
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_closing_stops_the_audio_source(self, mock_iter, _transcribe):
+        """Closing the transcript generator closes the underlying audio generator."""
+        source = ClosableSegments(make_segments(3))
+        mock_iter.return_value = source
+
+        segments = transcribe_live("test.monitor", self.config, segment_seconds=8)
+        first = next(segments)
+        segments.close()
+
+        self.assertEqual(first.index, 0)
+        self.assertTrue(source.closed)
+
+    @patch("sys2txt.pipeline.transcribe_file", return_value="hello")
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_exhausting_the_generator_closes_the_audio_source(self, mock_iter, _transcribe):
+        """Iterating to the end also releases the audio source."""
+        source = ClosableSegments(make_segments(2))
+        mock_iter.return_value = source
+
+        list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+        self.assertTrue(source.closed)
+
+
+class TestTranscribeOnce(unittest.TestCase):
+    """Tests for transcribe_once()."""
+
+    @patch("sys2txt.pipeline.transcribe_file", return_value="hello world")
+    @patch("sys2txt.pipeline.record_once")
+    def test_records_then_transcribes(self, mock_record, mock_transcribe):
+        config = TranscriptionConfig(model="tiny")
+
+        text = transcribe_once("test.monitor", config, 30)
+
+        self.assertEqual(text, "hello world")
+        record_args = mock_record.call_args
+        self.assertEqual(record_args[0][0], "test.monitor")
+        self.assertTrue(record_args[0][1].endswith("capture.wav"))
+        self.assertEqual(record_args[0][2], 30)
+        self.assertEqual(record_args[1], {"sample_rate": 16000, "channels": 1})
+        # The recording is transcribed from the same temporary file
+        self.assertEqual(mock_transcribe.call_args[0][0], record_args[0][1])
+
+    @patch("sys2txt.pipeline.transcribe_file", return_value="text")
+    @patch("sys2txt.pipeline.record_once")
+    def test_records_until_interrupted_by_default(self, mock_record, _transcribe):
+        transcribe_once("test.monitor", TranscriptionConfig())
+
+        self.assertIsNone(mock_record.call_args[0][2])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #62.

`sys2txt` shipped to PyPI with an empty `__init__.py`: installing it gave you a console script and nothing importable. The modules were CLI implementation details rather than a library with a CLI on top — most visibly `segment_and_transcribe_live()`, which spawned ffmpeg, polled for segments, scheduled transcription, **printed to stdout**, **appended to a file**, applied the silence policy and handled Ctrl-C.

## What changed

**`audio.py` goes back to producing audio.** `iter_audio_segments()` is a generator yielding `AudioSegment(index, path)`. Breaking out of the loop, closing the generator, or an exception all hit the `finally` that sends `q` to ffmpeg and removes the temp directory. Segment indices are tracked by a counter rather than recovered by parsing an ffmpeg-generated filename; a segment holding no audio is skipped but still consumes its index, so an index always maps to the same position on the timeline.

**New `pipeline.py`** combines recording and transcription without doing any I/O:

- `transcribe_live()` → `Iterator[TranscriptSegment(index, text, start, end)]`, transcribing each segment on a single-worker executor with the existing timeout. A segment that fails or times out is yielded with empty `text` and logged as a warning, so one bad segment never stops the stream (unchanged behaviour — #53 will give that case its own state).
- `transcribe_once()` wraps the record-to-temp-wav-then-transcribe dance that was inlined in `__main__.py`.

**`__main__.py` owns presentation and policy.** It formats, prints and appends each segment, and applies the silence timeout by `break`ing out of the loop. It also converts the argparse `Namespace` once into a frozen, validated `Options` dataclass; inconsistent flags now fail fast as usage errors (exit 2) instead of misbehaving later:

| Flags | Before | After |
| --- | --- | --- |
| `--input` naming a missing file | engine-specific error, or silence | `error: --input file not found: …` |
| `--duration 0`, `--segment-seconds 0` | accepted, then odd behaviour | usage error |
| `--silence-timeout 3 --segment-seconds 8` | accepted, could never fire | usage error |

**Public API.** `__init__.py` exports `AudioSegment`, `TranscriptSegment`, `TranscriptionConfig`, `get_default_monitor_source`, `iter_audio_segments`, `list_pulse_sources`, `record_once`, `transcribe_file`, `transcribe_live`, `transcribe_once` and `__version__`, and the package ships a `py.typed` marker (verified present in the built wheel). Engine imports stay lazy, so `import sys2txt` does not pull in faster-whisper or openai-whisper.

```python
from sys2txt import TranscriptionConfig, get_default_monitor_source, transcribe_live

config = TranscriptionConfig(model="small.en")
for segment in transcribe_live(get_default_monitor_source(), config, segment_seconds=8):
    print(f"[{segment.start:.0f}s] {segment.text}")
    if "goodbye" in segment.text.lower():
        break   # stops ffmpeg and cleans up
```

**Housekeeping.** `constants.py` collects the magic numbers that were scattered across modules (`64` bytes, `0.3`s poll, `max(segment_seconds * 5, 60)`, `3.0`s grace, `300`s whisper-cli timeout) plus the sample rate and channel count that were hardcoded at both call sites while being threaded down as parameters. `pulse.py`, `transcribe.py` and `utils.py` gained loggers, so no module prints any more except the CLI.

## Compatibility

`segment_and_transcribe_live()` is removed rather than deprecated: `__init__.py` was empty, so it was never part of a published API. `record_once()` keeps its name with `sample_rate`/`channels` demoted to keyword-only defaults. CLI flags, stdout, exit codes and Ctrl-C behaviour are unchanged apart from the new validation above.

## Verification

- `ruff format --check` and `ruff check` clean on `src/` and `tests/`.
- 117 unit tests pass (was 88): rewritten `test_audio.py`, new `test_pipeline.py` and `test_init.py`, reworked `test___main__.py` covering validation, the live consumption loop, the silence policy and Ctrl-C.
- End-to-end against a stub ffmpeg and a stub `whisper-cli`: `once` and `once --input` produce transcripts; `live --timestamps` prints and appends every segment; `--silence-timeout` stops after the expected number of silent segments; a real `SIGINT` exits 0 with the transcript saved, no stray ffmpeg process and no leftover `sys2txt_*` temp directory.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sg1NYoBzAnK7AB7i1mgXHL)_