### PR TITLE
feat: add SRT, WebVTT, JSON and TSV transcript output formats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Common flags:
 - `--engine {auto,faster,whisper,cpp}`: Force specific engine (default: auto)
 - `--device {auto,cpu,vulkan,gpu,cuda}`: Device for transcription (default: auto)
 - `--language <code>`: Force language code (e.g., en)
+- `--format {txt,srt,vtt,json,tsv}`: Transcript output format (default: txt)
 - `--output <path>`: Write transcript to file
 - `--duration <seconds>`: (once mode) Fixed recording duration
 - `--segment-seconds <n>`: (live mode) Segment length (default: 8)
@@ -79,10 +80,20 @@ The codebase is organized into focused modules by functionality:
 - `record_once()`: Spawns ffmpeg subprocess to record from PulseAudio/PipeWire source to WAV file. `sample_rate`/`channels` are keyword-only and default to the constants.
 - `iter_audio_segments()`: Generator. Spawns ffmpeg with the segment muxer, polls the temporary directory for finalized segments, and yields an `AudioSegment` for each. Indices are tracked by a counter (a segment holding no audio is skipped but still consumes its index). A consumer that breaks out of the loop or closes the generator triggers the `finally` that sends `q` to ffmpeg and removes the temporary directory. No transcription, no printing, no file writing.
 
+**formats.py** - Transcript data types and output formats:
+- `Cue`: Frozen dataclass of `(start, end, text)`; one timed span of speech, in seconds from the start of the recording. `shifted(offset)` moves it along the timeline
+- `Transcript`: Frozen dataclass of `(cues, language)` with a `text` property that flattens the cues
+- `OUTPUT_FORMATS` / `FORMAT_EXTENSIONS` / `TIMED_FORMATS`: the supported formats and their file extensions
+- `format_timestamp(seconds, decimal_separator=".")`: `HH:MM:SS.mmm`, with `","` for SubRip
+- `render_transcript(cues, output_format, timestamps=False, language=None)`: renders a whole document; used by once mode
+- `get_formatter(output_format, ...)`: returns a `TranscriptFormatter` with `header()`/`cue()`/`footer()` for incremental rendering; used by live mode. `render_transcript` is built on it so the two paths cannot drift. The JSON formatter buffers and emits the whole document from `footer()`
+- Pure formatting: no engine imports, no printing, no file writing
+
 **pipeline.py** - Recording and transcription combined:
-- `TranscriptSegment`: Frozen dataclass of `(index, text, start, end)`
+- `TranscriptSegment`: Frozen dataclass of `(index, text, start, end, cues)`. `start`/`end` are the segment's fixed window on the recording clock; `cues` are the engine's own per-utterance spans, rebased onto that timeline by adding the segment's start
 - `transcribe_live()`: Generator over `iter_audio_segments()`, transcribing each segment on a single-worker `ThreadPoolExecutor` with a timeout. A segment that fails or times out is yielded with empty text and logged as a warning.
-- `transcribe_once()`: Records to a temporary WAV and returns its transcript
+- `transcribe_once()`: Records to a temporary WAV and returns its transcript as text
+- `transcribe_once_cues()`: The structured form of `transcribe_once()`, returning a `Transcript`
 
 **pulse.py** - PulseAudio/PipeWire integration:
 - `list_pulse_sources()`: Uses `pactl list short sources` to enumerate audio sources
@@ -91,26 +102,28 @@ The codebase is organized into focused modules by functionality:
 
 **transcribe.py** - Whisper transcription:
 - `TranscriptionConfig`: Dataclass bundling engine, model, device, language, timestamps, model_path, and whisper_cpp_path
-- `transcribe_file(path, config)`: Main entry point, takes a file path and `TranscriptionConfig`, dispatches to appropriate engine
+- `transcribe_file_cues(path, config)`: Main entry point. Resolves the engine and returns a `Transcript` of timed `Cue` values
+- `transcribe_file(path, config)`: The text form, `render_transcript(..., "txt", timestamps=config.timestamps)` over the above. Output is unchanged from before formats existed
 - `_transcribe_faster_whisper()`: Uses faster_whisper.WhisperModel with VAD filter
 - `_transcribe_openai_whisper()`: Uses whisper.load_model() and model.transcribe()
 - `_transcribe_whisper_cpp()`: Runs whisper-cli subprocess with GPU/CPU support
 - `_resolve_whisper_cpp_binary()`: Resolves whisper-cli path from arg/env/PATH
 - `_resolve_whisper_cpp_model_path()`: Resolves model path from arg/env/default
-- `_parse_whisper_cpp_output()`: Parses whisper.cpp output format
-- All engines support timestamps flag for per-segment timing output
+- `_parse_whisper_cpp_output()`: Parses whisper.cpp's `[HH:MM:SS.mmm --> HH:MM:SS.mmm]` lines into cues
+- Every engine returns a `Transcript`, keeping real per-utterance times; `config.timestamps` only affects plain-text rendering, which happens in `formats.py`
 
-**constants.py** - Configuration shared by library and CLI: default model, capture `SAMPLE_RATE`/`CHANNELS`, segment length and poll interval, minimum segment size, ffmpeg shutdown grace, transcription timeouts.
+**constants.py** - Configuration shared by library and CLI: default model, capture `SAMPLE_RATE`/`CHANNELS`, segment length and poll interval, minimum segment size, ffmpeg shutdown grace, transcription timeouts, default output format.
 
 **utils.py** - Utility functions:
 - `which()`: Find command in PATH or raise RuntimeError
 
-**__init__.py** - The public API. Exports `AudioSegment`, `TranscriptSegment`, `TranscriptionConfig`, `get_default_monitor_source`, `iter_audio_segments`, `list_pulse_sources`, `record_once`, `transcribe_file`, `transcribe_live`, `transcribe_once` and `__version__`. Engine imports stay lazy so importing the package is cheap.
+**__init__.py** - The public API. Exports `AudioSegment`, `Cue`, `OUTPUT_FORMATS`, `Transcript`, `TranscriptSegment`, `TranscriptionConfig`, `get_default_monitor_source`, `iter_audio_segments`, `list_pulse_sources`, `record_once`, `render_transcript`, `transcribe_file`, `transcribe_file_cues`, `transcribe_live`, `transcribe_once`, `transcribe_once_cues` and `__version__`. Engine imports stay lazy so importing the package is cheap.
 
 **__main__.py** - CLI entry point, and the only module that prints:
 - argparse with subcommands: `once` and `live`, built by `_build_parser()`
 - `Options`: Frozen dataclass; `_build_options(args)` converts the argparse `Namespace` once and validates it (missing `--input` file, non-positive `--duration`/`--segment-seconds`, `--silence-timeout` shorter than a segment), raising `ValueError` that `main()` turns into a usage error (exit 2)
-- `_run_live()`: Consumes `transcribe_live()`, formatting, printing and appending each segment, and applying the silence-timeout policy by breaking out of the loop
+- `_run_once()`: Transcribes to cues, renders them in `--format`, and prints and writes the document
+- `_run_live()`: Consumes `transcribe_live()`, applying the silence-timeout policy by breaking out of the loop. Plain text keeps its per-segment line format and appends to the output file; the timed formats stream a document through `get_formatter()`, opening the file for writing and emitting the footer after the loop so Ctrl-C and the silence timeout both close it
 
 ### Key Dependencies
 - **ffmpeg**: System command for audio recording (checked via shutil.which)
@@ -209,6 +222,7 @@ ruff check --fix src/
 ## File Structure
 - `src/sys2txt/__main__.py`: CLI entry point: parsing, validation, printing, output files, stop policy
 - `src/sys2txt/audio.py`: Audio recording with ffmpeg
+- `src/sys2txt/formats.py`: Transcript cues and the txt/srt/vtt/json/tsv renderers
 - `src/sys2txt/pipeline.py`: Recording and transcription combined (`transcribe_live`, `transcribe_once`)
 - `src/sys2txt/transcribe.py`: Whisper transcription engines
 - `src/sys2txt/pulse.py`: PulseAudio/PipeWire source management
@@ -221,6 +235,7 @@ ruff check --fix src/
   - `tests/test_pulse.py`: Tests for PulseAudio integration
   - `tests/test_transcribe.py`: Tests for transcription engines
   - `tests/test_audio.py`: Tests for audio recording
+  - `tests/test_formats.py`: Tests for the transcript output formats
   - `tests/test_pipeline.py`: Tests for the recording/transcription pipeline
   - `tests/test___main__.py`: Tests for the CLI
   - `tests/test_init.py`: Tests for the public API surface

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,8 @@ The codebase is organized into focused modules by functionality:
 - Pure formatting: no engine imports, no printing, no file writing
 
 **pipeline.py** - Recording and transcription combined:
-- `TranscriptSegment`: Frozen dataclass of `(index, text, start, end, cues)`. `start`/`end` are the segment's fixed window on the recording clock; `cues` are the engine's own per-utterance spans, rebased onto that timeline by adding the segment's start
-- `transcribe_live()`: Generator over `iter_audio_segments()`, transcribing each segment on a single-worker `ThreadPoolExecutor` with a timeout. A segment that fails or times out is yielded with empty text and logged as a warning.
+- `TranscriptSegment`: Frozen dataclass of `(index, text, start, end, cues, error)` with a `failed` property. `start`/`end` are the segment's fixed window on the recording clock; `cues` are the engine's own per-utterance spans, rebased onto that timeline by adding the segment's start. `error` is `None` on success and holds the reason on failure, which is what distinguishes a failed segment from a silent one (both have empty `text`).
+- `transcribe_live()`: Generator over `iter_audio_segments()`, transcribing each segment on a single-worker `ThreadPoolExecutor` with a timeout. A segment that fails or times out is yielded with empty text and an `error`, and logged as a warning. A timed-out worker cannot be cancelled, so the pool is abandoned (`_new_executor()` builds a replacement) rather than letting the next segment queue behind it and time out too.
 - `transcribe_once()`: Records to a temporary WAV and returns its transcript as text
 - `transcribe_once_cues()`: The structured form of `transcribe_once()`, returning a `Transcript`
 
@@ -112,7 +112,7 @@ The codebase is organized into focused modules by functionality:
 - `_parse_whisper_cpp_output()`: Parses whisper.cpp's `[HH:MM:SS.mmm --> HH:MM:SS.mmm]` lines into cues
 - Every engine returns a `Transcript`, keeping real per-utterance times; `config.timestamps` only affects plain-text rendering, which happens in `formats.py`
 
-**constants.py** - Configuration shared by library and CLI: default model, capture `SAMPLE_RATE`/`CHANNELS`, segment length and poll interval, minimum segment size, ffmpeg shutdown grace, transcription timeouts, default output format.
+**constants.py** - Configuration shared by library and CLI: default model, capture `SAMPLE_RATE`/`CHANNELS`, segment length and poll interval, minimum segment size, ffmpeg shutdown grace, transcription timeouts, `MAX_CONSECUTIVE_SEGMENT_FAILURES`, default output format.
 
 **utils.py** - Utility functions:
 - `which()`: Find command in PATH or raise RuntimeError
@@ -123,7 +123,7 @@ The codebase is organized into focused modules by functionality:
 - argparse with subcommands: `once` and `live`, built by `_build_parser()`
 - `Options`: Frozen dataclass; `_build_options(args)` converts the argparse `Namespace` once and validates it (missing `--input` file, non-positive `--duration`/`--segment-seconds`, `--silence-timeout` shorter than a segment), raising `ValueError` that `main()` turns into a usage error (exit 2)
 - `_run_once()`: Transcribes to cues, renders them in `--format`, and prints and writes the document
-- `_run_live()`: Consumes `transcribe_live()`, applying the silence-timeout policy by breaking out of the loop. Plain text keeps its per-segment line format and appends to the output file; the timed formats stream a document through `get_formatter()`, opening the file for writing and emitting the footer after the loop so Ctrl-C and the silence timeout both close it
+- `_run_live()`: Consumes `transcribe_live()`, formatting and printing each segment, and applying the stop policies by breaking out of the loop. Plain text keeps its per-segment line format and appends to the output file; the timed formats stream a document through `get_formatter()`, opening the file for writing and emitting the footer after the loop so Ctrl-C and the silence timeout both close it. Silence is measured along the segment timeline (`segment.end` minus the start of the silent stretch), so skipped segments are accounted for. Failed segments never count as silence; `MAX_CONSECUTIVE_SEGMENT_FAILURES` of them in a row save the transcript and raise `RuntimeError`, which `main()` turns into an error and exit 1
 
 ### Key Dependencies
 - **ffmpeg**: System command for audio recording (checked via shutil.which)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ sys2txt live --model small.en --segment-seconds 8
   replace it, since a subtitle or JSON document cannot resume mid-file
 - `--duration <seconds>` - (once mode) Record fixed duration instead of waiting for Ctrl-C
 - `--segment-seconds <n>` - (live mode) Segment length in seconds (default: 8)
+- `--silence-timeout <seconds>` - (live mode) Stop automatically after N consecutive seconds of silence (0=disabled, default: 0). Segments that fail to transcribe do not count as silence
 - `--timestamps` - Print timestamps alongside text (plain text only; the timed formats always carry
   their own)
 
@@ -201,8 +202,10 @@ for segment in transcribe_live(get_default_monitor_source(), config, segment_sec
         break
 ```
 
-A segment whose transcription fails or times out is yielded with empty `text` and logged as a warning,
-so a failure never stops the stream.
+A segment whose transcription fails or times out is yielded with empty `text`, an `error` describing
+the failure (`segment.failed` is `True`) and a warning in the log, so a failure never stops the stream
+and is never mistaken for silence. A segment that times out does not hold up the ones after it: its
+worker is abandoned and the next segment is transcribed on a fresh one.
 
 To handle the audio yourself, `iter_audio_segments()` yields `AudioSegment(index, path)` values without
 transcribing them, and `transcribe_file(path, config)` transcribes any audio file. Nothing in the library

--- a/README.md
+++ b/README.md
@@ -78,10 +78,29 @@ sys2txt live --model small.en --segment-seconds 8
 - `--engine <auto|faster|whisper|cpp>` - Force a specific engine (default: auto)
 - `--device <auto|cpu|vulkan|gpu|cuda>` - Device for transcription (default: auto)
 - `--language <code>` - Force language code (e.g., en). Omit to auto-detect
-- `--output <path>` - Write final transcript to a file (in live mode, appends)
+- `--format <txt|srt|vtt|json|tsv>` - Transcript format (default: txt). See [Output formats](#output-formats)
+- `--output <path>` - Write the transcript to a file. Without it, one is written to
+  `./output/<timestamp>.<ext>`. In live mode `txt` appends to an existing file; the timed formats
+  replace it, since a subtitle or JSON document cannot resume mid-file
 - `--duration <seconds>` - (once mode) Record fixed duration instead of waiting for Ctrl-C
 - `--segment-seconds <n>` - (live mode) Segment length in seconds (default: 8)
-- `--timestamps` - Print timestamps alongside text
+- `--timestamps` - Print timestamps alongside text (plain text only; the timed formats always carry
+  their own)
+
+### Output formats
+
+`--format` picks how the transcript is written, and applies to stdout and the output file alike.
+
+| Format | Extension | What it is |
+| --- | --- | --- |
+| `txt` | `.txt` | Plain text, the default. One line per segment in live mode |
+| `srt` | `.srt` | [SubRip](https://en.wikipedia.org/wiki/SubRip) subtitles, understood by essentially every video player |
+| `vtt` | `.vtt` | [WebVTT](https://www.w3.org/TR/webvtt1/), the W3C standard, loadable by a browser `<track>` element |
+| `json` | `.json` | openai-whisper's JSON schema (`text`, `segments`, `language`), for programmatic use |
+| `tsv` | `.tsv` | Tab-separated `start`/`end` milliseconds and text |
+
+The timed formats carry the engine's own per-utterance timings. In live mode those are rebased onto
+the timeline of the whole recording, so cue times keep increasing across segments.
 
 ## Examples
 
@@ -101,6 +120,25 @@ Live mode with shorter latency and timestamps:
 
 ```bash
 sys2txt live --segment-seconds 5 --timestamps
+```
+
+Produce subtitles for a recording, ready to drop next to a video:
+
+```bash
+sys2txt once --input talk.wav --format srt --output talk.srt
+sys2txt once --input talk.wav --format vtt --output talk.vtt
+```
+
+Capture a meeting live as WebVTT, stopping after 30 seconds of silence:
+
+```bash
+sys2txt live --format vtt --silence-timeout 30 --output meeting.vtt
+```
+
+Get machine-readable output with per-segment timings:
+
+```bash
+sys2txt once --input talk.wav --format json --output talk.json
 ```
 
 Force the reference openai-whisper engine:
@@ -171,9 +209,25 @@ transcribing them, and `transcribe_file(path, config)` transcribes any audio fil
 prints or writes files, and every module logs through the standard `logging` module under the `sys2txt`
 logger.
 
-The full public API is `AudioSegment`, `TranscriptSegment`, `TranscriptionConfig`,
-`get_default_monitor_source`, `iter_audio_segments`, `list_pulse_sources`, `record_once`,
-`transcribe_file`, `transcribe_live` and `transcribe_once`. The package ships type hints (`py.typed`).
+For timed output, use the `_cues` variants and render them yourself. They return a `Transcript` of
+`Cue(start, end, text)` values plus the detected language, which `render_transcript()` turns into any
+of the output formats:
+
+```python
+from sys2txt import TranscriptionConfig, render_transcript, transcribe_file_cues
+
+transcript = transcribe_file_cues("talk.wav", TranscriptionConfig(model="small.en"))
+with open("talk.srt", "w", encoding="utf-8") as f:
+    f.write(render_transcript(transcript.cues, "srt"))
+```
+
+In live mode the same cues are on each `TranscriptSegment` as `segment.cues`, already rebased onto the
+timeline of the recording.
+
+The full public API is `AudioSegment`, `Cue`, `OUTPUT_FORMATS`, `Transcript`, `TranscriptSegment`,
+`TranscriptionConfig`, `get_default_monitor_source`, `iter_audio_segments`, `list_pulse_sources`,
+`record_once`, `render_transcript`, `transcribe_file`, `transcribe_file_cues`, `transcribe_live`,
+`transcribe_once` and `transcribe_once_cues`. The package ships type hints (`py.typed`).
 
 ## Whisper.cpp with Vulkan GPU
 

--- a/src/sys2txt/__init__.py
+++ b/src/sys2txt/__init__.py
@@ -3,7 +3,8 @@
 The public API is small: enumerate sources with :func:`list_pulse_sources` or
 :func:`get_default_monitor_source`, then either transcribe a single recording with
 :func:`transcribe_once` or consume a live recording segment by segment with
-:func:`transcribe_live`.
+:func:`transcribe_live`. Either can be rendered as plain text, SubRip, WebVTT, JSON or
+TSV with :func:`render_transcript`.
 
     from sys2txt import TranscriptionConfig, get_default_monitor_source, transcribe_live
 
@@ -15,9 +16,10 @@ The public API is small: enumerate sources with :func:`list_pulse_sources` or
 from importlib.metadata import PackageNotFoundError, version
 
 from .audio import AudioSegment, iter_audio_segments, record_once
-from .pipeline import TranscriptSegment, transcribe_live, transcribe_once
+from .formats import OUTPUT_FORMATS, Cue, Transcript, render_transcript
+from .pipeline import TranscriptSegment, transcribe_live, transcribe_once, transcribe_once_cues
 from .pulse import get_default_monitor_source, list_pulse_sources
-from .transcribe import TranscriptionConfig, transcribe_file
+from .transcribe import TranscriptionConfig, transcribe_file, transcribe_file_cues
 
 try:
     __version__ = version("sys2txt")
@@ -26,6 +28,9 @@ except PackageNotFoundError:  # running from a source tree without an installed 
 
 __all__ = [
     "AudioSegment",
+    "Cue",
+    "OUTPUT_FORMATS",
+    "Transcript",
     "TranscriptSegment",
     "TranscriptionConfig",
     "__version__",
@@ -33,7 +38,10 @@ __all__ = [
     "iter_audio_segments",
     "list_pulse_sources",
     "record_once",
+    "render_transcript",
     "transcribe_file",
+    "transcribe_file_cues",
     "transcribe_live",
     "transcribe_once",
+    "transcribe_once_cues",
 ]

--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -8,13 +8,14 @@ import os
 import sys
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from typing import Optional, TextIO
 
 from . import __version__
-from .constants import DEFAULT_SEGMENT_SECONDS, WHISPER_MODEL
-from .pipeline import TranscriptSegment, transcribe_live, transcribe_once
+from .constants import DEFAULT_OUTPUT_FORMAT, DEFAULT_SEGMENT_SECONDS, WHISPER_MODEL
+from .formats import FORMAT_EXTENSIONS, OUTPUT_FORMATS, TIMED_FORMATS, get_formatter, render_transcript
+from .pipeline import TranscriptSegment, transcribe_live, transcribe_once_cues
 from .pulse import get_default_monitor_source, list_pulse_sources
-from .transcribe import TranscriptionConfig, transcribe_file
+from .transcribe import TranscriptionConfig, transcribe_file_cues
 
 logger = logging.getLogger(__name__)
 
@@ -38,15 +39,19 @@ class Options:
     input_path: Optional[str] = None
     segment_seconds: int = DEFAULT_SEGMENT_SECONDS
     silence_timeout: int = 0
+    output_format: str = DEFAULT_OUTPUT_FORMAT
 
 
-def get_timestamp_filename() -> str:
+def get_timestamp_filename(extension: str = ".txt") -> str:
     """Generate a timestamp-based filename for output files.
 
+    Args:
+        extension: File extension to append, including the leading dot
+
     Returns:
-        A filename string in the format: YYYY-MM-DD_HH-MM-SS.txt
+        A filename string in the format: YYYY-MM-DD_HH-MM-SS<extension>
     """
-    return datetime.now().strftime("%Y-%m-%d_%H-%M-%S.txt")
+    return datetime.now().strftime("%Y-%m-%d_%H-%M-%S") + extension
 
 
 def ensure_output_dir() -> str:
@@ -60,10 +65,16 @@ def ensure_output_dir() -> str:
     return output_dir
 
 
-def _resolve_output_path(output_arg: Optional[str]) -> str:
-    """Return the output file path, generating a timestamped name if none given."""
+def _resolve_output_path(output_arg: Optional[str], output_format: str = DEFAULT_OUTPUT_FORMAT) -> str:
+    """Return the output file path, generating a timestamped name if none given.
+
+    A generated name takes the extension of the output format; an explicit path is used
+    as given, on the assumption the caller named it deliberately.
+    """
     output_dir = ensure_output_dir()
-    return output_arg if output_arg else os.path.join(output_dir, get_timestamp_filename())
+    if output_arg:
+        return output_arg
+    return os.path.join(output_dir, get_timestamp_filename(FORMAT_EXTENSIONS[output_format]))
 
 
 def _build_options(args: argparse.Namespace) -> Options:
@@ -91,6 +102,10 @@ def _build_options(args: argparse.Namespace) -> Options:
             f"({segment_seconds}s), since silence is only measured a whole segment at a time"
         )
 
+    output_format = getattr(args, "output_format", DEFAULT_OUTPUT_FORMAT)
+    if args.timestamps and output_format in TIMED_FORMATS:
+        logger.warning("--timestamps has no effect with --format %s, which always carries times", output_format)
+
     if args.engine not in ("cpp", "auto"):
         if args.model_path:
             logger.warning("--model-path is only used with --engine cpp")
@@ -113,6 +128,7 @@ def _build_options(args: argparse.Namespace) -> Options:
         input_path=input_path,
         segment_seconds=segment_seconds,
         silence_timeout=silence_timeout,
+        output_format=output_format,
     )
 
 
@@ -130,10 +146,14 @@ def _build_transcription_config(options: Options) -> TranscriptionConfig:
 
 
 def _save_transcript(text: str, output_file: str) -> None:
-    """Print transcript, write it to output_file, and log the saved path."""
-    print(text)
+    """Print transcript, write it to output_file, and log the saved path.
+
+    The document ends in exactly one newline, whether or not the format supplied its own.
+    """
+    document = text if text.endswith("\n") else text + "\n"
+    print(document, end="")
     with open(output_file, "w", encoding="utf-8") as w:
-        w.write(text + "\n")
+        w.write(document)
     logger.info("Transcript saved to: %s", output_file)
 
 
@@ -213,6 +233,16 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     common.add_argument("--language", default=None, help="Force language code (e.g., en). Defaults to auto-detect")
     common.add_argument("--timestamps", action="store_true", help="Print timestamps with transcript")
+    common.add_argument(
+        "--format",
+        dest="output_format",
+        choices=list(OUTPUT_FORMATS),
+        default=DEFAULT_OUTPUT_FORMAT,
+        help=(
+            "Transcript format: txt (plain text), srt (SubRip subtitles), vtt (WebVTT subtitles), "
+            f"json (openai-whisper schema), tsv (default: {DEFAULT_OUTPUT_FORMAT})"
+        ),
+    )
     common.add_argument("--list-sources", action="store_true", help="List PulseAudio sources and exit")
     common.add_argument(
         "--device",
@@ -292,34 +322,61 @@ def _list_sources() -> None:
 
 def _run_once(options: Options, source: str) -> None:
     """Record (or read) a single audio file, transcribe it, and save the transcript."""
-    output_file = _resolve_output_path(options.output)
+    output_file = _resolve_output_path(options.output, options.output_format)
     config = _build_transcription_config(options)
 
     if options.input_path:
-        text = transcribe_file(options.input_path, config)
+        transcript = transcribe_file_cues(options.input_path, config)
     else:
-        text = transcribe_once(source, config, options.duration)
+        transcript = transcribe_once_cues(source, config, options.duration)
 
+    text = render_transcript(
+        transcript.cues,
+        options.output_format,
+        timestamps=options.timestamps,
+        language=transcript.language,
+    )
     _save_transcript(text, output_file)
+
+
+def _emit(chunk: str, handle: TextIO) -> None:
+    """Print one piece of a transcript document and append it to the open output file."""
+    if not chunk:
+        return
+    print(chunk, end="", flush=True)
+    handle.write(chunk)
+    handle.flush()
 
 
 def _run_live(options: Options, source: str) -> None:
     """Consume live transcript segments, printing and saving each one as it arrives."""
-    output_file = _resolve_output_path(options.output)
+    output_file = _resolve_output_path(options.output, options.output_format)
     config = _build_transcription_config(options)
     logger.info("Live transcript will be saved to: %s", output_file)
     logger.info("Press Ctrl-C once to stop live capture and save the transcript.")
 
+    # Plain text is a running log that can be appended to. The other formats are documents
+    # with their own header, cue numbering and syntax, so each run starts a fresh one.
+    formatter = (
+        None if options.output_format == "txt" else get_formatter(options.output_format, language=options.language)
+    )
+
     segments = transcribe_live(source, config, segment_seconds=options.segment_seconds)
     silent_seconds = 0
-    with open(output_file, "a", encoding="utf-8") as handle:
+    with open(output_file, "a" if formatter is None else "w", encoding="utf-8") as handle:
+        if formatter is not None:
+            _emit(formatter.header(), handle)
         try:
             with contextlib.closing(segments):
                 for segment in segments:
-                    line = _format_segment(segment, options.timestamps)
-                    print(line, flush=True)
-                    handle.write(line + "\n")
-                    handle.flush()
+                    if formatter is None:
+                        line = _format_segment(segment, options.timestamps)
+                        print(line, flush=True)
+                        handle.write(line + "\n")
+                        handle.flush()
+                    else:
+                        for cue in segment.cues:
+                            _emit(formatter.cue(cue), handle)
 
                     if segment.text.strip():
                         silent_seconds = 0
@@ -330,6 +387,10 @@ def _run_live(options: Options, source: str) -> None:
                         break
         except KeyboardInterrupt:
             logger.info("Stopping live capture...")
+        if formatter is not None:
+            # Closes the document, so it has to run whether capture ended, timed out or
+            # was interrupted. JSON in particular is written entirely from here.
+            _emit(formatter.footer(), handle)
 
     logger.info("Transcript saved to: %s", output_file)
 

--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -11,7 +11,12 @@ from datetime import datetime
 from typing import Optional, TextIO
 
 from . import __version__
-from .constants import DEFAULT_OUTPUT_FORMAT, DEFAULT_SEGMENT_SECONDS, WHISPER_MODEL
+from .constants import (
+    DEFAULT_OUTPUT_FORMAT,
+    DEFAULT_SEGMENT_SECONDS,
+    MAX_CONSECUTIVE_SEGMENT_FAILURES,
+    WHISPER_MODEL,
+)
 from .formats import FORMAT_EXTENSIONS, OUTPUT_FORMATS, TIMED_FORMATS, get_formatter, render_transcript
 from .pipeline import TranscriptSegment, transcribe_live, transcribe_once_cues
 from .pulse import get_default_monitor_source, list_pulse_sources
@@ -362,7 +367,9 @@ def _run_live(options: Options, source: str) -> None:
     )
 
     segments = transcribe_live(source, config, segment_seconds=options.segment_seconds)
-    silent_seconds = 0
+    silence_start: Optional[float] = None
+    failures = 0
+    failure: Optional[str] = None
     with open(output_file, "a" if formatter is None else "w", encoding="utf-8") as handle:
         if formatter is not None:
             _emit(formatter.header(), handle)
@@ -378,12 +385,30 @@ def _run_live(options: Options, source: str) -> None:
                         for cue in segment.cues:
                             _emit(formatter.cue(cue), handle)
 
+                    if segment.failed:
+                        # A failure says nothing about what the segment held, so it neither
+                        # counts as speech nor accumulates towards the silence timeout.
+                        failures += 1
+                        silence_start = None
+                        if failures >= MAX_CONSECUTIVE_SEGMENT_FAILURES:
+                            failure = (
+                                f"Transcription failed for {failures} consecutive segments ({segment.error}), stopping."
+                            )
+                            break
+                        continue
+
+                    failures = 0
                     if segment.text.strip():
-                        silent_seconds = 0
-                    else:
-                        silent_seconds += options.segment_seconds
+                        silence_start = None
+                        continue
+
+                    # Measure silence along the recording's timeline, since segments holding no
+                    # audio at all are skipped and the processed ones need not be contiguous.
+                    if silence_start is None:
+                        silence_start = segment.start
+                    silent_seconds = segment.end - silence_start
                     if 0 < options.silence_timeout <= silent_seconds:
-                        logger.info("No speech detected for %d seconds, stopping automatically.", silent_seconds)
+                        logger.info("No speech detected for %.0f seconds, stopping automatically.", silent_seconds)
                         break
         except KeyboardInterrupt:
             logger.info("Stopping live capture...")
@@ -393,6 +418,8 @@ def _run_live(options: Options, source: str) -> None:
             _emit(formatter.footer(), handle)
 
     logger.info("Transcript saved to: %s", output_file)
+    if failure:
+        raise RuntimeError(failure)
 
 
 def _run(options: Options) -> None:

--- a/src/sys2txt/constants.py
+++ b/src/sys2txt/constants.py
@@ -31,3 +31,6 @@ MIN_TRANSCRIBE_TIMEOUT = 60
 
 WHISPER_CPP_TIMEOUT = 300
 "Seconds to wait for whisper-cli before assuming a GPU hang or malformed audio"
+
+DEFAULT_OUTPUT_FORMAT = "txt"
+"Default transcript output format. See sys2txt.formats.OUTPUT_FORMATS for the rest."

--- a/src/sys2txt/constants.py
+++ b/src/sys2txt/constants.py
@@ -32,5 +32,8 @@ MIN_TRANSCRIBE_TIMEOUT = 60
 WHISPER_CPP_TIMEOUT = 300
 "Seconds to wait for whisper-cli before assuming a GPU hang or malformed audio"
 
+MAX_CONSECUTIVE_SEGMENT_FAILURES = 3
+"Consecutive live-mode transcription failures tolerated before giving up"
+
 DEFAULT_OUTPUT_FORMAT = "txt"
 "Default transcript output format. See sys2txt.formats.OUTPUT_FORMATS for the rest."

--- a/src/sys2txt/formats.py
+++ b/src/sys2txt/formats.py
@@ -1,0 +1,305 @@
+"""Transcript data types and the output formats they can be rendered as.
+
+A transcript is a sequence of :class:`Cue` values: timed spans of speech measured in
+seconds from the start of the recording. Rendering them is separate from producing
+them, so any engine can feed any format.
+
+Four of the five formats are the ones the speech-to-text ecosystem has settled on:
+WebVTT is a W3C standard, SubRip (SRT) is the de-facto subtitle format, and the JSON
+and TSV layouts match what openai-whisper's own CLI writes. ``txt`` is sys2txt's
+original plain-text output, kept as the default.
+
+Nothing here prints or writes files: renderers return strings and the caller decides
+where they go.
+"""
+
+import json
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+
+OUTPUT_FORMATS = ("txt", "srt", "vtt", "json", "tsv")
+"Output formats a transcript can be rendered as"
+
+FORMAT_EXTENSIONS: Dict[str, str] = {
+    "txt": ".txt",
+    "srt": ".srt",
+    "vtt": ".vtt",
+    "json": ".json",
+    "tsv": ".tsv",
+}
+"File extension to use for each output format"
+
+TIMED_FORMATS = ("srt", "vtt", "json", "tsv")
+"Formats that carry cue timings of their own, so ``--timestamps`` adds nothing"
+
+
+@dataclass(frozen=True)
+class Cue:
+    """One timed span of transcribed speech.
+
+    Attributes:
+        start: Start of the span in seconds from the beginning of the recording
+        end: End of the span in seconds from the beginning of the recording
+        text: Transcribed text of the span
+    """
+
+    start: float
+    end: float
+    text: str
+
+    def shifted(self, offset: float) -> "Cue":
+        """Return this cue moved along the timeline by ``offset`` seconds."""
+        return Cue(start=self.start + offset, end=self.end + offset, text=self.text)
+
+
+@dataclass(frozen=True)
+class Transcript:
+    """A transcribed audio file.
+
+    Attributes:
+        cues: Timed spans of speech, in chronological order
+        language: Language code the engine detected or was told to use, when known
+    """
+
+    cues: Tuple[Cue, ...] = ()
+    language: Optional[str] = None
+
+    @property
+    def text(self) -> str:
+        """The transcript as a single line of plain text."""
+        return " ".join(cue.text.strip() for cue in self.cues if cue.text.strip()).strip()
+
+
+def format_timestamp(seconds: float, *, decimal_separator: str = ".") -> str:
+    """Format a number of seconds as ``HH:MM:SS.mmm``.
+
+    Args:
+        seconds: Time in seconds. Negative values are clamped to zero.
+        decimal_separator: Separator before the milliseconds. SubRip requires ``","``,
+            WebVTT requires ``"."``.
+
+    Returns:
+        A timestamp string with two-digit hours, which both SubRip and WebVTT accept.
+    """
+    if seconds < 0:
+        seconds = 0.0
+    milliseconds = round(seconds * 1000)
+    hours, milliseconds = divmod(milliseconds, 3_600_000)
+    minutes, milliseconds = divmod(milliseconds, 60_000)
+    secs, milliseconds = divmod(milliseconds, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}{decimal_separator}{milliseconds:03d}"
+
+
+def _escape_vtt(text: str) -> str:
+    """Escape the characters WebVTT reads as cue markup."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+class TranscriptFormatter:
+    """Renders cues into a transcript document, one piece at a time.
+
+    A document is ``header()``, then one ``cue()`` per cue, then ``footer()``. Formats
+    that can be written incrementally return each cue from ``cue()``; ``json`` has to
+    see every cue before it can be serialized, so it buffers and returns the whole
+    document from ``footer()``. Either way the concatenation is the finished document,
+    which is what lets live mode stream and once mode render in one go.
+
+    Args:
+        timestamps: Include timings in plain-text output. Ignored by timed formats.
+        language: Language code to record in formats that have somewhere to put it.
+    """
+
+    def __init__(self, *, timestamps: bool = False, language: Optional[str] = None) -> None:
+        self.timestamps = timestamps
+        self.language = language
+
+    def header(self) -> str:
+        """Return the text that opens the document."""
+        return ""
+
+    def cue(self, cue: Cue) -> str:
+        """Return the text for one cue, which may be empty if the format skips it."""
+        raise NotImplementedError
+
+    def footer(self) -> str:
+        """Return the text that closes the document."""
+        return ""
+
+
+class _TxtFormatter(TranscriptFormatter):
+    """sys2txt's original plain-text output.
+
+    Without timings the whole transcript is one space-separated line; with them it is
+    one line per cue. The separator goes before each cue rather than after it so the
+    document never ends in trailing whitespace.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._emitted = False
+
+    def cue(self, cue: Cue) -> str:
+        text = cue.text.strip()
+        if self.timestamps:
+            chunk = f"[{cue.start:6.2f}-{cue.end:6.2f}] {text}"
+        elif text:
+            chunk = text
+        else:
+            return ""
+        separator = ("\n" if self.timestamps else " ") if self._emitted else ""
+        self._emitted = True
+        return separator + chunk
+
+
+class _CueBlockFormatter(TranscriptFormatter):
+    """Shared behaviour for the two subtitle formats, which differ only in detail."""
+
+    decimal_separator = "."
+    numbered = False
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._count = 0
+
+    def cue(self, cue: Cue) -> str:
+        text = cue.text.strip()
+        if not text:
+            # A subtitle cue with no text is noise, and silence needs no cue at all.
+            return ""
+        self._count += 1
+        start = format_timestamp(cue.start, decimal_separator=self.decimal_separator)
+        end = format_timestamp(max(cue.end, cue.start), decimal_separator=self.decimal_separator)
+        number = f"{self._count}\n" if self.numbered else ""
+        return f"{number}{start} --> {end}\n{self._render_text(text)}\n\n"
+
+    def _render_text(self, text: str) -> str:
+        return text
+
+
+class _SrtFormatter(_CueBlockFormatter):
+    """SubRip (``.srt``): the de-facto subtitle format, understood by every player."""
+
+    decimal_separator = ","
+    numbered = True
+
+
+class _VttFormatter(_CueBlockFormatter):
+    """WebVTT (``.vtt``): the W3C standard, consumed natively by browsers."""
+
+    decimal_separator = "."
+    numbered = False
+
+    def header(self) -> str:
+        return "WEBVTT\n\n"
+
+    def _render_text(self, text: str) -> str:
+        return _escape_vtt(text)
+
+
+class _TsvFormatter(TranscriptFormatter):
+    """Tab-separated milliseconds and text, matching openai-whisper's TSV writer."""
+
+    def header(self) -> str:
+        return "start\tend\ttext\n"
+
+    def cue(self, cue: Cue) -> str:
+        text = " ".join(cue.text.split())
+        if not text:
+            return ""
+        start = round(max(cue.start, 0.0) * 1000)
+        end = round(max(cue.end, cue.start, 0.0) * 1000)
+        return f"{start}\t{end}\t{text}\n"
+
+
+class _JsonFormatter(TranscriptFormatter):
+    """openai-whisper's JSON shape, so existing tooling reads sys2txt output unchanged.
+
+    Cues have to be buffered: the document cannot be closed until the last one arrives.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._cues: List[Cue] = []
+
+    def cue(self, cue: Cue) -> str:
+        if cue.text.strip():
+            self._cues.append(cue)
+        return ""
+
+    def footer(self) -> str:
+        segments = [
+            {
+                "id": index,
+                "start": round(cue.start, 3),
+                "end": round(max(cue.end, cue.start), 3),
+                "text": cue.text.strip(),
+            }
+            for index, cue in enumerate(self._cues)
+        ]
+        document = {
+            "text": " ".join(segment["text"] for segment in segments).strip(),
+            "segments": segments,
+            "language": self.language,
+        }
+        return json.dumps(document, ensure_ascii=False, indent=2) + "\n"
+
+
+_FORMATTERS = {
+    "txt": _TxtFormatter,
+    "srt": _SrtFormatter,
+    "vtt": _VttFormatter,
+    "json": _JsonFormatter,
+    "tsv": _TsvFormatter,
+}
+
+
+def get_formatter(
+    output_format: str, *, timestamps: bool = False, language: Optional[str] = None
+) -> TranscriptFormatter:
+    """Build the formatter for an output format.
+
+    Args:
+        output_format: One of :data:`OUTPUT_FORMATS`
+        timestamps: Include timings in plain-text output
+        language: Language code to record where the format allows it
+
+    Returns:
+        A formatter ready to render a document
+
+    Raises:
+        ValueError: If the output format is not one of :data:`OUTPUT_FORMATS`
+    """
+    try:
+        formatter_class = _FORMATTERS[output_format]
+    except KeyError:
+        raise ValueError(f"Unknown output format: {output_format}") from None
+    return formatter_class(timestamps=timestamps, language=language)
+
+
+def render_transcript(
+    cues: Iterable[Cue],
+    output_format: str = "txt",
+    *,
+    timestamps: bool = False,
+    language: Optional[str] = None,
+) -> str:
+    """Render cues as a complete transcript document.
+
+    Args:
+        cues: Timed spans of speech, in chronological order
+        output_format: One of :data:`OUTPUT_FORMATS`
+        timestamps: Include timings in plain-text output. Ignored by timed formats,
+            which always carry their own.
+        language: Language code to record where the format allows it
+
+    Returns:
+        The finished document
+
+    Raises:
+        ValueError: If the output format is not one of :data:`OUTPUT_FORMATS`
+    """
+    formatter = get_formatter(output_format, timestamps=timestamps, language=language)
+    parts = [formatter.header()]
+    parts.extend(formatter.cue(cue) for cue in cues)
+    parts.append(formatter.footer())
+    return "".join(parts)

--- a/src/sys2txt/pipeline.py
+++ b/src/sys2txt/pipeline.py
@@ -29,12 +29,14 @@ class TranscriptSegment:
 
     Attributes:
         index: Position of the segment in the recording, counting from 0
-        text: Transcribed text, empty when the segment held no speech or transcription failed
+        text: Transcribed text, empty when the segment held no speech or when ``error`` is set
         start: Start of the segment in seconds from the beginning of the recording
         end: End of the segment in seconds from the beginning of the recording
         cues: The engine's own timed spans of speech within the segment, rebased onto the
             recording timeline so their times are comparable with ``start`` and ``end``.
             Empty when the segment held no speech or transcription failed.
+        error: Why transcription failed, or None when it succeeded. Silence and failure both
+            leave ``text`` empty, so this is what tells them apart.
     """
 
     index: int
@@ -42,11 +44,22 @@ class TranscriptSegment:
     start: float
     end: float
     cues: Tuple[Cue, ...] = ()
+    error: Optional[str] = None
+
+    @property
+    def failed(self) -> bool:
+        """Whether transcription of this segment failed rather than finding no speech."""
+        return self.error is not None
 
 
 def _segment_timeout(segment_seconds: int) -> float:
     """Allow generous time to transcribe a segment while preventing indefinite hangs."""
     return max(segment_seconds * TRANSCRIBE_TIMEOUT_FACTOR, MIN_TRANSCRIBE_TIMEOUT)
+
+
+def _new_executor() -> ThreadPoolExecutor:
+    """Create the single-worker pool that transcribes one segment at a time."""
+    return ThreadPoolExecutor(max_workers=1)
 
 
 def transcribe_live(
@@ -72,23 +85,32 @@ def transcribe_live(
 
     Yields:
         TranscriptSegment values in chronological order. A segment whose transcription times
-        out or fails is yielded with empty text and logged as a warning.
+        out or fails is yielded with empty text, an ``error`` describing the failure, and a
+        warning in the log.
     """
     timeout = _segment_timeout(segment_seconds)
     segments = iter_audio_segments(source, segment_seconds, sample_rate=sample_rate, channels=channels)
-    executor = ThreadPoolExecutor(max_workers=1)
+    executor = _new_executor()
     try:
         with contextlib.closing(segments):
             for segment in segments:
                 future = executor.submit(transcribe_file_cues, segment.path, config)
+                error = None
                 try:
                     transcript = future.result(timeout=timeout)
                 except FuturesTimeoutError:
                     logger.warning("Segment %d transcription timed out, skipping", segment.index)
                     transcript = Transcript()
+                    error = f"transcription timed out after {timeout:.0f}s"
+                    # The worker cannot be cancelled and keeps running, so the next segment
+                    # would queue behind it and time out without ever being transcribed.
+                    # Abandon the pool and give the next segment a worker of its own.
+                    executor.shutdown(wait=False)
+                    executor = _new_executor()
                 except Exception as e:
                     logger.warning("Segment %d transcription failed: %s", segment.index, e)
                     transcript = Transcript()
+                    error = f"transcription failed: {e}"
                 start = segment.index * segment_seconds
                 # The engine times each segment from zero, so shift its cues onto the
                 # timeline of the recording as a whole.
@@ -99,6 +121,7 @@ def transcribe_live(
                     start=float(start),
                     end=float(start + segment_seconds),
                     cues=cues,
+                    error=error,
                 )
     finally:
         executor.shutdown(wait=False)

--- a/src/sys2txt/pipeline.py
+++ b/src/sys2txt/pipeline.py
@@ -7,7 +7,7 @@ import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from dataclasses import dataclass
-from typing import Iterator, Optional
+from typing import Iterator, Optional, Tuple
 
 from .audio import iter_audio_segments, record_once
 from .constants import (
@@ -17,7 +17,8 @@ from .constants import (
     SAMPLE_RATE,
     TRANSCRIBE_TIMEOUT_FACTOR,
 )
-from .transcribe import TranscriptionConfig, transcribe_file
+from .formats import Cue, Transcript, render_transcript
+from .transcribe import TranscriptionConfig, transcribe_file_cues
 
 logger = logging.getLogger(__name__)
 
@@ -31,12 +32,16 @@ class TranscriptSegment:
         text: Transcribed text, empty when the segment held no speech or transcription failed
         start: Start of the segment in seconds from the beginning of the recording
         end: End of the segment in seconds from the beginning of the recording
+        cues: The engine's own timed spans of speech within the segment, rebased onto the
+            recording timeline so their times are comparable with ``start`` and ``end``.
+            Empty when the segment held no speech or transcription failed.
     """
 
     index: int
     text: str
     start: float
     end: float
+    cues: Tuple[Cue, ...] = ()
 
 
 def _segment_timeout(segment_seconds: int) -> float:
@@ -75,21 +80,25 @@ def transcribe_live(
     try:
         with contextlib.closing(segments):
             for segment in segments:
-                future = executor.submit(transcribe_file, segment.path, config)
+                future = executor.submit(transcribe_file_cues, segment.path, config)
                 try:
-                    text = future.result(timeout=timeout)
+                    transcript = future.result(timeout=timeout)
                 except FuturesTimeoutError:
                     logger.warning("Segment %d transcription timed out, skipping", segment.index)
-                    text = ""
+                    transcript = Transcript()
                 except Exception as e:
                     logger.warning("Segment %d transcription failed: %s", segment.index, e)
-                    text = ""
+                    transcript = Transcript()
                 start = segment.index * segment_seconds
+                # The engine times each segment from zero, so shift its cues onto the
+                # timeline of the recording as a whole.
+                cues = tuple(cue.shifted(float(start)) for cue in transcript.cues)
                 yield TranscriptSegment(
                     index=segment.index,
-                    text=text,
+                    text=render_transcript(transcript.cues, "txt", timestamps=config.timestamps),
                     start=float(start),
                     end=float(start + segment_seconds),
+                    cues=cues,
                 )
     finally:
         executor.shutdown(wait=False)
@@ -103,7 +112,7 @@ def transcribe_once(
     sample_rate: int = SAMPLE_RATE,
     channels: int = CHANNELS,
 ) -> str:
-    """Record audio once and return its transcript.
+    """Record audio once and return its transcript as text.
 
     Args:
         source: PulseAudio source name
@@ -115,7 +124,34 @@ def transcribe_once(
     Returns:
         Transcribed text
     """
+    transcript = transcribe_once_cues(source, config, duration, sample_rate=sample_rate, channels=channels)
+    return render_transcript(transcript.cues, "txt", timestamps=config.timestamps)
+
+
+def transcribe_once_cues(
+    source: str,
+    config: TranscriptionConfig,
+    duration: Optional[int] = None,
+    *,
+    sample_rate: int = SAMPLE_RATE,
+    channels: int = CHANNELS,
+) -> Transcript:
+    """Record audio once and return its transcript as timed cues.
+
+    This is the structured form of :func:`transcribe_once`, keeping the per-utterance
+    timings that the subtitle and JSON output formats need.
+
+    Args:
+        source: PulseAudio source name
+        config: Transcription configuration
+        duration: Recording duration in seconds. If None, records until interrupted.
+        sample_rate: Sample rate in Hz
+        channels: Number of audio channels
+
+    Returns:
+        The transcript, with cue times in seconds from the start of the recording
+    """
     with tempfile.TemporaryDirectory(prefix="sys2txt_") as tmp:
         wav = os.path.join(tmp, "capture.wav")
         record_once(source, wav, duration, sample_rate=sample_rate, channels=channels)
-        return transcribe_file(wav, config)
+        return transcribe_file_cues(wav, config)

--- a/src/sys2txt/transcribe.py
+++ b/src/sys2txt/transcribe.py
@@ -8,9 +8,10 @@ import subprocess
 import threading
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from .constants import WHISPER_CPP_TIMEOUT
+from .formats import Cue, Transcript, render_transcript
 
 logger = logging.getLogger(__name__)
 
@@ -37,14 +38,37 @@ _model_cache_lock = threading.Lock()
 
 
 def transcribe_file(path: str, config: TranscriptionConfig) -> str:
-    """Transcribe an audio file using the specified Whisper engine.
+    """Transcribe an audio file and return its text.
 
     Args:
         path: Path to audio file
         config: Transcription configuration
 
     Returns:
-        Transcribed text
+        Transcribed text, one line per cue when ``config.timestamps`` is set
+
+    Raises:
+        ValueError: If the configured engine is unknown
+    """
+    transcript = transcribe_file_cues(path, config)
+    return render_transcript(transcript.cues, "txt", timestamps=config.timestamps)
+
+
+def transcribe_file_cues(path: str, config: TranscriptionConfig) -> Transcript:
+    """Transcribe an audio file into timed cues.
+
+    This is the structured form of :func:`transcribe_file`, keeping the per-utterance
+    timings that the subtitle and JSON output formats need.
+
+    Args:
+        path: Path to audio file
+        config: Transcription configuration
+
+    Returns:
+        The transcript, with cue times in seconds from the start of the audio file
+
+    Raises:
+        ValueError: If the configured engine is unknown
     """
     engine = config.engine.lower()
     if engine == "auto":
@@ -64,15 +88,14 @@ def transcribe_file(path: str, config: TranscriptionConfig) -> str:
     logger.debug("Transcribing %s with engine '%s', model '%s'", path, engine, config.model)
 
     if engine == "faster":
-        return _transcribe_faster_whisper(path, config.model, config.language, config.timestamps, config.device)
+        return _transcribe_faster_whisper(path, config.model, config.language, config.device)
     elif engine == "whisper":
-        return _transcribe_openai_whisper(path, config.model, config.language, config.timestamps)
+        return _transcribe_openai_whisper(path, config.model, config.language)
     elif engine == "cpp":
         return _transcribe_whisper_cpp(
             path,
             config.model,
             config.language,
-            config.timestamps,
             config.model_path,
             config.whisper_cpp_path,
             config.device,
@@ -81,9 +104,7 @@ def transcribe_file(path: str, config: TranscriptionConfig) -> str:
         raise ValueError(f"Unknown engine: {engine}")
 
 
-def _transcribe_faster_whisper(
-    path: str, model_size: str, language: Optional[str], timestamps: bool, device: str = "auto"
-) -> str:
+def _transcribe_faster_whisper(path: str, model_size: str, language: Optional[str], device: str = "auto") -> Transcript:
     """Transcribe using faster-whisper (ctranslate2 backend)."""
     try:
         from faster_whisper import WhisperModel  # type: ignore
@@ -110,18 +131,11 @@ def _transcribe_faster_whisper(
             _faster_whisper_model_key = key
         model = _faster_whisper_model
     segments, info = model.transcribe(path, vad_filter=True, language=language)
-    if timestamps:
-        lines = []
-        for seg in segments:
-            s = f"[{seg.start:6.2f}-{seg.end:6.2f}] {seg.text.strip()}"
-            lines.append(s)
-        return "\n".join(lines)
-    else:
-        text_parts = [seg.text for seg in segments]
-        return " ".join(t.strip() for t in text_parts).strip()
+    cues = tuple(Cue(start=float(seg.start), end=float(seg.end), text=seg.text.strip()) for seg in segments)
+    return Transcript(cues=cues, language=getattr(info, "language", None) or language)
 
 
-def _transcribe_openai_whisper(path: str, model_size: str, language: Optional[str], timestamps: bool) -> str:
+def _transcribe_openai_whisper(path: str, model_size: str, language: Optional[str]) -> Transcript:
     """Transcribe using openai-whisper (reference implementation)."""
     try:
         import whisper  # type: ignore
@@ -136,16 +150,22 @@ def _transcribe_openai_whisper(path: str, model_size: str, language: Optional[st
             _openai_whisper_model_key = model_size
         model = _openai_whisper_model
     result = model.transcribe(path, language=language)
-    if timestamps and "segments" in result:
-        lines = []
-        for seg in result.get("segments", []):
-            start = seg.get("start", 0.0)
-            end = seg.get("end", 0.0)
-            text = seg.get("text", "").strip()
-            lines.append(f"[{start:6.2f}-{end:6.2f}] {text}")
-        return "\n".join(lines)
+    detected = result.get("language") or language
+    segments = result.get("segments") or []
+    if segments:
+        cues = tuple(
+            Cue(
+                start=float(seg.get("start", 0.0)),
+                end=float(seg.get("end", 0.0)),
+                text=seg.get("text", "").strip(),
+            )
+            for seg in segments
+        )
     else:
-        return result.get("text", "").strip()
+        # Untimed fallback: the whole transcript as a single cue of unknown extent.
+        text = result.get("text", "").strip()
+        cues = (Cue(start=0.0, end=0.0, text=text),) if text else ()
+    return Transcript(cues=cues, language=detected)
 
 
 def _resolve_whisper_cpp_binary(whisper_cpp_path: Optional[str]) -> str:
@@ -232,7 +252,7 @@ def _resolve_whisper_cpp_model_path(model_path: Optional[str], model_size: str) 
     )
 
 
-def _parse_whisper_cpp_output(output: str, timestamps: bool) -> str:
+def _parse_whisper_cpp_output(output: str, language: Optional[str] = None) -> Transcript:
     """Parse whisper.cpp stdout format.
 
     Whisper.cpp outputs lines like:
@@ -240,12 +260,12 @@ def _parse_whisper_cpp_output(output: str, timestamps: bool) -> str:
 
     Args:
         output: Raw stdout from whisper-cli
-        timestamps: Whether to include timestamps in output
+        language: Language code the caller asked for, recorded on the transcript
 
     Returns:
-        Parsed transcription text
+        The transcript parsed out of the timestamped lines
     """
-    lines = []
+    cues: List[Cue] = []
     # Pattern: [HH:MM:SS.mmm --> HH:MM:SS.mmm] text
     pattern = re.compile(r"\[(\d{2}:\d{2}:\d{2}\.\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}\.\d{3})\]\s*(.*)")
 
@@ -256,18 +276,15 @@ def _parse_whisper_cpp_output(output: str, timestamps: bool) -> str:
             text = text.strip()
             if not text:
                 continue
-            if timestamps:
-                # Convert HH:MM:SS.mmm to seconds for consistent formatting
-                start_secs = _timestamp_to_seconds(start_str)
-                end_secs = _timestamp_to_seconds(end_str)
-                lines.append(f"[{start_secs:6.2f}-{end_secs:6.2f}] {text}")
-            else:
-                lines.append(text)
+            cues.append(
+                Cue(
+                    start=_timestamp_to_seconds(start_str),
+                    end=_timestamp_to_seconds(end_str),
+                    text=text,
+                )
+            )
 
-    if timestamps:
-        return "\n".join(lines)
-    else:
-        return " ".join(lines).strip()
+    return Transcript(cues=tuple(cues), language=language)
 
 
 def _timestamp_to_seconds(ts: str) -> float:
@@ -293,24 +310,22 @@ def _transcribe_whisper_cpp(
     path: str,
     model_size: str,
     language: Optional[str],
-    timestamps: bool,
     model_path: Optional[str],
     whisper_cpp_path: Optional[str],
     device: str,
-) -> str:
+) -> Transcript:
     """Transcribe using whisper.cpp (with optional Vulkan GPU support).
 
     Args:
         path: Path to audio file
         model_size: Whisper model size (tiny, base, small, medium, large-v2)
         language: Optional language code (e.g., "en"). If None, auto-detect.
-        timestamps: Whether to include timestamps in output
         model_path: Path to whisper.cpp model file
         whisper_cpp_path: Path to whisper-cli binary
         device: Device to use ("auto", "cpu", "vulkan", "gpu", "cuda")
 
     Returns:
-        Transcribed text
+        The transcript, with cue times parsed from whisper-cli's output
 
     Raises:
         RuntimeError: If whisper-cli binary or model not found, or transcription fails
@@ -343,4 +358,4 @@ def _transcribe_whisper_cpp(
     except FileNotFoundError as e:
         raise RuntimeError(f"whisper-cli binary not found: {binary}") from e
 
-    return _parse_whisper_cpp_output(result.stdout, timestamps)
+    return _parse_whisper_cpp_output(result.stdout, language)

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -1,5 +1,6 @@
 """Tests for sys2txt.__main__ module."""
 
+import json
 import logging
 import os
 import tempfile
@@ -17,6 +18,7 @@ from sys2txt.__main__ import (
     _save_transcript,
     main,
 )
+from sys2txt.formats import Cue, Transcript
 from sys2txt.pipeline import TranscriptSegment
 from sys2txt.transcribe import TranscriptionConfig
 
@@ -37,16 +39,28 @@ def make_args(**overrides):
         output=None,
         segment_seconds=8,
         silence_timeout=0,
+        output_format="txt",
     )
     values.update(overrides)
     return Namespace(**values)
 
 
 def live_segments(*texts, segment_seconds=8):
-    """Yield TranscriptSegment values the way transcribe_live does."""
+    """Yield TranscriptSegment values the way transcribe_live does.
+
+    Each spoken segment carries one cue two seconds long, already rebased onto the
+    recording timeline; a silent segment carries none.
+    """
     for index, text in enumerate(texts):
         start = index * segment_seconds
-        yield TranscriptSegment(index=index, text=text, start=float(start), end=float(start + segment_seconds))
+        cues = (Cue(start=float(start), end=float(start + 2), text=text),) if text.strip() else ()
+        yield TranscriptSegment(
+            index=index,
+            text=text,
+            start=float(start),
+            end=float(start + segment_seconds),
+            cues=cues,
+        )
 
 
 class TestResolveOutputPath(unittest.TestCase):
@@ -129,6 +143,23 @@ class TestBuildOptions(unittest.TestCase):
         options = _build_options(make_args(segment_seconds=8, silence_timeout=8))
         self.assertEqual(options.silence_timeout, 8)
 
+    def test_output_format_defaults_to_txt(self):
+        self.assertEqual(_build_options(make_args()).output_format, "txt")
+
+    def test_output_format_is_copied_onto_options(self):
+        self.assertEqual(_build_options(make_args(output_format="srt")).output_format, "srt")
+
+    def test_warns_that_timestamps_add_nothing_to_a_timed_format(self):
+        args = make_args(timestamps=True, output_format="vtt")
+        with self.assertLogs("sys2txt.__main__", level="WARNING") as logs:
+            _build_options(args)
+        self.assertIn("--timestamps has no effect", logs.output[0])
+
+    def test_no_warning_for_timestamps_with_plain_text(self):
+        with self.assertRaises(AssertionError):
+            with self.assertLogs("sys2txt.__main__", level="WARNING"):
+                _build_options(make_args(timestamps=True, output_format="txt"))
+
     def test_warns_about_cpp_only_flags(self):
         args = make_args(engine="faster", model_path="/m.bin", whisper_cpp_path="/w")
         with self.assertLogs("sys2txt.__main__", level="WARNING") as logs:
@@ -181,7 +212,7 @@ class TestSaveTranscript(unittest.TestCase):
         ):
             _save_transcript("hello world", "/out/transcript.txt")
 
-        mock_print.assert_called_once_with("hello world")
+        mock_print.assert_called_once_with("hello world\n", end="")
         m.assert_called_once_with("/out/transcript.txt", "w", encoding="utf-8")
         m().write.assert_called_once_with("hello world\n")
         mock_logger.info.assert_called_once_with("Transcript saved to: %s", "/out/transcript.txt")
@@ -192,7 +223,7 @@ class TestArgumentParsing(unittest.TestCase):
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
-    @patch("sys2txt.__main__.transcribe_once", return_value="text")
+    @patch("sys2txt.__main__.transcribe_once_cues", return_value=Transcript())
     @patch("sys2txt.__main__._save_transcript")
     @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
     def test_once_defaults(self, _res, _save, mock_once, _src, _log):
@@ -217,14 +248,14 @@ class TestArgumentParsing(unittest.TestCase):
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
-    @patch("sys2txt.__main__.transcribe_file", return_value="text")
+    @patch("sys2txt.__main__.transcribe_file_cues", return_value=Transcript())
     @patch("sys2txt.__main__._save_transcript")
     @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
     def test_once_with_input_skips_recording(self, _res, _save, mock_trans, _src, _log):
         with tempfile.NamedTemporaryFile(suffix=".wav") as audio:
             with (
                 patch("sys.argv", ["sys2txt", "once", "--input", audio.name]),
-                patch("sys2txt.__main__.transcribe_once") as mock_once,
+                patch("sys2txt.__main__.transcribe_once_cues") as mock_once,
             ):
                 main()
             mock_once.assert_not_called()
@@ -232,7 +263,7 @@ class TestArgumentParsing(unittest.TestCase):
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
-    @patch("sys2txt.__main__.transcribe_once", return_value="text")
+    @patch("sys2txt.__main__.transcribe_once_cues", return_value=Transcript())
     @patch("sys2txt.__main__._save_transcript")
     @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
     def test_once_all_flags(self, _res, _save, mock_once, _src, _log):
@@ -265,7 +296,7 @@ class TestArgumentParsing(unittest.TestCase):
         self.assertEqual(mock_once.call_args[0][0], "my.monitor")
         self.assertEqual(mock_once.call_args[0][2], 30)
         # Output was explicitly provided so _resolve_output_path gets it
-        _res.assert_called_once_with("/tmp/my.txt")
+        _res.assert_called_once_with("/tmp/my.txt", "txt")
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
@@ -319,7 +350,7 @@ class TestArgumentParsing(unittest.TestCase):
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
-    @patch("sys2txt.__main__.transcribe_once", side_effect=KeyboardInterrupt())
+    @patch("sys2txt.__main__.transcribe_once_cues", side_effect=KeyboardInterrupt())
     @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
     def test_keyboard_interrupt_exits_cleanly(self, _res, _once, _src, _log):
         with patch("sys.argv", ["sys2txt", "once"]):
@@ -358,6 +389,9 @@ class TestInvalidArguments(unittest.TestCase):
     def test_silence_timeout_shorter_than_segment(self):
         self._assert_usage_error(["sys2txt", "live", "--segment-seconds", "8", "--silence-timeout", "3"])
 
+    def test_unknown_output_format(self):
+        self._assert_usage_error(["sys2txt", "once", "--format", "docx"])
+
 
 class TestListSources(unittest.TestCase):
     """Tests for --list-sources flag."""
@@ -388,7 +422,7 @@ class TestModeDispatchOnce(unittest.TestCase):
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
-    @patch("sys2txt.__main__.transcribe_once", return_value="hello world")
+    @patch("sys2txt.__main__.transcribe_once_cues", return_value=Transcript((Cue(0.0, 1.0, "hello world"),)))
     @patch("sys2txt.__main__._save_transcript")
     @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
     def test_once_records_then_transcribes(self, _res, mock_save, mock_once, _src, _log):
@@ -399,7 +433,7 @@ class TestModeDispatchOnce(unittest.TestCase):
 
     @patch("sys2txt.__main__._configure_logging")
     @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
-    @patch("sys2txt.__main__.transcribe_file", return_value="from file")
+    @patch("sys2txt.__main__.transcribe_file_cues", return_value=Transcript((Cue(0.0, 1.0, "from file"),)))
     @patch("sys2txt.__main__._save_transcript")
     @patch("sys2txt.__main__._resolve_output_path", return_value="/tmp/out.txt")
     def test_once_input_skips_recording(self, _res, mock_save, mock_trans, _src, _log):
@@ -408,6 +442,162 @@ class TestModeDispatchOnce(unittest.TestCase):
                 main()
             self.assertEqual(mock_trans.call_args[0][0], audio.name)
         mock_save.assert_called_once_with("from file", "/tmp/out.txt")
+
+
+class TestOnceOutputFormats(unittest.TestCase):
+    """once mode renders the transcript in the format the user asked for."""
+
+    def _run_once(self, argv, transcript):
+        """Run the CLI in once mode against a canned transcript, returning the output file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_file = os.path.join(tmp, "out")
+            with (
+                patch("sys2txt.__main__._configure_logging"),
+                patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor"),
+                patch("sys2txt.__main__._resolve_output_path", return_value=output_file),
+                patch("sys2txt.__main__.transcribe_once_cues", return_value=transcript),
+                patch("builtins.print") as mock_print,
+                patch("sys.argv", argv),
+            ):
+                main()
+            with open(output_file, encoding="utf-8") as f:
+                written = f.read()
+        return mock_print, written
+
+    def setUp(self):
+        self.transcript = Transcript(
+            cues=(Cue(0.0, 1.5, "Hello"), Cue(1.5, 3.25, "world")),
+            language="en",
+        )
+
+    def test_txt_is_unchanged_by_the_new_flag(self):
+        _, written = self._run_once(["sys2txt", "once"], self.transcript)
+        self.assertEqual(written, "Hello world\n")
+
+    def test_srt(self):
+        _, written = self._run_once(["sys2txt", "once", "--format", "srt"], self.transcript)
+        self.assertEqual(
+            written,
+            "1\n00:00:00,000 --> 00:00:01,500\nHello\n\n2\n00:00:01,500 --> 00:00:03,250\nworld\n\n",
+        )
+
+    def test_vtt(self):
+        _, written = self._run_once(["sys2txt", "once", "--format", "vtt"], self.transcript)
+        self.assertTrue(written.startswith("WEBVTT\n\n"))
+        self.assertIn("00:00:01.500 --> 00:00:03.250\nworld", written)
+
+    def test_json_records_the_detected_language(self):
+        _, written = self._run_once(["sys2txt", "once", "--format", "json"], self.transcript)
+        document = json.loads(written)
+        self.assertEqual(document["language"], "en")
+        self.assertEqual(document["text"], "Hello world")
+
+    def test_tsv(self):
+        _, written = self._run_once(["sys2txt", "once", "--format", "tsv"], self.transcript)
+        self.assertEqual(written, "start\tend\ttext\n0\t1500\tHello\n1500\t3250\tworld\n")
+
+    def test_stdout_mirrors_the_file(self):
+        mock_print, written = self._run_once(["sys2txt", "once", "--format", "srt"], self.transcript)
+        mock_print.assert_called_once_with(written, end="")
+
+    def test_generated_filename_takes_the_format_extension(self):
+        with (
+            patch("sys2txt.__main__.ensure_output_dir", return_value="/out"),
+            patch("sys2txt.__main__.datetime") as mock_datetime,
+        ):
+            mock_datetime.now.return_value.strftime.return_value = "2024-01-01_00-00-00"
+            self.assertEqual(_resolve_output_path(None, "srt"), os.path.join("/out", "2024-01-01_00-00-00.srt"))
+            self.assertEqual(_resolve_output_path(None, "json"), os.path.join("/out", "2024-01-01_00-00-00.json"))
+
+
+class TestLiveOutputFormats(unittest.TestCase):
+    """live mode streams the transcript in the format the user asked for."""
+
+    def _run_live(self, argv, segments):
+        """Run the CLI in live mode against a canned segment stream, returning the output file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_file = os.path.join(tmp, "out")
+            with (
+                patch("sys2txt.__main__._configure_logging"),
+                patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor"),
+                patch("sys2txt.__main__._resolve_output_path", return_value=output_file),
+                patch("sys2txt.__main__.transcribe_live", return_value=segments),
+                patch("builtins.print"),
+                patch("sys.argv", argv),
+            ):
+                main()
+            with open(output_file, encoding="utf-8") as f:
+                written = f.read()
+        return written
+
+    def test_srt_numbers_cues_across_segments(self):
+        written = self._run_live(
+            ["sys2txt", "live", "--format", "srt"],
+            live_segments("hello", "world"),
+        )
+        self.assertEqual(
+            written,
+            "1\n00:00:00,000 --> 00:00:02,000\nhello\n\n2\n00:00:08,000 --> 00:00:10,000\nworld\n\n",
+        )
+
+    def test_vtt_header_is_written_once_up_front(self):
+        written = self._run_live(
+            ["sys2txt", "live", "--format", "vtt"],
+            live_segments("hello", "world"),
+        )
+        self.assertEqual(written.count("WEBVTT"), 1)
+        self.assertTrue(written.startswith("WEBVTT\n\n"))
+
+    def test_json_document_is_closed_when_capture_stops(self):
+        written = self._run_live(
+            ["sys2txt", "live", "--format", "json"],
+            live_segments("hello", "world"),
+        )
+        document = json.loads(written)
+        self.assertEqual([segment["start"] for segment in document["segments"]], [0.0, 8.0])
+
+    def test_json_document_is_closed_on_keyboard_interrupt(self):
+        """The whole JSON document is written from the footer, so Ctrl-C must still reach it."""
+
+        def segments():
+            yield from live_segments("hello")
+            raise KeyboardInterrupt()
+
+        written = self._run_live(["sys2txt", "live", "--format", "json"], segments())
+
+        self.assertEqual(json.loads(written)["text"], "hello")
+
+    def test_json_document_is_closed_on_silence_timeout(self):
+        written = self._run_live(
+            ["sys2txt", "live", "--format", "json", "--silence-timeout", "16"],
+            live_segments("hello", "", "", "unreachable"),
+        )
+        self.assertEqual(json.loads(written)["text"], "hello")
+
+    def test_silent_segments_produce_no_cues(self):
+        written = self._run_live(
+            ["sys2txt", "live", "--format", "srt"],
+            live_segments("hello", "", "world"),
+        )
+        self.assertEqual(written.count("-->"), 2)
+
+    def test_a_timed_format_replaces_rather_than_appends(self):
+        """An SRT document cannot resume: cue numbering would restart mid-file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_file = os.path.join(tmp, "out.srt")
+            with open(output_file, "w", encoding="utf-8") as handle:
+                handle.write("stale content\n")
+            with (
+                patch("sys2txt.__main__._configure_logging"),
+                patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor"),
+                patch("sys2txt.__main__._resolve_output_path", return_value=output_file),
+                patch("sys2txt.__main__.transcribe_live", return_value=live_segments("hello")),
+                patch("builtins.print"),
+                patch("sys.argv", ["sys2txt", "live", "--format", "srt"]),
+            ):
+                main()
+            with open(output_file, encoding="utf-8") as f:
+                self.assertNotIn("stale content", f.read())
 
 
 class TestModeDispatchLive(unittest.TestCase):

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -45,14 +45,26 @@ def make_args(**overrides):
     return Namespace(**values)
 
 
-def live_segments(*texts, segment_seconds=8):
+class Failure:
+    """Marker for live_segments(): emit a failed segment instead of transcribed text."""
+
+    def __init__(self, reason="transcription timed out after 60s"):
+        self.reason = reason
+
+
+def live_segments(*items, segment_seconds=8, indices=None):
     """Yield TranscriptSegment values the way transcribe_live does.
 
-    Each spoken segment carries one cue two seconds long, already rebased onto the
-    recording timeline; a silent segment carries none.
+    Each item is either transcript text or a Failure marker. A spoken segment carries one cue
+    two seconds long, already rebased onto the recording timeline; a silent or failed segment
+    carries none. Pass indices to place the segments on the timeline non-contiguously, as
+    happens when empty segments are skipped.
     """
-    for index, text in enumerate(texts):
+    for position, item in enumerate(items):
+        index = indices[position] if indices else position
         start = index * segment_seconds
+        failed = isinstance(item, Failure)
+        text = "" if failed else item
         cues = (Cue(start=float(start), end=float(start + 2), text=text),) if text.strip() else ()
         yield TranscriptSegment(
             index=index,
@@ -60,6 +72,7 @@ def live_segments(*texts, segment_seconds=8):
             start=float(start),
             end=float(start + segment_seconds),
             cues=cues,
+            error=item.reason if failed else None,
         )
 
 
@@ -603,8 +616,15 @@ class TestLiveOutputFormats(unittest.TestCase):
 class TestModeDispatchLive(unittest.TestCase):
     """Tests for live mode consumption of the transcript stream."""
 
+    def setUp(self):
+        self.exit_code = 0
+
     def _run_live(self, argv, segments):
-        """Run the CLI in live mode against a canned segment stream, returning the transcript file."""
+        """Run the CLI in live mode against a canned segment stream, returning the transcript file.
+
+        A non-zero exit is recorded in self.exit_code rather than raised, so the transcript
+        written before the CLI gave up can still be inspected.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             output_file = os.path.join(tmp, "out.txt")
             with (
@@ -615,7 +635,10 @@ class TestModeDispatchLive(unittest.TestCase):
                 patch("builtins.print") as mock_print,
                 patch("sys.argv", argv),
             ):
-                main()
+                try:
+                    main()
+                except SystemExit as e:
+                    self.exit_code = e.code
             with open(output_file, encoding="utf-8") as f:
                 written = f.read()
         return mock_live, mock_print, written
@@ -662,6 +685,53 @@ class TestModeDispatchLive(unittest.TestCase):
         )
         self.assertEqual(mock_print.call_count, 3)
         self.assertEqual(written, "\n\n\n")
+
+    def test_silence_measured_across_gaps_in_the_timeline(self):
+        """Silence is measured on the recording's timeline, not by counting segments."""
+        # One silent segment at 0-8s, the next at 24-32s: 32s of quiet in two segments
+        segments = live_segments("", "", "should never be reached", indices=[0, 3, 4])
+        _, mock_print, _ = self._run_live(
+            ["sys2txt", "live", "--silence-timeout", "24"],
+            segments,
+        )
+        self.assertEqual(mock_print.call_count, 2)
+        self.assertEqual(self.exit_code, 0)
+
+    def test_failures_do_not_count_as_silence(self):
+        """Transcription failures never accumulate towards the silence timeout."""
+        segments = live_segments(Failure(), "", Failure(), "", Failure(), "hello")
+        _, mock_print, written = self._run_live(
+            ["sys2txt", "live", "--silence-timeout", "16"],
+            segments,
+        )
+        self.assertEqual(mock_print.call_count, 6)
+        self.assertEqual(written, "\n\n\n\n\n" + "hello\n")
+        self.assertEqual(self.exit_code, 0)
+
+    def test_repeated_failures_stop_with_an_error(self):
+        """A persistent failure is reported as a failure, not as silence."""
+        segments = live_segments(Failure(), Failure(), Failure(), "should never be reached")
+        with self.assertLogs("sys2txt.__main__", level="ERROR") as logs:
+            _, mock_print, written = self._run_live(
+                ["sys2txt", "live", "--silence-timeout", "16"],
+                segments,
+            )
+
+        self.assertEqual(self.exit_code, 1)
+        self.assertEqual(mock_print.call_count, 3)
+        self.assertIn("3 consecutive segments", logs.output[0])
+        self.assertIn("timed out", logs.output[0])
+        # The transcript produced before giving up is still saved
+        self.assertEqual(written, "\n\n\n")
+
+    def test_recovered_failures_do_not_stop_the_run(self):
+        """The failure counter only fires on consecutive failures."""
+        segments = live_segments(Failure(), Failure(), "hello", Failure(), Failure())
+        _, mock_print, written = self._run_live(["sys2txt", "live"], segments)
+
+        self.assertEqual(mock_print.call_count, 5)
+        self.assertEqual(written, "\n\nhello\n\n\n")
+        self.assertEqual(self.exit_code, 0)
 
     def test_keyboard_interrupt_saves_what_was_transcribed(self):
         def segments():

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,0 +1,235 @@
+"""Tests for sys2txt.formats module."""
+
+import json
+import unittest
+
+from sys2txt.formats import (
+    FORMAT_EXTENSIONS,
+    OUTPUT_FORMATS,
+    Cue,
+    Transcript,
+    format_timestamp,
+    get_formatter,
+    render_transcript,
+)
+
+HELLO_WORLD = (Cue(0.0, 1.5, "Hello"), Cue(1.5, 3.25, "world"))
+
+
+class TestCue(unittest.TestCase):
+    """Tests for the Cue dataclass."""
+
+    def test_shifted_moves_both_ends(self):
+        self.assertEqual(Cue(1.0, 2.0, "hi").shifted(8.0), Cue(9.0, 10.0, "hi"))
+
+    def test_shifted_leaves_the_original_alone(self):
+        cue = Cue(1.0, 2.0, "hi")
+        cue.shifted(8.0)
+        self.assertEqual(cue, Cue(1.0, 2.0, "hi"))
+
+
+class TestTranscript(unittest.TestCase):
+    """Tests for the Transcript dataclass."""
+
+    def test_text_joins_cues(self):
+        self.assertEqual(Transcript(cues=HELLO_WORLD).text, "Hello world")
+
+    def test_text_skips_empty_cues(self):
+        transcript = Transcript(cues=(Cue(0.0, 1.0, "Hello"), Cue(1.0, 2.0, "   "), Cue(2.0, 3.0, "world")))
+        self.assertEqual(transcript.text, "Hello world")
+
+    def test_empty_transcript(self):
+        self.assertEqual(Transcript().text, "")
+        self.assertIsNone(Transcript().language)
+
+
+class TestFormatTimestamp(unittest.TestCase):
+    """Tests for format_timestamp()."""
+
+    def test_zero(self):
+        self.assertEqual(format_timestamp(0.0), "00:00:00.000")
+
+    def test_milliseconds_are_rounded(self):
+        self.assertEqual(format_timestamp(1.2345), "00:00:01.234")
+        self.assertEqual(format_timestamp(1.2346), "00:00:01.235")
+
+    def test_minutes_and_hours_roll_over(self):
+        self.assertEqual(format_timestamp(61.5), "00:01:01.500")
+        self.assertEqual(format_timestamp(3661.5), "01:01:01.500")
+
+    def test_hours_beyond_a_day_keep_counting(self):
+        self.assertEqual(format_timestamp(90000.0), "25:00:00.000")
+
+    def test_subrip_uses_a_comma(self):
+        self.assertEqual(format_timestamp(5.12, decimal_separator=","), "00:00:05,120")
+
+    def test_negative_times_are_clamped(self):
+        self.assertEqual(format_timestamp(-3.0), "00:00:00.000")
+
+
+class TestRenderTxt(unittest.TestCase):
+    """Plain text output, which predates the other formats and must not change."""
+
+    def test_untimed_is_one_line(self):
+        self.assertEqual(render_transcript(HELLO_WORLD, "txt"), "Hello world")
+
+    def test_timestamps_give_one_line_per_cue(self):
+        self.assertEqual(
+            render_transcript(HELLO_WORLD, "txt", timestamps=True),
+            "[  0.00-  1.50] Hello\n[  1.50-  3.25] world",
+        )
+
+    def test_no_trailing_whitespace(self):
+        for timestamps in (False, True):
+            with self.subTest(timestamps=timestamps):
+                rendered = render_transcript(HELLO_WORLD, "txt", timestamps=timestamps)
+                self.assertEqual(rendered, rendered.strip())
+
+    def test_empty_cues_are_dropped_when_untimed(self):
+        cues = (Cue(0.0, 1.0, "Hello"), Cue(1.0, 2.0, ""), Cue(2.0, 3.0, "world"))
+        self.assertEqual(render_transcript(cues, "txt"), "Hello world")
+
+    def test_txt_is_the_default_format(self):
+        self.assertEqual(render_transcript(HELLO_WORLD), "Hello world")
+
+
+class TestRenderSrt(unittest.TestCase):
+    """SubRip output."""
+
+    def test_numbered_cue_blocks_with_comma_separators(self):
+        self.assertEqual(
+            render_transcript(HELLO_WORLD, "srt"),
+            "1\n00:00:00,000 --> 00:00:01,500\nHello\n\n2\n00:00:01,500 --> 00:00:03,250\nworld\n\n",
+        )
+
+    def test_empty_cues_do_not_consume_a_number(self):
+        cues = (Cue(0.0, 1.0, "Hello"), Cue(1.0, 2.0, "  "), Cue(2.0, 3.0, "world"))
+        rendered = render_transcript(cues, "srt")
+
+        self.assertEqual(
+            rendered,
+            "1\n00:00:00,000 --> 00:00:01,000\nHello\n\n2\n00:00:02,000 --> 00:00:03,000\nworld\n\n",
+        )
+
+    def test_empty_transcript_is_an_empty_document(self):
+        self.assertEqual(render_transcript((), "srt"), "")
+
+    def test_end_before_start_is_clamped(self):
+        self.assertIn("00:00:02,000 --> 00:00:02,000", render_transcript((Cue(2.0, 1.0, "oops"),), "srt"))
+
+
+class TestRenderVtt(unittest.TestCase):
+    """WebVTT output."""
+
+    def test_header_and_unnumbered_cue_blocks(self):
+        self.assertEqual(
+            render_transcript(HELLO_WORLD, "vtt"),
+            "WEBVTT\n\n00:00:00.000 --> 00:00:01.500\nHello\n\n00:00:01.500 --> 00:00:03.250\nworld\n\n",
+        )
+
+    def test_header_is_written_even_with_no_cues(self):
+        self.assertEqual(render_transcript((), "vtt"), "WEBVTT\n\n")
+
+    def test_cue_markup_is_escaped(self):
+        rendered = render_transcript((Cue(0.0, 1.0, "Tom & <b>Jerry</b>"),), "vtt")
+        self.assertIn("Tom &amp; &lt;b&gt;Jerry&lt;/b&gt;", rendered)
+
+    def test_ampersand_is_escaped_before_the_angle_brackets(self):
+        """Escaping in the wrong order would turn a literal < into &amp;lt;."""
+        self.assertIn("a &lt; b", render_transcript((Cue(0.0, 1.0, "a < b"),), "vtt"))
+
+
+class TestRenderJson(unittest.TestCase):
+    """openai-whisper's JSON schema."""
+
+    def test_document_shape(self):
+        document = json.loads(render_transcript(HELLO_WORLD, "json", language="en"))
+
+        self.assertEqual(
+            document,
+            {
+                "text": "Hello world",
+                "segments": [
+                    {"id": 0, "start": 0.0, "end": 1.5, "text": "Hello"},
+                    {"id": 1, "start": 1.5, "end": 3.25, "text": "world"},
+                ],
+                "language": "en",
+            },
+        )
+
+    def test_unknown_language_is_null(self):
+        self.assertIsNone(json.loads(render_transcript(HELLO_WORLD, "json"))["language"])
+
+    def test_empty_transcript_is_still_valid_json(self):
+        document = json.loads(render_transcript((), "json"))
+        self.assertEqual(document["segments"], [])
+        self.assertEqual(document["text"], "")
+
+    def test_ids_stay_contiguous_when_empty_cues_are_dropped(self):
+        cues = (Cue(0.0, 1.0, "Hello"), Cue(1.0, 2.0, ""), Cue(2.0, 3.0, "world"))
+        document = json.loads(render_transcript(cues, "json"))
+        self.assertEqual([segment["id"] for segment in document["segments"]], [0, 1])
+
+    def test_non_ascii_is_not_escaped(self):
+        self.assertIn("Grüße", render_transcript((Cue(0.0, 1.0, "Grüße"),), "json"))
+
+
+class TestRenderTsv(unittest.TestCase):
+    """Tab-separated output."""
+
+    def test_header_row_and_integer_milliseconds(self):
+        self.assertEqual(
+            render_transcript(HELLO_WORLD, "tsv"),
+            "start\tend\ttext\n0\t1500\tHello\n1500\t3250\tworld\n",
+        )
+
+    def test_text_never_contains_a_tab_or_newline(self):
+        rendered = render_transcript((Cue(0.0, 1.0, "one\ttwo\nthree"),), "tsv")
+        self.assertEqual(rendered.splitlines()[1], "0\t1000\tone two three")
+
+
+class TestGetFormatter(unittest.TestCase):
+    """Tests for the incremental formatter used by live mode."""
+
+    def test_streaming_matches_a_whole_document_render(self):
+        for output_format in OUTPUT_FORMATS:
+            with self.subTest(output_format=output_format):
+                formatter = get_formatter(output_format, language="en")
+                streamed = formatter.header()
+                for cue in HELLO_WORLD:
+                    streamed += formatter.cue(cue)
+                streamed += formatter.footer()
+
+                self.assertEqual(streamed, render_transcript(HELLO_WORLD, output_format, language="en"))
+
+    def test_json_is_written_entirely_by_the_footer(self):
+        """Live mode relies on this: the document cannot be closed until capture stops."""
+        formatter = get_formatter("json")
+        self.assertEqual(formatter.header(), "")
+        self.assertEqual([formatter.cue(cue) for cue in HELLO_WORLD], ["", ""])
+        self.assertIn("Hello world", formatter.footer())
+
+    def test_unknown_format_is_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            get_formatter("docx")
+        self.assertIn("docx", str(ctx.exception))
+
+    def test_render_rejects_an_unknown_format(self):
+        with self.assertRaises(ValueError):
+            render_transcript(HELLO_WORLD, "docx")
+
+
+class TestFormatRegistry(unittest.TestCase):
+    """Every declared format is renderable and has an extension."""
+
+    def test_every_format_has_an_extension(self):
+        self.assertEqual(sorted(FORMAT_EXTENSIONS), sorted(OUTPUT_FORMATS))
+
+    def test_every_format_renders(self):
+        for output_format in OUTPUT_FORMATS:
+            with self.subTest(output_format=output_format):
+                self.assertIsInstance(render_transcript(HELLO_WORLD, output_format), str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -22,6 +22,9 @@ class TestPublicApi(unittest.TestCase):
             sorted(sys2txt.__all__),
             [
                 "AudioSegment",
+                "Cue",
+                "OUTPUT_FORMATS",
+                "Transcript",
                 "TranscriptSegment",
                 "TranscriptionConfig",
                 "__version__",
@@ -29,9 +32,12 @@ class TestPublicApi(unittest.TestCase):
                 "iter_audio_segments",
                 "list_pulse_sources",
                 "record_once",
+                "render_transcript",
                 "transcribe_file",
+                "transcribe_file_cues",
                 "transcribe_live",
                 "transcribe_once",
+                "transcribe_once_cues",
             ],
         )
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,7 +5,14 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 from unittest.mock import MagicMock, patch
 
 from sys2txt.audio import AudioSegment
-from sys2txt.pipeline import TranscriptSegment, _segment_timeout, transcribe_live, transcribe_once
+from sys2txt.formats import Cue, Transcript
+from sys2txt.pipeline import (
+    TranscriptSegment,
+    _segment_timeout,
+    transcribe_live,
+    transcribe_once,
+    transcribe_once_cues,
+)
 from sys2txt.transcribe import TranscriptionConfig
 
 
@@ -13,6 +20,11 @@ def make_segments(count, start=0):
     """Yield AudioSegment values the way iter_audio_segments does."""
     for i in range(start, start + count):
         yield AudioSegment(index=i, path=f"/tmp/seg_{i:05d}.wav")
+
+
+def spoken(text, start=0.0, end=1.0):
+    """Build the Transcript an engine returns for one segment, timed from the segment start."""
+    return Transcript(cues=(Cue(start=start, end=end, text=text),))
 
 
 class ClosableSegments:
@@ -45,31 +57,44 @@ class TestTranscribeLive(unittest.TestCase):
     def setUp(self):
         self.config = TranscriptionConfig(model="tiny")
 
-    @patch("sys2txt.pipeline.transcribe_file")
+    @patch("sys2txt.pipeline.transcribe_file_cues")
     @patch("sys2txt.pipeline.iter_audio_segments")
     def test_yields_a_transcript_per_segment(self, mock_iter, mock_transcribe):
         """Each audio segment becomes a TranscriptSegment with its position on the timeline."""
         mock_iter.return_value = make_segments(2)
-        mock_transcribe.side_effect = ["hello", "world"]
+        mock_transcribe.side_effect = [spoken("hello"), spoken("world")]
 
         segments = list(transcribe_live("test.monitor", self.config, segment_seconds=8))
 
-        self.assertEqual(segments[0], TranscriptSegment(index=0, text="hello", start=0.0, end=8.0))
-        self.assertEqual(segments[1], TranscriptSegment(index=1, text="world", start=8.0, end=16.0))
+        self.assertEqual([s.text for s in segments], ["hello", "world"])
+        self.assertEqual([(s.index, s.start, s.end) for s in segments], [(0, 0.0, 8.0), (1, 8.0, 16.0)])
         mock_iter.assert_called_once_with("test.monitor", 8, sample_rate=16000, channels=1)
         self.assertEqual(mock_transcribe.call_args_list[0][0], ("/tmp/seg_00000.wav", self.config))
 
-    @patch("sys2txt.pipeline.transcribe_file")
+    @patch("sys2txt.pipeline.transcribe_file_cues")
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_cues_are_rebased_onto_the_recording_timeline(self, mock_iter, mock_transcribe):
+        """Engines time each segment from zero, so cues are shifted by the segment's start."""
+        mock_iter.return_value = make_segments(2)
+        mock_transcribe.side_effect = [spoken("hello", 0.5, 2.0), spoken("world", 1.0, 3.5)]
+
+        segments = list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+        self.assertEqual(segments[0].cues, (Cue(0.5, 2.0, "hello"),))
+        self.assertEqual(segments[1].cues, (Cue(9.0, 11.5, "world"),))
+
+    @patch("sys2txt.pipeline.transcribe_file_cues")
     @patch("sys2txt.pipeline.iter_audio_segments")
     def test_failed_segment_yields_empty_text(self, mock_iter, mock_transcribe):
         """A segment that fails to transcribe is yielded with empty text and a warning."""
         mock_iter.return_value = make_segments(2)
-        mock_transcribe.side_effect = [RuntimeError("engine exploded"), "recovered"]
+        mock_transcribe.side_effect = [RuntimeError("engine exploded"), spoken("recovered")]
 
         with self.assertLogs("sys2txt.pipeline", level="WARNING") as logs:
             segments = list(transcribe_live("test.monitor", self.config, segment_seconds=8))
 
         self.assertEqual([s.text for s in segments], ["", "recovered"])
+        self.assertEqual(segments[0].cues, ())
         self.assertIn("engine exploded", logs.output[0])
 
     @patch("sys2txt.pipeline.ThreadPoolExecutor")
@@ -90,7 +115,7 @@ class TestTranscribeLive(unittest.TestCase):
         future.result.assert_called_once_with(timeout=60)
         executor.shutdown.assert_called_once_with(wait=False)
 
-    @patch("sys2txt.pipeline.transcribe_file", return_value="hello")
+    @patch("sys2txt.pipeline.transcribe_file_cues", return_value=spoken("hello"))
     @patch("sys2txt.pipeline.iter_audio_segments")
     def test_closing_stops_the_audio_source(self, mock_iter, _transcribe):
         """Closing the transcript generator closes the underlying audio generator."""
@@ -104,7 +129,7 @@ class TestTranscribeLive(unittest.TestCase):
         self.assertEqual(first.index, 0)
         self.assertTrue(source.closed)
 
-    @patch("sys2txt.pipeline.transcribe_file", return_value="hello")
+    @patch("sys2txt.pipeline.transcribe_file_cues", return_value=spoken("hello"))
     @patch("sys2txt.pipeline.iter_audio_segments")
     def test_exhausting_the_generator_closes_the_audio_source(self, mock_iter, _transcribe):
         """Iterating to the end also releases the audio source."""
@@ -119,7 +144,7 @@ class TestTranscribeLive(unittest.TestCase):
 class TestTranscribeOnce(unittest.TestCase):
     """Tests for transcribe_once()."""
 
-    @patch("sys2txt.pipeline.transcribe_file", return_value="hello world")
+    @patch("sys2txt.pipeline.transcribe_file_cues", return_value=spoken("hello world"))
     @patch("sys2txt.pipeline.record_once")
     def test_records_then_transcribes(self, mock_record, mock_transcribe):
         config = TranscriptionConfig(model="tiny")
@@ -135,12 +160,20 @@ class TestTranscribeOnce(unittest.TestCase):
         # The recording is transcribed from the same temporary file
         self.assertEqual(mock_transcribe.call_args[0][0], record_args[0][1])
 
-    @patch("sys2txt.pipeline.transcribe_file", return_value="text")
+    @patch("sys2txt.pipeline.transcribe_file_cues", return_value=spoken("text"))
     @patch("sys2txt.pipeline.record_once")
     def test_records_until_interrupted_by_default(self, mock_record, _transcribe):
         transcribe_once("test.monitor", TranscriptionConfig())
 
         self.assertIsNone(mock_record.call_args[0][2])
+
+    @patch("sys2txt.pipeline.transcribe_file_cues", return_value=spoken("hello world", 0.5, 2.0))
+    @patch("sys2txt.pipeline.record_once")
+    def test_cues_variant_keeps_the_timings(self, _record, _transcribe):
+        """transcribe_once_cues() returns the engine's cues rather than flattened text."""
+        transcript = transcribe_once_cues("test.monitor", TranscriptionConfig(), 30)
+
+        self.assertEqual(transcript.cues, (Cue(0.5, 2.0, "hello world"),))
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -83,6 +83,17 @@ class TestTranscribeLive(unittest.TestCase):
         self.assertEqual(segments[0].cues, (Cue(0.5, 2.0, "hello"),))
         self.assertEqual(segments[1].cues, (Cue(9.0, 11.5, "world"),))
 
+    @patch("sys2txt.pipeline.transcribe_file_cues", return_value=spoken("hello"))
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_transcribed_segment_carries_no_error(self, mock_iter, _transcribe):
+        """A segment that transcribes cleanly is not marked as failed."""
+        mock_iter.return_value = make_segments(1)
+
+        segment = next(iter(transcribe_live("test.monitor", self.config, segment_seconds=8)))
+
+        self.assertIsNone(segment.error)
+        self.assertFalse(segment.failed)
+
     @patch("sys2txt.pipeline.transcribe_file_cues")
     @patch("sys2txt.pipeline.iter_audio_segments")
     def test_failed_segment_yields_empty_text(self, mock_iter, mock_transcribe):
@@ -96,6 +107,23 @@ class TestTranscribeLive(unittest.TestCase):
         self.assertEqual([s.text for s in segments], ["", "recovered"])
         self.assertEqual(segments[0].cues, ())
         self.assertIn("engine exploded", logs.output[0])
+
+    @patch("sys2txt.pipeline.transcribe_file_cues")
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_failed_segment_reports_why_it_failed(self, mock_iter, mock_transcribe):
+        """A failure is distinguishable from silence by the error it carries."""
+        mock_iter.return_value = make_segments(2)
+        mock_transcribe.side_effect = [RuntimeError("engine exploded"), Transcript()]
+
+        with self.assertLogs("sys2txt.pipeline", level="WARNING"):
+            failed, silent = list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+        self.assertTrue(failed.failed)
+        self.assertIn("engine exploded", failed.error)
+        # A silent segment looks the same in text alone, which is the bug this guards against
+        self.assertEqual(silent.text, failed.text)
+        self.assertFalse(silent.failed)
+        self.assertIsNone(silent.error)
 
     @patch("sys2txt.pipeline.ThreadPoolExecutor")
     @patch("sys2txt.pipeline.iter_audio_segments")
@@ -111,9 +139,33 @@ class TestTranscribeLive(unittest.TestCase):
             segments = list(transcribe_live("test.monitor", self.config, segment_seconds=8))
 
         self.assertEqual([s.text for s in segments], [""])
+        self.assertTrue(segments[0].failed)
+        self.assertIn("timed out after 60s", segments[0].error)
         self.assertIn("timed out", logs.output[0])
         future.result.assert_called_once_with(timeout=60)
-        executor.shutdown.assert_called_once_with(wait=False)
+        executor.shutdown.assert_called_with(wait=False)
+
+    @patch("sys2txt.pipeline.ThreadPoolExecutor")
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_timeout_abandons_the_pool_so_the_next_segment_is_transcribed(self, mock_iter, mock_executor_cls):
+        """The stranded worker is left behind rather than queueing the next segment behind it."""
+        mock_iter.return_value = make_segments(2)
+        stuck, recovered = MagicMock(), MagicMock()
+        stuck.result.side_effect = FuturesTimeoutError()
+        recovered.result.return_value = spoken("recovered")
+        first, second = MagicMock(), MagicMock()
+        first.submit.return_value = stuck
+        second.submit.return_value = recovered
+        mock_executor_cls.side_effect = [first, second]
+
+        with self.assertLogs("sys2txt.pipeline", level="WARNING"):
+            segments = list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+        self.assertEqual([s.text for s in segments], ["", "recovered"])
+        self.assertEqual(mock_executor_cls.call_count, 2)
+        first.shutdown.assert_called_once_with(wait=False)
+        second.submit.assert_called_once()
+        second.shutdown.assert_called_once_with(wait=False)
 
     @patch("sys2txt.pipeline.transcribe_file_cues", return_value=spoken("hello"))
     @patch("sys2txt.pipeline.iter_audio_segments")

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -6,7 +6,14 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from sys2txt.transcribe import TranscriptionConfig, transcribe_file
+from sys2txt.formats import Cue, Transcript
+from sys2txt.transcribe import TranscriptionConfig, transcribe_file, transcribe_file_cues
+
+
+def transcript(*texts, language=None):
+    """Build a Transcript with one one-second cue per text."""
+    cues = tuple(Cue(start=float(i), end=float(i + 1), text=text) for i, text in enumerate(texts))
+    return Transcript(cues=cues, language=language)
 
 
 class TestTranscribeFile(unittest.TestCase):
@@ -16,38 +23,38 @@ class TestTranscribeFile(unittest.TestCase):
         """Test transcribe_file() auto-selects faster-whisper when available."""
         with patch.dict("sys.modules", {"faster_whisper": MagicMock()}):
             with patch("sys2txt.transcribe._transcribe_faster_whisper") as mock_transcribe:
-                mock_transcribe.return_value = "test transcript"
+                mock_transcribe.return_value = transcript("test transcript")
                 result = transcribe_file("/path/to/audio.wav", TranscriptionConfig())
 
         self.assertEqual(result, "test transcript")
-        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, False, "auto")
+        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, "auto")
 
     @patch("sys2txt.transcribe._transcribe_faster_whisper")
     def test_transcribe_file_faster_engine(self, mock_transcribe):
         """Test transcribe_file() with explicit faster engine."""
-        mock_transcribe.return_value = "faster transcript"
+        mock_transcribe.return_value = transcript("faster transcript")
 
         config = TranscriptionConfig(engine="faster", model="base", language="en", timestamps=True)
         result = transcribe_file("/path/to/audio.wav", config)
 
-        self.assertEqual(result, "faster transcript")
-        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "base", "en", True, "auto")
+        self.assertEqual(result, "[  0.00-  1.00] faster transcript")
+        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "base", "en", "auto")
 
     @patch("sys2txt.transcribe._transcribe_openai_whisper")
     def test_transcribe_file_whisper_engine(self, mock_transcribe):
         """Test transcribe_file() with explicit whisper engine."""
-        mock_transcribe.return_value = "whisper transcript"
+        mock_transcribe.return_value = transcript("whisper transcript")
 
         config = TranscriptionConfig(engine="whisper", model="medium", language="fr")
         result = transcribe_file("/path/to/audio.wav", config)
 
         self.assertEqual(result, "whisper transcript")
-        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "medium", "fr", False)
+        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "medium", "fr")
 
     @patch("sys2txt.transcribe._transcribe_whisper_cpp")
     def test_transcribe_file_cpp_engine(self, mock_transcribe):
         """Test transcribe_file() with cpp engine."""
-        mock_transcribe.return_value = "cpp transcript"
+        mock_transcribe.return_value = transcript("cpp transcript")
 
         config = TranscriptionConfig(
             engine="cpp",
@@ -60,12 +67,11 @@ class TestTranscribeFile(unittest.TestCase):
         )
         result = transcribe_file("/path/to/audio.wav", config)
 
-        self.assertEqual(result, "cpp transcript")
+        self.assertEqual(result, "[  0.00-  1.00] cpp transcript")
         mock_transcribe.assert_called_once_with(
             "/path/to/audio.wav",
             "small",
             "en",
-            True,
             "/path/to/model.bin",
             "/path/to/whisper-cli",
             "vulkan",
@@ -75,22 +81,22 @@ class TestTranscribeFile(unittest.TestCase):
         """Test transcribe_file() auto falls back to openai-whisper when faster-whisper is not installed."""
         with patch.dict("sys.modules", {"faster_whisper": None, "whisper": MagicMock()}):
             with patch("sys2txt.transcribe._transcribe_openai_whisper") as mock_transcribe:
-                mock_transcribe.return_value = "fallback transcript"
+                mock_transcribe.return_value = transcript("fallback transcript")
                 result = transcribe_file("/path/to/audio.wav", TranscriptionConfig())
 
         self.assertEqual(result, "fallback transcript")
-        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, False)
+        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None)
 
     def test_transcribe_file_auto_falls_back_to_cpp(self):
         """Test transcribe_file() auto falls back to whisper.cpp when neither Python engine is installed."""
         with patch.dict("sys.modules", {"faster_whisper": None, "whisper": None}):
             with patch("sys2txt.transcribe._transcribe_whisper_cpp") as mock_transcribe:
-                mock_transcribe.return_value = "cpp fallback transcript"
+                mock_transcribe.return_value = transcript("cpp fallback transcript")
                 config = TranscriptionConfig()
                 result = transcribe_file("/path/to/audio.wav", config)
 
         self.assertEqual(result, "cpp fallback transcript")
-        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, False, None, None, "auto")
+        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, None, None, "auto")
 
     def test_transcribe_file_invalid_engine(self):
         """Test transcribe_file() raises ValueError for invalid engine."""
@@ -99,6 +105,27 @@ class TestTranscribeFile(unittest.TestCase):
 
         self.assertIn("Unknown engine", str(cm.exception))
         self.assertIn("invalid", str(cm.exception))
+
+
+class TestTranscribeFileCues(unittest.TestCase):
+    """Tests for the transcribe_file_cues() function."""
+
+    @patch("sys2txt.transcribe._transcribe_faster_whisper")
+    def test_returns_the_engine_transcript_unchanged(self, mock_transcribe):
+        """Test transcribe_file_cues() hands back the engine's cues and language."""
+        mock_transcribe.return_value = transcript("hello", language="en")
+
+        result = transcribe_file_cues("/path/to/audio.wav", TranscriptionConfig(engine="faster"))
+
+        self.assertEqual(result.cues, (Cue(0.0, 1.0, "hello"),))
+        self.assertEqual(result.language, "en")
+
+    def test_invalid_engine(self):
+        """Test transcribe_file_cues() raises ValueError for an invalid engine."""
+        with self.assertRaises(ValueError) as cm:
+            transcribe_file_cues("/path/to/audio.wav", TranscriptionConfig(engine="invalid"))
+
+        self.assertIn("Unknown engine", str(cm.exception))
 
 
 class TestTranscribeFasterWhisper(unittest.TestCase):
@@ -135,9 +162,9 @@ class TestTranscribeFasterWhisper(unittest.TestCase):
         mock_model = mock_model_class.return_value
         mock_model.transcribe.return_value = ([seg1, seg2], None)
 
-        result = _transcribe_faster_whisper("/path/to/audio.wav", "small", None, False)
+        result = _transcribe_faster_whisper("/path/to/audio.wav", "small", None)
 
-        self.assertEqual(result, "Hello world Test audio")
+        self.assertEqual(result.cues, (Cue(0.0, 1.5, "Hello world"), Cue(1.5, 3.0, "Test audio")))
         mock_model.transcribe.assert_called_once_with("/path/to/audio.wav", vad_filter=True, language=None)
 
     @patch("faster_whisper.WhisperModel")
@@ -159,10 +186,10 @@ class TestTranscribeFasterWhisper(unittest.TestCase):
         mock_model = mock_model_class.return_value
         mock_model.transcribe.return_value = ([seg1, seg2], None)
 
-        result = _transcribe_faster_whisper("/path/to/audio.wav", "base", "en", True)
+        result = _transcribe_faster_whisper("/path/to/audio.wav", "base", "en")
 
-        self.assertIn("[  0.00-  1.50] Hello", result)
-        self.assertIn("[  1.50-  3.00] world", result)
+        self.assertEqual(result.cues, (Cue(0.0, 1.5, "Hello"), Cue(1.5, 3.0, "world")))
+        self.assertEqual(result.language, "en")
         mock_model.transcribe.assert_called_once_with("/path/to/audio.wav", vad_filter=True, language="en")
 
     @patch("faster_whisper.WhisperModel")
@@ -174,7 +201,7 @@ class TestTranscribeFasterWhisper(unittest.TestCase):
         mock_model = mock_model_class.return_value
         mock_model.transcribe.return_value = ([], None)
 
-        _transcribe_faster_whisper("/path/to/audio.wav", "small", None, False, device="auto")
+        _transcribe_faster_whisper("/path/to/audio.wav", "small", None, device="auto")
 
         mock_model_class.assert_called_once_with("small", device="cuda", compute_type="float16")
 
@@ -186,7 +213,7 @@ class TestTranscribeFasterWhisper(unittest.TestCase):
         mock_model = mock_model_class.return_value
         mock_model.transcribe.return_value = ([], None)
 
-        _transcribe_faster_whisper("/path/to/audio.wav", "small", None, False, device="cuda")
+        _transcribe_faster_whisper("/path/to/audio.wav", "small", None, device="cuda")
 
         mock_model_class.assert_called_once_with("small", device="cuda", compute_type="float16")
 
@@ -198,7 +225,7 @@ class TestTranscribeFasterWhisper(unittest.TestCase):
         mock_model = mock_model_class.return_value
         mock_model.transcribe.return_value = ([], None)
 
-        _transcribe_faster_whisper("/path/to/audio.wav", "small", None, False, device="cpu")
+        _transcribe_faster_whisper("/path/to/audio.wav", "small", None, device="cpu")
 
         mock_model_class.assert_called_once_with("small", device="cpu", compute_type="int8")
 
@@ -209,7 +236,7 @@ class TestTranscribeFasterWhisper(unittest.TestCase):
         # Mock the import to fail at the point where it's actually imported in the function
         with patch.dict("sys.modules", {"faster_whisper": None}):
             with self.assertRaises(RuntimeError) as cm:
-                _transcribe_faster_whisper("/path/to/audio.wav", "small", None, False)
+                _transcribe_faster_whisper("/path/to/audio.wav", "small", None)
 
             self.assertIn("faster-whisper is not installed", str(cm.exception))
 
@@ -238,9 +265,9 @@ class TestTranscribeOpenAIWhisper(unittest.TestCase):
         mock_load_model.return_value = mock_model
         mock_model.transcribe.return_value = {"text": " Hello world "}
 
-        result = _transcribe_openai_whisper("/path/to/audio.wav", "small", None, False)
+        result = _transcribe_openai_whisper("/path/to/audio.wav", "small", None)
 
-        self.assertEqual(result, "Hello world")
+        self.assertEqual(result.cues, (Cue(0.0, 0.0, "Hello world"),))
         mock_load_model.assert_called_once_with("small")
         mock_model.transcribe.assert_called_once_with("/path/to/audio.wav", language=None)
 
@@ -259,10 +286,10 @@ class TestTranscribeOpenAIWhisper(unittest.TestCase):
             ],
         }
 
-        result = _transcribe_openai_whisper("/path/to/audio.wav", "base", "en", True)
+        result = _transcribe_openai_whisper("/path/to/audio.wav", "base", "en")
 
-        self.assertIn("[  0.00-  1.50] Hello", result)
-        self.assertIn("[  1.50-  3.00] world", result)
+        self.assertEqual(result.cues, (Cue(0.0, 1.5, "Hello"), Cue(1.5, 3.0, "world")))
+        self.assertEqual(result.language, "en")
         mock_model.transcribe.assert_called_once_with("/path/to/audio.wav", language="en")
 
     def test_transcribe_openai_whisper_not_installed(self):
@@ -272,7 +299,7 @@ class TestTranscribeOpenAIWhisper(unittest.TestCase):
         # Mock the import to fail at the point where it's actually imported in the function
         with patch.dict("sys.modules", {"whisper": None}):
             with self.assertRaises(RuntimeError) as cm:
-                _transcribe_openai_whisper("/path/to/audio.wav", "small", None, False)
+                _transcribe_openai_whisper("/path/to/audio.wav", "small", None)
 
             self.assertIn("openai-whisper is not installed", str(cm.exception))
 
@@ -402,28 +429,27 @@ class TestResolveWhisperCppModelPath(unittest.TestCase):
 class TestParseWhisperCppOutput(unittest.TestCase):
     """Tests for the _parse_whisper_cpp_output() function."""
 
-    def test_parse_with_timestamps(self):
-        """Test parsing whisper.cpp output with timestamps enabled."""
+    def test_parse_keeps_cue_times(self):
+        """Test parsing whisper.cpp output into cues that keep their times."""
         from sys2txt.transcribe import _parse_whisper_cpp_output
 
         output = """[00:00:00.000 --> 00:00:05.120]   Hello world
 [00:00:05.120 --> 00:00:10.240]   This is a test"""
 
-        result = _parse_whisper_cpp_output(output, timestamps=True)
+        result = _parse_whisper_cpp_output(output)
 
-        self.assertIn("[  0.00-  5.12] Hello world", result)
-        self.assertIn("[  5.12- 10.24] This is a test", result)
+        self.assertEqual(
+            result.cues,
+            (Cue(0.0, 5.12, "Hello world"), Cue(5.12, 10.24, "This is a test")),
+        )
 
-    def test_parse_without_timestamps(self):
-        """Test parsing whisper.cpp output without timestamps."""
+    def test_parse_records_the_language(self):
+        """Test that the requested language is recorded on the transcript."""
         from sys2txt.transcribe import _parse_whisper_cpp_output
 
-        output = """[00:00:00.000 --> 00:00:05.120]   Hello world
-[00:00:05.120 --> 00:00:10.240]   This is a test"""
+        result = _parse_whisper_cpp_output("[00:00:00.000 --> 00:00:05.120]   Bonjour", "fr")
 
-        result = _parse_whisper_cpp_output(output, timestamps=False)
-
-        self.assertEqual(result, "Hello world This is a test")
+        self.assertEqual(result.language, "fr")
 
     def test_parse_empty_segments_ignored(self):
         """Test that empty segments are ignored."""
@@ -433,9 +459,9 @@ class TestParseWhisperCppOutput(unittest.TestCase):
 [00:00:05.120 --> 00:00:10.240]
 [00:00:10.240 --> 00:00:15.000]   World"""
 
-        result = _parse_whisper_cpp_output(output, timestamps=False)
+        result = _parse_whisper_cpp_output(output)
 
-        self.assertEqual(result, "Hello World")
+        self.assertEqual(result.text, "Hello World")
 
     def test_parse_non_matching_lines_ignored(self):
         """Test that non-matching lines are ignored."""
@@ -445,9 +471,9 @@ class TestParseWhisperCppOutput(unittest.TestCase):
 [00:00:00.000 --> 00:00:05.120]   Hello world
 main: some debug output"""
 
-        result = _parse_whisper_cpp_output(output, timestamps=False)
+        result = _parse_whisper_cpp_output(output)
 
-        self.assertEqual(result, "Hello world")
+        self.assertEqual(result.text, "Hello world")
 
 
 class TestTimestampToSeconds(unittest.TestCase):
@@ -492,9 +518,9 @@ class TestTranscribeWhisperCpp(unittest.TestCase):
             returncode=0,
         )
 
-        result = _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, False, None, None, "auto")
+        result = _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, None, None, "auto")
 
-        self.assertEqual(result, "Hello world")
+        self.assertEqual(result.cues, (Cue(0.0, 5.0, "Hello world"),))
         mock_run.assert_called_once()
 
     @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
@@ -511,7 +537,7 @@ class TestTranscribeWhisperCpp(unittest.TestCase):
             returncode=0,
         )
 
-        _transcribe_whisper_cpp("/path/to/audio.wav", "small", "fr", False, None, None, "auto")
+        _transcribe_whisper_cpp("/path/to/audio.wav", "small", "fr", None, None, "auto")
 
         # Check -l fr is in the command
         call_args = mock_run.call_args[0][0]
@@ -532,7 +558,7 @@ class TestTranscribeWhisperCpp(unittest.TestCase):
             returncode=0,
         )
 
-        _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, False, None, None, "cpu")
+        _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, None, None, "cpu")
 
         call_args = mock_run.call_args[0][0]
         self.assertIn("--no-gpu", call_args)
@@ -551,7 +577,7 @@ class TestTranscribeWhisperCpp(unittest.TestCase):
             returncode=0,
         )
 
-        _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, False, None, None, "vulkan")
+        _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, None, None, "vulkan")
 
         call_args = mock_run.call_args[0][0]
         self.assertNotIn("--no-gpu", call_args)
@@ -575,11 +601,11 @@ class TestTranscribeWhisperCpp(unittest.TestCase):
             returncode=0,
         )
 
-        result = _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, False, None, None, "auto")
+        result = _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, None, None, "auto")
 
         call_args = mock_run.call_args[0][0]
         self.assertNotIn("--no-timestamps", call_args)
-        self.assertEqual(result, "Hello world")
+        self.assertEqual(result.text, "Hello world")
 
     @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
     @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
@@ -595,7 +621,7 @@ class TestTranscribeWhisperCpp(unittest.TestCase):
         mock_run.side_effect = subprocess.CalledProcessError(1, "whisper-cli", stderr="Error: model not found")
 
         with self.assertRaises(RuntimeError) as cm:
-            _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, False, None, None, "auto")
+            _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, None, None, "auto")
 
         self.assertIn("whisper-cli failed", str(cm.exception))
 
@@ -613,7 +639,7 @@ class TestTranscribeWhisperCpp(unittest.TestCase):
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="whisper-cli", timeout=300)
 
         with self.assertRaises(RuntimeError) as cm:
-            _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, False, None, None, "auto")
+            _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, None, None, "auto")
 
         self.assertIn("timed out", str(cm.exception))
 
@@ -654,7 +680,7 @@ class TestModelCacheThreadSafety(unittest.TestCase):
         def worker():
             try:
                 barrier.wait(timeout=5)
-                _transcribe_faster_whisper("/path/to/audio.wav", "small", None, False, device="cpu")
+                _transcribe_faster_whisper("/path/to/audio.wav", "small", None, device="cpu")
             except Exception as e:
                 errors.append(e)
 


### PR DESCRIPTION
## Why

sys2txt could only emit plain text. There is a settled answer to "what's the standard format for a speech-to-text transcript":

- **WebVTT** (`.vtt`) — the only one that is a real standard: a [W3C Candidate Recommendation](https://www.w3.org/TR/webvtt1/) from the Timed Text Working Group, loaded natively by a browser `<track>` element.
- **SubRip** (`.srt`) — no standards body, but the universal de-facto subtitle format.
- **JSON** / **TSV** — openai-whisper's own schemas, so existing tooling reads sys2txt output unchanged.

openai-whisper's CLI ships exactly this set (`--output_format txt|vtt|srt|tsv|json`), so this follows a well-trodden path rather than inventing one.

## What

A `--format {txt,srt,vtt,json,tsv}` flag on both `once` and `live`, defaulting to `txt`. It applies to stdout and the output file alike, and a generated output filename now takes the format's extension (`./output/<timestamp>.srt`).

```bash
sys2txt once --input talk.wav --format srt --output talk.srt
sys2txt live --format vtt --silence-timeout 30 --output meeting.vtt
```

The blocker was architectural: `transcribe_file()` returned a plain `str`, and every engine baked timings into an `f"[{start:6.2f}-{end:6.2f}] "` prefix and threw the floats away. So:

- New `formats.py` holds `Cue(start, end, text)`, `Transcript(cues, language)` and the renderers. A single formatter serves both the whole-document render `once` mode uses and the incremental one `live` mode streams through, so the two paths cannot drift. JSON buffers and emits from the footer, which runs after the loop so Ctrl-C and `--silence-timeout` both close the document.
- Engines now return a `Transcript`; the `timestamps` bool drops out of their signatures. `transcribe_file()` stays and renders text over the new entry point, joined by `transcribe_file_cues()` / `transcribe_once_cues()` and `render_transcript()` in the public API.

### Bug fixed on the way

Engines time each segment from zero, and live mode never rebased those times. With `--timestamps` you got:

```
[    8-   16s] [  0.00-  1.50] hello
```

a coarse segment window wrapping a misleading inner time. Cues are now shifted onto the timeline of the recording as a whole, so cue times keep increasing across segments.

## Compatibility

- Default `txt` output is **byte-identical** to before, with and without `--timestamps` — verified by diffing the CLI's output against the pre-change modules run from `git show HEAD:`.
- `--timestamps` with a timed format logs a warning (it adds nothing) rather than erroring.
- In live mode `txt` still appends to an existing file; the timed formats replace it, since cue numbering and JSON syntax cannot resume mid-file.
- Stdlib only — the package stays dependency-free.

## Testing

- `python -m unittest discover -s tests -p "test_*.py"` — 177 tests pass; `ruff format --check src/` and `ruff check src/` clean.
- New `tests/test_formats.py` (37 tests): timestamp formatting and hour rollover, the SRT comma separator, cue numbering with empty cues dropped, WebVTT header and markup escaping, the JSON schema, TSV milliseconds, and streaming output matching a whole-document render for every format.
- New CLI tests per format for both modes, including JSON being closed on Ctrl-C and on the silence timeout.
- End-to-end: ran the CLI for each format against a stub engine and parsed the results back with `webvtt-py` (an independent parser) — 3 cues each from the `.srt` and `.vtt`, valid JSON, well-formed TSV. Also drove `live` through the real pipeline with a stubbed audio source: cue numbers run continuously 1–9 across three segments with times rebased by `index × 8s`.

Live capture against a real PulseAudio source was not exercised — no audio device in the environment — so that path rests on the unit tests and the stubbed pipeline run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cpk8vog8jJkXpGfxECkLYj)_