### PR TITLE
fix: tell transcription failures apart from silence in live mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,8 @@ The codebase is organized into focused modules by functionality:
 - `iter_audio_segments()`: Generator. Spawns ffmpeg with the segment muxer, polls the temporary directory for finalized segments, and yields an `AudioSegment` for each. Indices are tracked by a counter (a segment holding no audio is skipped but still consumes its index). A consumer that breaks out of the loop or closes the generator triggers the `finally` that sends `q` to ffmpeg and removes the temporary directory. No transcription, no printing, no file writing.
 
 **pipeline.py** - Recording and transcription combined:
-- `TranscriptSegment`: Frozen dataclass of `(index, text, start, end)`
-- `transcribe_live()`: Generator over `iter_audio_segments()`, transcribing each segment on a single-worker `ThreadPoolExecutor` with a timeout. A segment that fails or times out is yielded with empty text and logged as a warning.
+- `TranscriptSegment`: Frozen dataclass of `(index, text, start, end, error)` with a `failed` property. `error` is `None` on success and holds the reason on failure, which is what distinguishes a failed segment from a silent one (both have empty `text`).
+- `transcribe_live()`: Generator over `iter_audio_segments()`, transcribing each segment on a single-worker `ThreadPoolExecutor` with a timeout. A segment that fails or times out is yielded with empty text and an `error`, and logged as a warning. A timed-out worker cannot be cancelled, so the pool is abandoned (`_new_executor()` builds a replacement) rather than letting the next segment queue behind it and time out too.
 - `transcribe_once()`: Records to a temporary WAV and returns its transcript
 
 **pulse.py** - PulseAudio/PipeWire integration:
@@ -100,7 +100,7 @@ The codebase is organized into focused modules by functionality:
 - `_parse_whisper_cpp_output()`: Parses whisper.cpp output format
 - All engines support timestamps flag for per-segment timing output
 
-**constants.py** - Configuration shared by library and CLI: default model, capture `SAMPLE_RATE`/`CHANNELS`, segment length and poll interval, minimum segment size, ffmpeg shutdown grace, transcription timeouts.
+**constants.py** - Configuration shared by library and CLI: default model, capture `SAMPLE_RATE`/`CHANNELS`, segment length and poll interval, minimum segment size, ffmpeg shutdown grace, transcription timeouts, `MAX_CONSECUTIVE_SEGMENT_FAILURES`.
 
 **utils.py** - Utility functions:
 - `which()`: Find command in PATH or raise RuntimeError
@@ -110,7 +110,7 @@ The codebase is organized into focused modules by functionality:
 **__main__.py** - CLI entry point, and the only module that prints:
 - argparse with subcommands: `once` and `live`, built by `_build_parser()`
 - `Options`: Frozen dataclass; `_build_options(args)` converts the argparse `Namespace` once and validates it (missing `--input` file, non-positive `--duration`/`--segment-seconds`, `--silence-timeout` shorter than a segment), raising `ValueError` that `main()` turns into a usage error (exit 2)
-- `_run_live()`: Consumes `transcribe_live()`, formatting, printing and appending each segment, and applying the silence-timeout policy by breaking out of the loop
+- `_run_live()`: Consumes `transcribe_live()`, formatting, printing and appending each segment, and applying the stop policies by breaking out of the loop. Silence is measured along the segment timeline (`segment.end` minus the start of the silent stretch), so skipped segments are accounted for. Failed segments never count as silence; `MAX_CONSECUTIVE_SEGMENT_FAILURES` of them in a row saves the transcript and raises `RuntimeError`, which `main()` turns into an error and exit 1
 
 ### Key Dependencies
 - **ffmpeg**: System command for audio recording (checked via shutil.which)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ sys2txt live --model small.en --segment-seconds 8
 - `--output <path>` - Write final transcript to a file (in live mode, appends)
 - `--duration <seconds>` - (once mode) Record fixed duration instead of waiting for Ctrl-C
 - `--segment-seconds <n>` - (live mode) Segment length in seconds (default: 8)
+- `--silence-timeout <seconds>` - (live mode) Stop automatically after N consecutive seconds of silence (0=disabled, default: 0). Segments that fail to transcribe do not count as silence
 - `--timestamps` - Print timestamps alongside text
 
 ## Examples
@@ -163,8 +164,10 @@ for segment in transcribe_live(get_default_monitor_source(), config, segment_sec
         break
 ```
 
-A segment whose transcription fails or times out is yielded with empty `text` and logged as a warning,
-so a failure never stops the stream.
+A segment whose transcription fails or times out is yielded with empty `text`, an `error` describing
+the failure (`segment.failed` is `True`) and a warning in the log, so a failure never stops the stream
+and is never mistaken for silence. A segment that times out does not hold up the ones after it: its
+worker is abandoned and the next segment is transcribed on a fresh one.
 
 To handle the audio yourself, `iter_audio_segments()` yields `AudioSegment(index, path)` values without
 transcribing them, and `transcribe_file(path, config)` transcribes any audio file. Nothing in the library

--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import Optional
 
 from . import __version__
-from .constants import DEFAULT_SEGMENT_SECONDS, WHISPER_MODEL
+from .constants import DEFAULT_SEGMENT_SECONDS, MAX_CONSECUTIVE_SEGMENT_FAILURES, WHISPER_MODEL
 from .pipeline import TranscriptSegment, transcribe_live, transcribe_once
 from .pulse import get_default_monitor_source, list_pulse_sources
 from .transcribe import TranscriptionConfig, transcribe_file
@@ -311,7 +311,9 @@ def _run_live(options: Options, source: str) -> None:
     logger.info("Press Ctrl-C once to stop live capture and save the transcript.")
 
     segments = transcribe_live(source, config, segment_seconds=options.segment_seconds)
-    silent_seconds = 0
+    silence_start: Optional[float] = None
+    failures = 0
+    failure: Optional[str] = None
     with open(output_file, "a", encoding="utf-8") as handle:
         try:
             with contextlib.closing(segments):
@@ -321,17 +323,37 @@ def _run_live(options: Options, source: str) -> None:
                     handle.write(line + "\n")
                     handle.flush()
 
+                    if segment.failed:
+                        # A failure says nothing about what the segment held, so it neither
+                        # counts as speech nor accumulates towards the silence timeout.
+                        failures += 1
+                        silence_start = None
+                        if failures >= MAX_CONSECUTIVE_SEGMENT_FAILURES:
+                            failure = (
+                                f"Transcription failed for {failures} consecutive segments ({segment.error}), stopping."
+                            )
+                            break
+                        continue
+
+                    failures = 0
                     if segment.text.strip():
-                        silent_seconds = 0
-                    else:
-                        silent_seconds += options.segment_seconds
+                        silence_start = None
+                        continue
+
+                    # Measure silence along the recording's timeline, since segments holding no
+                    # audio at all are skipped and the processed ones need not be contiguous.
+                    if silence_start is None:
+                        silence_start = segment.start
+                    silent_seconds = segment.end - silence_start
                     if 0 < options.silence_timeout <= silent_seconds:
-                        logger.info("No speech detected for %d seconds, stopping automatically.", silent_seconds)
+                        logger.info("No speech detected for %.0f seconds, stopping automatically.", silent_seconds)
                         break
         except KeyboardInterrupt:
             logger.info("Stopping live capture...")
 
     logger.info("Transcript saved to: %s", output_file)
+    if failure:
+        raise RuntimeError(failure)
 
 
 def _run(options: Options) -> None:

--- a/src/sys2txt/constants.py
+++ b/src/sys2txt/constants.py
@@ -31,3 +31,6 @@ MIN_TRANSCRIBE_TIMEOUT = 60
 
 WHISPER_CPP_TIMEOUT = 300
 "Seconds to wait for whisper-cli before assuming a GPU hang or malformed audio"
+
+MAX_CONSECUTIVE_SEGMENT_FAILURES = 3
+"Consecutive live-mode transcription failures tolerated before giving up"

--- a/src/sys2txt/pipeline.py
+++ b/src/sys2txt/pipeline.py
@@ -28,20 +28,33 @@ class TranscriptSegment:
 
     Attributes:
         index: Position of the segment in the recording, counting from 0
-        text: Transcribed text, empty when the segment held no speech or transcription failed
+        text: Transcribed text, empty when the segment held no speech or when ``error`` is set
         start: Start of the segment in seconds from the beginning of the recording
         end: End of the segment in seconds from the beginning of the recording
+        error: Why transcription failed, or None when it succeeded. Silence and failure both
+            leave ``text`` empty, so this is what tells them apart.
     """
 
     index: int
     text: str
     start: float
     end: float
+    error: Optional[str] = None
+
+    @property
+    def failed(self) -> bool:
+        """Whether transcription of this segment failed rather than finding no speech."""
+        return self.error is not None
 
 
 def _segment_timeout(segment_seconds: int) -> float:
     """Allow generous time to transcribe a segment while preventing indefinite hangs."""
     return max(segment_seconds * TRANSCRIBE_TIMEOUT_FACTOR, MIN_TRANSCRIBE_TIMEOUT)
+
+
+def _new_executor() -> ThreadPoolExecutor:
+    """Create the single-worker pool that transcribes one segment at a time."""
+    return ThreadPoolExecutor(max_workers=1)
 
 
 def transcribe_live(
@@ -67,29 +80,38 @@ def transcribe_live(
 
     Yields:
         TranscriptSegment values in chronological order. A segment whose transcription times
-        out or fails is yielded with empty text and logged as a warning.
+        out or fails is yielded with empty text, an ``error`` describing the failure, and a
+        warning in the log.
     """
     timeout = _segment_timeout(segment_seconds)
     segments = iter_audio_segments(source, segment_seconds, sample_rate=sample_rate, channels=channels)
-    executor = ThreadPoolExecutor(max_workers=1)
+    executor = _new_executor()
     try:
         with contextlib.closing(segments):
             for segment in segments:
                 future = executor.submit(transcribe_file, segment.path, config)
+                error = None
+                text = ""
                 try:
                     text = future.result(timeout=timeout)
                 except FuturesTimeoutError:
                     logger.warning("Segment %d transcription timed out, skipping", segment.index)
-                    text = ""
+                    error = f"transcription timed out after {timeout:.0f}s"
+                    # The worker cannot be cancelled and keeps running, so the next segment
+                    # would queue behind it and time out without ever being transcribed.
+                    # Abandon the pool and give the next segment a worker of its own.
+                    executor.shutdown(wait=False)
+                    executor = _new_executor()
                 except Exception as e:
                     logger.warning("Segment %d transcription failed: %s", segment.index, e)
-                    text = ""
+                    error = f"transcription failed: {e}"
                 start = segment.index * segment_seconds
                 yield TranscriptSegment(
                     index=segment.index,
                     text=text,
                     start=float(start),
                     end=float(start + segment_seconds),
+                    error=error,
                 )
     finally:
         executor.shutdown(wait=False)

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -42,11 +42,30 @@ def make_args(**overrides):
     return Namespace(**values)
 
 
-def live_segments(*texts, segment_seconds=8):
-    """Yield TranscriptSegment values the way transcribe_live does."""
-    for index, text in enumerate(texts):
+class Failure:
+    """Marker for live_segments(): emit a failed segment instead of transcribed text."""
+
+    def __init__(self, reason="transcription timed out after 60s"):
+        self.reason = reason
+
+
+def live_segments(*items, segment_seconds=8, indices=None):
+    """Yield TranscriptSegment values the way transcribe_live does.
+
+    Each item is either transcript text or a Failure marker. Pass indices to place the
+    segments on the timeline non-contiguously, as happens when empty segments are skipped.
+    """
+    for position, item in enumerate(items):
+        index = indices[position] if indices else position
         start = index * segment_seconds
-        yield TranscriptSegment(index=index, text=text, start=float(start), end=float(start + segment_seconds))
+        failed = isinstance(item, Failure)
+        yield TranscriptSegment(
+            index=index,
+            text="" if failed else item,
+            start=float(start),
+            end=float(start + segment_seconds),
+            error=item.reason if failed else None,
+        )
 
 
 class TestResolveOutputPath(unittest.TestCase):
@@ -413,8 +432,15 @@ class TestModeDispatchOnce(unittest.TestCase):
 class TestModeDispatchLive(unittest.TestCase):
     """Tests for live mode consumption of the transcript stream."""
 
+    def setUp(self):
+        self.exit_code = 0
+
     def _run_live(self, argv, segments):
-        """Run the CLI in live mode against a canned segment stream, returning the transcript file."""
+        """Run the CLI in live mode against a canned segment stream, returning the transcript file.
+
+        A non-zero exit is recorded in self.exit_code rather than raised, so the transcript
+        written before the CLI gave up can still be inspected.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             output_file = os.path.join(tmp, "out.txt")
             with (
@@ -425,7 +451,10 @@ class TestModeDispatchLive(unittest.TestCase):
                 patch("builtins.print") as mock_print,
                 patch("sys.argv", argv),
             ):
-                main()
+                try:
+                    main()
+                except SystemExit as e:
+                    self.exit_code = e.code
             with open(output_file, encoding="utf-8") as f:
                 written = f.read()
         return mock_live, mock_print, written
@@ -472,6 +501,53 @@ class TestModeDispatchLive(unittest.TestCase):
         )
         self.assertEqual(mock_print.call_count, 3)
         self.assertEqual(written, "\n\n\n")
+
+    def test_silence_measured_across_gaps_in_the_timeline(self):
+        """Silence is measured on the recording's timeline, not by counting segments."""
+        # One silent segment at 0-8s, the next at 24-32s: 32s of quiet in two segments
+        segments = live_segments("", "", "should never be reached", indices=[0, 3, 4])
+        _, mock_print, _ = self._run_live(
+            ["sys2txt", "live", "--silence-timeout", "24"],
+            segments,
+        )
+        self.assertEqual(mock_print.call_count, 2)
+        self.assertEqual(self.exit_code, 0)
+
+    def test_failures_do_not_count_as_silence(self):
+        """Transcription failures never accumulate towards the silence timeout."""
+        segments = live_segments(Failure(), "", Failure(), "", Failure(), "hello")
+        _, mock_print, written = self._run_live(
+            ["sys2txt", "live", "--silence-timeout", "16"],
+            segments,
+        )
+        self.assertEqual(mock_print.call_count, 6)
+        self.assertEqual(written, "\n\n\n\n\n" + "hello\n")
+        self.assertEqual(self.exit_code, 0)
+
+    def test_repeated_failures_stop_with_an_error(self):
+        """A persistent failure is reported as a failure, not as silence."""
+        segments = live_segments(Failure(), Failure(), Failure(), "should never be reached")
+        with self.assertLogs("sys2txt.__main__", level="ERROR") as logs:
+            _, mock_print, written = self._run_live(
+                ["sys2txt", "live", "--silence-timeout", "16"],
+                segments,
+            )
+
+        self.assertEqual(self.exit_code, 1)
+        self.assertEqual(mock_print.call_count, 3)
+        self.assertIn("3 consecutive segments", logs.output[0])
+        self.assertIn("timed out", logs.output[0])
+        # The transcript produced before giving up is still saved
+        self.assertEqual(written, "\n\n\n")
+
+    def test_recovered_failures_do_not_stop_the_run(self):
+        """The failure counter only fires on consecutive failures."""
+        segments = live_segments(Failure(), Failure(), "hello", Failure(), Failure())
+        _, mock_print, written = self._run_live(["sys2txt", "live"], segments)
+
+        self.assertEqual(mock_print.call_count, 5)
+        self.assertEqual(written, "\n\nhello\n\n\n")
+        self.assertEqual(self.exit_code, 0)
 
     def test_keyboard_interrupt_saves_what_was_transcribed(self):
         def segments():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -59,6 +59,17 @@ class TestTranscribeLive(unittest.TestCase):
         mock_iter.assert_called_once_with("test.monitor", 8, sample_rate=16000, channels=1)
         self.assertEqual(mock_transcribe.call_args_list[0][0], ("/tmp/seg_00000.wav", self.config))
 
+    @patch("sys2txt.pipeline.transcribe_file", return_value="hello")
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_transcribed_segment_carries_no_error(self, mock_iter, _transcribe):
+        """A segment that transcribes cleanly is not marked as failed."""
+        mock_iter.return_value = make_segments(1)
+
+        segment = next(iter(transcribe_live("test.monitor", self.config, segment_seconds=8)))
+
+        self.assertIsNone(segment.error)
+        self.assertFalse(segment.failed)
+
     @patch("sys2txt.pipeline.transcribe_file")
     @patch("sys2txt.pipeline.iter_audio_segments")
     def test_failed_segment_yields_empty_text(self, mock_iter, mock_transcribe):
@@ -71,6 +82,23 @@ class TestTranscribeLive(unittest.TestCase):
 
         self.assertEqual([s.text for s in segments], ["", "recovered"])
         self.assertIn("engine exploded", logs.output[0])
+
+    @patch("sys2txt.pipeline.transcribe_file")
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_failed_segment_reports_why_it_failed(self, mock_iter, mock_transcribe):
+        """A failure is distinguishable from silence by the error it carries."""
+        mock_iter.return_value = make_segments(2)
+        mock_transcribe.side_effect = [RuntimeError("engine exploded"), ""]
+
+        with self.assertLogs("sys2txt.pipeline", level="WARNING"):
+            failed, silent = list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+        self.assertTrue(failed.failed)
+        self.assertIn("engine exploded", failed.error)
+        # A silent segment looks the same in text alone, which is the bug this guards against
+        self.assertEqual(silent.text, failed.text)
+        self.assertFalse(silent.failed)
+        self.assertIsNone(silent.error)
 
     @patch("sys2txt.pipeline.ThreadPoolExecutor")
     @patch("sys2txt.pipeline.iter_audio_segments")
@@ -86,9 +114,33 @@ class TestTranscribeLive(unittest.TestCase):
             segments = list(transcribe_live("test.monitor", self.config, segment_seconds=8))
 
         self.assertEqual([s.text for s in segments], [""])
+        self.assertTrue(segments[0].failed)
+        self.assertIn("timed out after 60s", segments[0].error)
         self.assertIn("timed out", logs.output[0])
         future.result.assert_called_once_with(timeout=60)
-        executor.shutdown.assert_called_once_with(wait=False)
+        executor.shutdown.assert_called_with(wait=False)
+
+    @patch("sys2txt.pipeline.ThreadPoolExecutor")
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_timeout_abandons_the_pool_so_the_next_segment_is_transcribed(self, mock_iter, mock_executor_cls):
+        """The stranded worker is left behind rather than queueing the next segment behind it."""
+        mock_iter.return_value = make_segments(2)
+        stuck, recovered = MagicMock(), MagicMock()
+        stuck.result.side_effect = FuturesTimeoutError()
+        recovered.result.return_value = "recovered"
+        first, second = MagicMock(), MagicMock()
+        first.submit.return_value = stuck
+        second.submit.return_value = recovered
+        mock_executor_cls.side_effect = [first, second]
+
+        with self.assertLogs("sys2txt.pipeline", level="WARNING"):
+            segments = list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+        self.assertEqual([s.text for s in segments], ["", "recovered"])
+        self.assertEqual(mock_executor_cls.call_count, 2)
+        first.shutdown.assert_called_once_with(wait=False)
+        second.submit.assert_called_once()
+        second.shutdown.assert_called_once_with(wait=False)
 
     @patch("sys2txt.pipeline.transcribe_file", return_value="hello")
     @patch("sys2txt.pipeline.iter_audio_segments")


### PR DESCRIPTION
A failed transcription and a silent segment were both an empty string, so
--silence-timeout counted failures as quiet and ended the session reporting
"No speech detected". A single slow segment made that far worse: the
single-worker pool could not cancel a timed-out worker, so every later
segment queued behind it and timed out without ever being transcribed.

- TranscriptSegment carries an `error` (and a `failed` property); text is
  still empty on failure, but the reason now travels with the segment.
- transcribe_live() abandons the pool after a timeout and transcribes the
  next segment on a fresh one, so one slow segment no longer cascades.
- _run_live() no longer counts failures towards the silence timeout, and
  measures silence along the segment timeline rather than assuming every
  processed segment is segment_seconds long, which is untrue once empty
  segments are skipped.
- MAX_CONSECUTIVE_SEGMENT_FAILURES failures in a row save the transcript
  and exit 1 with an error, so a persistent failure is reported as one.

Fixes #53

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016a3n3Fwahfn6KC3Sdmf78y