### PR TITLE
refactor: replace engine dispatch and global model cache with a TranscriptionEngine protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,24 +100,33 @@ The codebase is organized into focused modules by functionality:
 - `get_default_monitor_source()`: Uses `pactl get-default-sink` to find default monitor source, with fallback logic to first `.monitor` source or "default"
 - `run_command()`: Helper for running system commands
 
-**transcribe.py** - Whisper transcription:
-- `TranscriptionConfig`: Dataclass bundling engine, model, device, language, timestamps, model_path, and whisper_cpp_path
-- `transcribe_file_cues(path, config)`: Main entry point. Resolves the engine and returns a `Transcript` of timed `Cue` values
-- `transcribe_file(path, config)`: The text form, `render_transcript(..., "txt", timestamps=config.timestamps)` over the above. Output is unchanged from before formats existed
-- `_transcribe_faster_whisper()`: Uses faster_whisper.WhisperModel with VAD filter
-- `_transcribe_openai_whisper()`: Uses whisper.load_model() and model.transcribe()
-- `_transcribe_whisper_cpp()`: Runs whisper-cli subprocess with GPU/CPU support
+**engines.py** - The transcription engines and the registry that selects between them:
+- `TranscriptionConfig`: Dataclass bundling engine, model, device, language, timestamps, model_path, and whisper_cpp_path. Engines take it whole; nothing destructures it into positional arguments
+- `TranscriptionEngine`: `Protocol` of `name`, `is_available()`, `transcribe(path, config) -> Transcript` and `unload()`
+- `_CachedModelEngine`: Base for engines that load a model. Holds the model, its key and a lock as instance state, reloading only when the key changes. One model per engine: a second would double the memory a transcription needs, and a run only ever uses one
+- `FasterWhisperEngine` (`faster`): faster_whisper.WhisperModel with VAD filter, keyed on `(model, device, compute_type)`
+- `OpenAIWhisperEngine` (`whisper`): `whisper.load_model(model, device=...)`, keyed on `(model, device)`
+- `WhisperCppEngine` (`cpp`): Runs the whisper-cli subprocess with GPU/CPU support. Caches nothing, since the binary loads its own model
+- `_resolve_device()`: `auto` reads `SYS2TXT_DEVICE` then falls back to CPU; the whisper.cpp-only GPU choices (`vulkan`, `gpu`) resolve to CPU for the Python engines
 - `_resolve_whisper_cpp_binary()`: Resolves whisper-cli path from arg/env/PATH
 - `_resolve_whisper_cpp_model_path()`: Resolves model path from arg/env/default
 - `_parse_whisper_cpp_output()`: Parses whisper.cpp's `[HH:MM:SS.mmm --> HH:MM:SS.mmm]` lines into cues
+- `ENGINES`: The registry, in the order `auto` prefers them. `ENGINE_NAMES` derives the `--engine` choices from it, so adding an engine means writing one class and adding it here
+- `get_engine(name)`: `auto` returns the first engine whose `is_available()` is true, raising `RuntimeError` naming all of them if none is installed; a named engine is returned without the availability check, so the user gets that backend's own diagnostic; anything else raises `ValueError`
+- Backends are imported inside the engine that needs them, so importing the package stays cheap
 - Every engine returns a `Transcript`, keeping real per-utterance times; `config.timestamps` only affects plain-text rendering, which happens in `formats.py`
+
+**transcribe.py** - The transcription entry points:
+- `transcribe_file_cues(path, config)`: Asks `get_engine()` for the engine and hands it the config, returning a `Transcript` of timed `Cue` values
+- `transcribe_file(path, config)`: The text form, `render_transcript(..., "txt", timestamps=config.timestamps)` over the above. Output is unchanged from before formats existed
+- Re-exports `TranscriptionConfig` from `engines.py`, so `from sys2txt.transcribe import TranscriptionConfig` keeps working
 
 **constants.py** - Configuration shared by library and CLI: default model, capture `SAMPLE_RATE`/`CHANNELS`, segment length and poll interval, minimum segment size, ffmpeg shutdown grace, transcription timeouts, `MAX_CONSECUTIVE_SEGMENT_FAILURES`, default output format.
 
 **utils.py** - Utility functions:
 - `which()`: Find command in PATH or raise RuntimeError
 
-**__init__.py** - The public API. Exports `AudioSegment`, `Cue`, `OUTPUT_FORMATS`, `Transcript`, `TranscriptSegment`, `TranscriptionConfig`, `get_default_monitor_source`, `iter_audio_segments`, `list_pulse_sources`, `record_once`, `render_transcript`, `transcribe_file`, `transcribe_file_cues`, `transcribe_live`, `transcribe_once`, `transcribe_once_cues` and `__version__`. Engine imports stay lazy so importing the package is cheap.
+**__init__.py** - The public API. Exports `AudioSegment`, `Cue`, `ENGINE_NAMES`, `OUTPUT_FORMATS`, `Transcript`, `TranscriptSegment`, `TranscriptionConfig`, `TranscriptionEngine`, `get_default_monitor_source`, `iter_audio_segments`, `list_pulse_sources`, `record_once`, `render_transcript`, `transcribe_file`, `transcribe_file_cues`, `transcribe_live`, `transcribe_once`, `transcribe_once_cues` and `__version__`. Engine imports stay lazy so importing the package is cheap.
 
 **__main__.py** - CLI entry point, and the only module that prints:
 - argparse with subcommands: `once` and `live`, built by `_build_parser()`
@@ -224,7 +233,8 @@ ruff check --fix src/
 - `src/sys2txt/audio.py`: Audio recording with ffmpeg
 - `src/sys2txt/formats.py`: Transcript cues and the txt/srt/vtt/json/tsv renderers
 - `src/sys2txt/pipeline.py`: Recording and transcription combined (`transcribe_live`, `transcribe_once`)
-- `src/sys2txt/transcribe.py`: Whisper transcription engines
+- `src/sys2txt/engines.py`: The transcription engines, the `TranscriptionEngine` protocol and the registry
+- `src/sys2txt/transcribe.py`: Transcription entry points over the engine registry
 - `src/sys2txt/pulse.py`: PulseAudio/PipeWire source management
 - `src/sys2txt/constants.py`: Shared configuration values
 - `src/sys2txt/utils.py`: Utility functions
@@ -233,7 +243,8 @@ ruff check --fix src/
 - `tests/`: Unit tests for all modules (using unittest framework)
   - `tests/test_utils.py`: Tests for utility functions
   - `tests/test_pulse.py`: Tests for PulseAudio integration
-  - `tests/test_transcribe.py`: Tests for transcription engines
+  - `tests/test_transcribe.py`: Tests for the transcription entry points
+  - `tests/test_engines.py`: Tests for the engines, the registry and the model cache
   - `tests/test_audio.py`: Tests for audio recording
   - `tests/test_formats.py`: Tests for the transcript output formats
   - `tests/test_pipeline.py`: Tests for the recording/transcription pipeline

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ You can use any of three transcription engines:
 - `openai-whisper` - Reference Python implementation
 - [`whisper.cpp`](https://github.com/ggerganov/whisper.cpp) - C++ implementation with Vulkan GPU support for AMD GPUs
 
-The tool auto-selects `faster-whisper` when available for better speed.
+The tool auto-selects the first engine that is installed, preferring `faster-whisper` for its speed,
+then `openai-whisper`, then `whisper.cpp`. With none of them installed it says so, rather than
+failing part-way through one of them.
 
 ## Installation
 
@@ -76,7 +78,8 @@ sys2txt live --model small.en --segment-seconds 8
 - `--list-sources` - List available Pulse sources and exit
 - `--model <size>` - tiny|base|small|medium|large-v2 (default: small)
 - `--engine <auto|faster|whisper|cpp>` - Force a specific engine (default: auto)
-- `--device <auto|cpu|vulkan|gpu|cuda>` - Device for transcription (default: auto)
+- `--device <auto|cpu|vulkan|gpu|cuda>` - Device for transcription (default: auto). `cuda` applies to the
+  Python engines (`faster`, `whisper`), `vulkan`/`gpu` to `cpp`; `auto` reads `SYS2TXT_DEVICE`, else CPU
 - `--language <code>` - Force language code (e.g., en). Omit to auto-detect
 - `--format <txt|srt|vtt|json|tsv>` - Transcript format (default: txt). See [Output formats](#output-formats)
 - `--output <path>` - Write the transcript to a file. Without it, one is written to
@@ -286,6 +289,7 @@ sys2txt once --engine cpp --model small --device cpu
 - PipeWire systems expose PulseAudio-compatible sources, so `-f pulse` in ffmpeg still works.
 - For better performance on CPU, use faster-whisper with model `base` or `small`. For the best accuracy, use `medium` or `large-v2` (these are heavier).
 - GPU acceleration for faster-whisper requires a compatible ctranslate2 CUDA wheel. Set `SYS2TXT_DEVICE=cuda` or use `--device cuda` to enable it.
+- `SYS2TXT_DEVICE`/`--device` apply to openai-whisper too, which needs a CUDA-capable PyTorch build for `cuda`.
 - For AMD GPUs, use whisper.cpp with Vulkan support (see above).
 
 ## Contributing

--- a/src/sys2txt/__init__.py
+++ b/src/sys2txt/__init__.py
@@ -16,6 +16,7 @@ TSV with :func:`render_transcript`.
 from importlib.metadata import PackageNotFoundError, version
 
 from .audio import AudioSegment, iter_audio_segments, record_once
+from .engines import ENGINE_NAMES, TranscriptionEngine
 from .formats import OUTPUT_FORMATS, Cue, Transcript, render_transcript
 from .pipeline import TranscriptSegment, transcribe_live, transcribe_once, transcribe_once_cues
 from .pulse import get_default_monitor_source, list_pulse_sources
@@ -29,10 +30,12 @@ except PackageNotFoundError:  # running from a source tree without an installed 
 __all__ = [
     "AudioSegment",
     "Cue",
+    "ENGINE_NAMES",
     "OUTPUT_FORMATS",
     "Transcript",
     "TranscriptSegment",
     "TranscriptionConfig",
+    "TranscriptionEngine",
     "__version__",
     "get_default_monitor_source",
     "iter_audio_segments",

--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -17,6 +17,7 @@ from .constants import (
     MAX_CONSECUTIVE_SEGMENT_FAILURES,
     WHISPER_MODEL,
 )
+from .engines import ENGINE_NAMES
 from .formats import FORMAT_EXTENSIONS, OUTPUT_FORMATS, TIMED_FORMATS, get_formatter, render_transcript
 from .pipeline import TranscriptSegment, transcribe_live, transcribe_once_cues
 from .pulse import get_default_monitor_source, list_pulse_sources
@@ -232,7 +233,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     common.add_argument(
         "--engine",
-        choices=["auto", "faster", "whisper", "cpp"],
+        choices=list(ENGINE_NAMES),
         default="auto",
         help="Transcription engine (default: auto)",
     )

--- a/src/sys2txt/engines.py
+++ b/src/sys2txt/engines.py
@@ -1,0 +1,453 @@
+"""Transcription engines and the registry that selects between them.
+
+An engine turns an audio file into a :class:`~sys2txt.formats.Transcript`. Each one
+answers for itself what it is called, whether it can run here, and how to transcribe;
+selecting between them is walking a registry, not a chain of ``if``\\ s.
+
+    from sys2txt.engines import TranscriptionConfig, get_engine
+
+    engine = get_engine("auto")
+    transcript = engine.transcribe("audio.wav", TranscriptionConfig(model="small"))
+
+Adding an engine means writing one class and adding it to :data:`ENGINES`; the ``auto``
+preference order, the ``--engine`` choices and the "nothing is installed" error all
+follow from the registry.
+
+Backends are imported inside the engine that needs them, so importing this module costs
+nothing and an uninstalled backend is a ``False`` from :meth:`is_available`, not an
+``ImportError`` at import time.
+"""
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Protocol, Tuple, runtime_checkable
+
+from .constants import WHISPER_CPP_TIMEOUT
+from .formats import Cue, Transcript
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TranscriptionConfig:
+    """Configuration for transcription that stays constant across calls."""
+
+    engine: str = "auto"
+    model: str = "small"
+    device: str = "auto"
+    language: Optional[str] = None
+    timestamps: bool = False
+    model_path: Optional[str] = None
+    whisper_cpp_path: Optional[str] = None
+
+
+@runtime_checkable
+class TranscriptionEngine(Protocol):
+    """One way of turning audio into a transcript.
+
+    Attributes:
+        name: The engine's ``--engine`` name
+    """
+
+    name: str
+
+    def is_available(self) -> bool:
+        """Return whether this engine can run on this machine.
+
+        Only ``auto`` selection consults this. Naming an engine explicitly runs it
+        regardless, so the user gets the backend's own diagnostic rather than a
+        generic "not available".
+        """
+        ...
+
+    def transcribe(self, path: str, config: TranscriptionConfig) -> Transcript:
+        """Transcribe an audio file into timed cues.
+
+        Args:
+            path: Path to the audio file
+            config: Transcription configuration
+
+        Returns:
+            The transcript, with cue times in seconds from the start of the file
+        """
+        ...
+
+    def unload(self) -> None:
+        """Release any cached model, freeing the memory it holds."""
+        ...
+
+
+def _resolve_device(device: str) -> str:
+    """Resolve a ``--device`` choice to a device the Python backends understand.
+
+    ``auto`` defers to ``SYS2TXT_DEVICE`` and then to CPU. The GPU choices that only
+    whisper.cpp can honour (``vulkan``, ``gpu``) fall back to CPU here.
+
+    Args:
+        device: Device as chosen on the command line
+
+    Returns:
+        Either ``"cuda"`` or ``"cpu"``
+    """
+    if device == "auto":
+        device = os.environ.get("SYS2TXT_DEVICE", "cpu")
+    return "cuda" if device == "cuda" else "cpu"
+
+
+class _CachedModelEngine:
+    """Base for engines that load a model into memory and reuse it.
+
+    Loading a Whisper model costs seconds, which live mode would otherwise pay for every
+    segment, so the loaded model is kept until a call asks for a different one. The cache
+    holds a single model: a second one would double the memory a transcription needs, and
+    a run only ever uses one.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._key: Optional[Tuple[Any, ...]] = None
+        self._model: Any = None
+
+    def _get_model(self, key: Tuple[Any, ...], load: Callable[[], Any]) -> Any:
+        """Return the cached model for ``key``, loading it if it is not the cached one."""
+        with self._lock:
+            if self._key != key:
+                self._model = load()
+                self._key = key
+            return self._model
+
+    def unload(self) -> None:
+        """Drop the cached model, releasing the memory it holds."""
+        with self._lock:
+            self._model = None
+            self._key = None
+
+
+class FasterWhisperEngine(_CachedModelEngine):
+    """faster-whisper: the ctranslate2 reimplementation, and the preferred engine."""
+
+    name = "faster"
+
+    def is_available(self) -> bool:
+        try:
+            import faster_whisper  # noqa: F401
+        except ImportError:
+            return False
+        return True
+
+    def transcribe(self, path: str, config: TranscriptionConfig) -> Transcript:
+        try:
+            from faster_whisper import WhisperModel  # type: ignore
+        except ImportError as e:
+            raise RuntimeError("faster-whisper is not installed. pip install faster-whisper") from e
+
+        device = _resolve_device(config.device)
+        compute_type = "float16" if device == "cuda" else "int8"
+
+        def load() -> Any:
+            logger.info("Loading faster-whisper model '%s' on %s (%s)", config.model, device, compute_type)
+            return WhisperModel(config.model, device=device, compute_type=compute_type)
+
+        model = self._get_model((config.model, device, compute_type), load)
+        segments, info = model.transcribe(path, vad_filter=True, language=config.language)
+        cues = tuple(Cue(start=float(seg.start), end=float(seg.end), text=seg.text.strip()) for seg in segments)
+        return Transcript(cues=cues, language=getattr(info, "language", None) or config.language)
+
+
+class OpenAIWhisperEngine(_CachedModelEngine):
+    """openai-whisper: the reference implementation, used when faster-whisper is absent."""
+
+    name = "whisper"
+
+    def is_available(self) -> bool:
+        try:
+            import whisper  # noqa: F401
+        except ImportError:
+            return False
+        return True
+
+    def transcribe(self, path: str, config: TranscriptionConfig) -> Transcript:
+        try:
+            import whisper  # type: ignore
+        except ImportError as e:
+            raise RuntimeError("openai-whisper is not installed. pip install openai-whisper") from e
+
+        device = _resolve_device(config.device)
+
+        def load() -> Any:
+            logger.info("Loading openai-whisper model '%s' on %s", config.model, device)
+            return whisper.load_model(config.model, device=device)
+
+        model = self._get_model((config.model, device), load)
+        result = model.transcribe(path, language=config.language)
+        detected = result.get("language") or config.language
+        segments = result.get("segments") or []
+        if segments:
+            cues = tuple(
+                Cue(
+                    start=float(seg.get("start", 0.0)),
+                    end=float(seg.get("end", 0.0)),
+                    text=seg.get("text", "").strip(),
+                )
+                for seg in segments
+            )
+        else:
+            # Untimed fallback: the whole transcript as a single cue of unknown extent.
+            text = result.get("text", "").strip()
+            cues = (Cue(start=0.0, end=0.0, text=text),) if text else ()
+        return Transcript(cues=cues, language=detected)
+
+
+def _resolve_whisper_cpp_binary(whisper_cpp_path: Optional[str]) -> str:
+    """Resolve the path to the whisper-cli binary.
+
+    Priority:
+    1. Explicit path argument
+    2. SYS2TXT_WHISPER_CPP environment variable
+    3. PATH lookup for 'whisper-cli'
+
+    Args:
+        whisper_cpp_path: Explicit path to whisper-cli binary
+
+    Returns:
+        Path to whisper-cli binary
+
+    Raises:
+        RuntimeError: If binary cannot be found
+    """
+    if whisper_cpp_path:
+        if not os.path.isfile(whisper_cpp_path):
+            raise RuntimeError(f"whisper-cli binary not found at: {whisper_cpp_path}")
+        return whisper_cpp_path
+
+    env_path = os.environ.get("SYS2TXT_WHISPER_CPP")
+    if env_path:
+        if not os.path.isfile(env_path):
+            raise RuntimeError(f"whisper-cli binary not found at SYS2TXT_WHISPER_CPP: {env_path}")
+        return env_path
+
+    path_lookup = shutil.which("whisper-cli")
+    if path_lookup:
+        return path_lookup
+
+    raise RuntimeError(
+        "whisper-cli binary not found. Install whisper.cpp and either:\n"
+        "  1. Add whisper-cli to PATH\n"
+        "  2. Set SYS2TXT_WHISPER_CPP environment variable\n"
+        "  3. Use --whisper-cpp-path argument"
+    )
+
+
+def _resolve_whisper_cpp_model_path(model_path: Optional[str], model_size: str) -> str:
+    """Resolve the path to a whisper.cpp model file.
+
+    Priority:
+    1. Explicit model_path argument
+    2. SYS2TXT_WHISPER_CPP_MODELS directory + ggml-{model_size}.bin
+    3. ~/.local/share/whisper.cpp/models/ggml-{model_size}.bin
+
+    Args:
+        model_path: Explicit path to model file
+        model_size: Whisper model size (tiny, base, small, medium, large-v2)
+
+    Returns:
+        Path to model file
+
+    Raises:
+        RuntimeError: If model file cannot be found
+    """
+    if model_path:
+        if not os.path.isfile(model_path):
+            raise RuntimeError(f"whisper.cpp model not found at: {model_path}")
+        return model_path
+
+    model_filename = f"ggml-{model_size}.bin"
+
+    env_models_dir = os.environ.get("SYS2TXT_WHISPER_CPP_MODELS")
+    if env_models_dir:
+        env_model_path = os.path.join(env_models_dir, model_filename)
+        if os.path.isfile(env_model_path):
+            return env_model_path
+
+    default_dir = Path.home() / ".local" / "share" / "whisper.cpp" / "models"
+    default_path = default_dir / model_filename
+    if default_path.is_file():
+        return str(default_path)
+
+    raise RuntimeError(
+        f"whisper.cpp model '{model_filename}' not found. Either:\n"
+        "  1. Use --model-path to specify the model file\n"
+        f"  2. Set SYS2TXT_WHISPER_CPP_MODELS to directory containing {model_filename}\n"
+        f"  3. Place model at {default_path}"
+    )
+
+
+def _timestamp_to_seconds(ts: str) -> float:
+    """Convert HH:MM:SS.mmm timestamp to seconds.
+
+    Args:
+        ts: Timestamp string like "00:01:23.456"
+
+    Returns:
+        Time in seconds as float
+    """
+    try:
+        parts = ts.split(":")
+        hours = int(parts[0])
+        minutes = int(parts[1])
+        seconds = float(parts[2])
+        return hours * 3600 + minutes * 60 + seconds
+    except (IndexError, ValueError):
+        return 0.0
+
+
+def _parse_whisper_cpp_output(output: str, language: Optional[str] = None) -> Transcript:
+    """Parse whisper.cpp stdout format.
+
+    Whisper.cpp outputs lines like:
+    [00:00:00.000 --> 00:00:05.120]   Hello world
+
+    Args:
+        output: Raw stdout from whisper-cli
+        language: Language code the caller asked for, recorded on the transcript
+
+    Returns:
+        The transcript parsed out of the timestamped lines
+    """
+    cues: List[Cue] = []
+    # Pattern: [HH:MM:SS.mmm --> HH:MM:SS.mmm] text
+    pattern = re.compile(r"\[(\d{2}:\d{2}:\d{2}\.\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}\.\d{3})\]\s*(.*)")
+
+    for line in output.splitlines():
+        match = pattern.match(line.strip())
+        if match:
+            start_str, end_str, text = match.groups()
+            text = text.strip()
+            if not text:
+                continue
+            cues.append(
+                Cue(
+                    start=_timestamp_to_seconds(start_str),
+                    end=_timestamp_to_seconds(end_str),
+                    text=text,
+                )
+            )
+
+    return Transcript(cues=tuple(cues), language=language)
+
+
+class WhisperCppEngine:
+    """whisper.cpp: an external whisper-cli binary, with optional Vulkan GPU support.
+
+    Nothing is cached: each transcription is a subprocess that loads the model itself.
+    """
+
+    name = "cpp"
+
+    def is_available(self) -> bool:
+        """Return whether a whisper-cli binary can be found on PATH or in the environment.
+
+        An explicit ``--whisper-cpp-path`` is not visible here, but a user who passes it
+        also names ``--engine cpp``, which skips this probe.
+        """
+        try:
+            _resolve_whisper_cpp_binary(None)
+        except RuntimeError:
+            return False
+        return True
+
+    def unload(self) -> None:
+        """No cached model to release."""
+
+    def transcribe(self, path: str, config: TranscriptionConfig) -> Transcript:
+        """Transcribe by running whisper-cli and parsing its timestamped output.
+
+        Raises:
+            RuntimeError: If whisper-cli or its model cannot be found, or it fails
+        """
+        binary = _resolve_whisper_cpp_binary(config.whisper_cpp_path)
+        model = _resolve_whisper_cpp_model_path(config.model_path, config.model)
+
+        # Build command
+        cmd = [binary, "-m", model, "-f", path, "-np"]  # -np = no progress
+
+        # Device selection
+        if config.device == "cpu":
+            cmd.append("--no-gpu")
+        # For auto/vulkan/gpu/cuda, let whisper.cpp use GPU if available
+
+        if config.language:
+            cmd.extend(["-l", config.language])
+
+        logger.debug("Running whisper-cli: %s", " ".join(cmd))
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=WHISPER_CPP_TIMEOUT)
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(
+                f"whisper-cli timed out after {WHISPER_CPP_TIMEOUT} seconds "
+                f"(possible GPU hang or malformed audio): {binary}"
+            ) from e
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.strip() if e.stderr else "No error output"
+            raise RuntimeError(f"whisper-cli failed: {stderr}") from e
+        except FileNotFoundError as e:
+            raise RuntimeError(f"whisper-cli binary not found: {binary}") from e
+
+        return _parse_whisper_cpp_output(result.stdout, config.language)
+
+
+ENGINES: Tuple[TranscriptionEngine, ...] = (
+    FasterWhisperEngine(),
+    OpenAIWhisperEngine(),
+    WhisperCppEngine(),
+)
+"The available engines, in the order ``auto`` prefers them"
+
+ENGINE_NAMES: Tuple[str, ...] = ("auto",) + tuple(engine.name for engine in ENGINES)
+"Valid ``--engine`` values: ``auto`` plus every registered engine"
+
+_INSTALL_HINTS = {
+    "faster": "pip install faster-whisper",
+    "whisper": "pip install openai-whisper",
+    "cpp": "build whisper.cpp and put whisper-cli on PATH",
+}
+
+
+def get_engine(name: str) -> TranscriptionEngine:
+    """Return the engine to transcribe with.
+
+    Args:
+        name: An engine name, or ``"auto"`` to pick the first available one
+
+    Returns:
+        The selected engine
+
+    Raises:
+        ValueError: If ``name`` is not a known engine
+        RuntimeError: If ``name`` is ``"auto"`` and no engine is installed
+    """
+    if name == "auto":
+        for engine in ENGINES:
+            if engine.is_available():
+                logger.debug("Auto-selected transcription engine: %s", engine.name)
+                return engine
+        installs = "\n".join(f"  {engine.name}: {_INSTALL_HINTS[engine.name]}" for engine in ENGINES)
+        raise RuntimeError(f"No transcription engine is installed. Install one of:\n{installs}")
+
+    for engine in ENGINES:
+        if engine.name == name:
+            return engine
+
+    raise ValueError(f"Unknown engine: {name}")
+
+
+def unload_engines() -> None:
+    """Release every engine's cached model."""
+    for engine in ENGINES:
+        engine.unload()

--- a/src/sys2txt/transcribe.py
+++ b/src/sys2txt/transcribe.py
@@ -1,40 +1,19 @@
-"""Transcription functionality using Whisper models."""
+"""Transcription entry points.
+
+Turning an audio file into a transcript is two decisions: which engine, and what the
+result should look like. This module makes the first by asking
+:func:`sys2txt.engines.get_engine`, and leaves the second to :mod:`sys2txt.formats`.
+The engines themselves live in :mod:`sys2txt.engines`.
+"""
 
 import logging
-import os
-import re
-import shutil
-import subprocess
-import threading
-from dataclasses import dataclass
-from pathlib import Path
-from typing import List, Optional
 
-from .constants import WHISPER_CPP_TIMEOUT
-from .formats import Cue, Transcript, render_transcript
+from .engines import TranscriptionConfig, get_engine
+from .formats import Transcript, render_transcript
 
 logger = logging.getLogger(__name__)
 
-
-@dataclass
-class TranscriptionConfig:
-    """Configuration for transcription that stays constant across calls."""
-
-    engine: str = "auto"
-    model: str = "small"
-    device: str = "auto"
-    language: Optional[str] = None
-    timestamps: bool = False
-    model_path: Optional[str] = None
-    whisper_cpp_path: Optional[str] = None
-
-
-# Cached model instances to avoid expensive reloads on every segment
-_faster_whisper_model = None
-_faster_whisper_model_key: Optional[tuple] = None
-_openai_whisper_model = None
-_openai_whisper_model_key: Optional[str] = None
-_model_cache_lock = threading.Lock()
+__all__ = ["TranscriptionConfig", "transcribe_file", "transcribe_file_cues"]
 
 
 def transcribe_file(path: str, config: TranscriptionConfig) -> str:
@@ -49,6 +28,7 @@ def transcribe_file(path: str, config: TranscriptionConfig) -> str:
 
     Raises:
         ValueError: If the configured engine is unknown
+        RuntimeError: If ``config.engine`` is ``"auto"`` and no engine is installed
     """
     transcript = transcribe_file_cues(path, config)
     return render_transcript(transcript.cues, "txt", timestamps=config.timestamps)
@@ -69,293 +49,8 @@ def transcribe_file_cues(path: str, config: TranscriptionConfig) -> Transcript:
 
     Raises:
         ValueError: If the configured engine is unknown
+        RuntimeError: If ``config.engine`` is ``"auto"`` and no engine is installed
     """
-    engine = config.engine.lower()
-    if engine == "auto":
-        try:
-            import faster_whisper  # noqa: F401
-
-            engine = "faster"
-        except ImportError:
-            try:
-                import whisper  # noqa: F401
-
-                engine = "whisper"
-            except ImportError:
-                engine = "cpp"
-        logger.debug("Auto-selected transcription engine: %s", engine)
-
-    logger.debug("Transcribing %s with engine '%s', model '%s'", path, engine, config.model)
-
-    if engine == "faster":
-        return _transcribe_faster_whisper(path, config.model, config.language, config.device)
-    elif engine == "whisper":
-        return _transcribe_openai_whisper(path, config.model, config.language)
-    elif engine == "cpp":
-        return _transcribe_whisper_cpp(
-            path,
-            config.model,
-            config.language,
-            config.model_path,
-            config.whisper_cpp_path,
-            config.device,
-        )
-    else:
-        raise ValueError(f"Unknown engine: {engine}")
-
-
-def _transcribe_faster_whisper(path: str, model_size: str, language: Optional[str], device: str = "auto") -> Transcript:
-    """Transcribe using faster-whisper (ctranslate2 backend)."""
-    try:
-        from faster_whisper import WhisperModel  # type: ignore
-    except ImportError as e:
-        raise RuntimeError("faster-whisper is not installed. pip install faster-whisper") from e
-
-    # Device selection: CLI arg > env var > default (cpu)
-    if device == "auto":
-        device = os.environ.get("SYS2TXT_DEVICE", "cpu")
-
-    if device == "cuda":
-        fw_device = "cuda"
-        compute_type = "float16"
-    else:
-        fw_device = "cpu"
-        compute_type = "int8"
-
-    global _faster_whisper_model, _faster_whisper_model_key
-    key = (model_size, fw_device, compute_type)
-    with _model_cache_lock:
-        if _faster_whisper_model_key != key:
-            logger.info("Loading faster-whisper model '%s' on %s (%s)", model_size, fw_device, compute_type)
-            _faster_whisper_model = WhisperModel(model_size, device=fw_device, compute_type=compute_type)
-            _faster_whisper_model_key = key
-        model = _faster_whisper_model
-    segments, info = model.transcribe(path, vad_filter=True, language=language)
-    cues = tuple(Cue(start=float(seg.start), end=float(seg.end), text=seg.text.strip()) for seg in segments)
-    return Transcript(cues=cues, language=getattr(info, "language", None) or language)
-
-
-def _transcribe_openai_whisper(path: str, model_size: str, language: Optional[str]) -> Transcript:
-    """Transcribe using openai-whisper (reference implementation)."""
-    try:
-        import whisper  # type: ignore
-    except ImportError as e:
-        raise RuntimeError("openai-whisper is not installed. pip install openai-whisper") from e
-
-    global _openai_whisper_model, _openai_whisper_model_key
-    with _model_cache_lock:
-        if _openai_whisper_model_key != model_size:
-            logger.info("Loading openai-whisper model '%s'", model_size)
-            _openai_whisper_model = whisper.load_model(model_size)
-            _openai_whisper_model_key = model_size
-        model = _openai_whisper_model
-    result = model.transcribe(path, language=language)
-    detected = result.get("language") or language
-    segments = result.get("segments") or []
-    if segments:
-        cues = tuple(
-            Cue(
-                start=float(seg.get("start", 0.0)),
-                end=float(seg.get("end", 0.0)),
-                text=seg.get("text", "").strip(),
-            )
-            for seg in segments
-        )
-    else:
-        # Untimed fallback: the whole transcript as a single cue of unknown extent.
-        text = result.get("text", "").strip()
-        cues = (Cue(start=0.0, end=0.0, text=text),) if text else ()
-    return Transcript(cues=cues, language=detected)
-
-
-def _resolve_whisper_cpp_binary(whisper_cpp_path: Optional[str]) -> str:
-    """Resolve the path to the whisper-cli binary.
-
-    Priority:
-    1. Explicit path argument
-    2. SYS2TXT_WHISPER_CPP environment variable
-    3. PATH lookup for 'whisper-cli'
-
-    Args:
-        whisper_cpp_path: Explicit path to whisper-cli binary
-
-    Returns:
-        Path to whisper-cli binary
-
-    Raises:
-        RuntimeError: If binary cannot be found
-    """
-    if whisper_cpp_path:
-        if not os.path.isfile(whisper_cpp_path):
-            raise RuntimeError(f"whisper-cli binary not found at: {whisper_cpp_path}")
-        return whisper_cpp_path
-
-    env_path = os.environ.get("SYS2TXT_WHISPER_CPP")
-    if env_path:
-        if not os.path.isfile(env_path):
-            raise RuntimeError(f"whisper-cli binary not found at SYS2TXT_WHISPER_CPP: {env_path}")
-        return env_path
-
-    path_lookup = shutil.which("whisper-cli")
-    if path_lookup:
-        return path_lookup
-
-    raise RuntimeError(
-        "whisper-cli binary not found. Install whisper.cpp and either:\n"
-        "  1. Add whisper-cli to PATH\n"
-        "  2. Set SYS2TXT_WHISPER_CPP environment variable\n"
-        "  3. Use --whisper-cpp-path argument"
-    )
-
-
-def _resolve_whisper_cpp_model_path(model_path: Optional[str], model_size: str) -> str:
-    """Resolve the path to a whisper.cpp model file.
-
-    Priority:
-    1. Explicit model_path argument
-    2. SYS2TXT_WHISPER_CPP_MODELS directory + ggml-{model_size}.bin
-    3. ~/.local/share/whisper.cpp/models/ggml-{model_size}.bin
-
-    Args:
-        model_path: Explicit path to model file
-        model_size: Whisper model size (tiny, base, small, medium, large-v2)
-
-    Returns:
-        Path to model file
-
-    Raises:
-        RuntimeError: If model file cannot be found
-    """
-    if model_path:
-        if not os.path.isfile(model_path):
-            raise RuntimeError(f"whisper.cpp model not found at: {model_path}")
-        return model_path
-
-    model_filename = f"ggml-{model_size}.bin"
-
-    env_models_dir = os.environ.get("SYS2TXT_WHISPER_CPP_MODELS")
-    if env_models_dir:
-        env_model_path = os.path.join(env_models_dir, model_filename)
-        if os.path.isfile(env_model_path):
-            return env_model_path
-
-    default_dir = Path.home() / ".local" / "share" / "whisper.cpp" / "models"
-    default_path = default_dir / model_filename
-    if default_path.is_file():
-        return str(default_path)
-
-    raise RuntimeError(
-        f"whisper.cpp model '{model_filename}' not found. Either:\n"
-        "  1. Use --model-path to specify the model file\n"
-        f"  2. Set SYS2TXT_WHISPER_CPP_MODELS to directory containing {model_filename}\n"
-        f"  3. Place model at {default_path}"
-    )
-
-
-def _parse_whisper_cpp_output(output: str, language: Optional[str] = None) -> Transcript:
-    """Parse whisper.cpp stdout format.
-
-    Whisper.cpp outputs lines like:
-    [00:00:00.000 --> 00:00:05.120]   Hello world
-
-    Args:
-        output: Raw stdout from whisper-cli
-        language: Language code the caller asked for, recorded on the transcript
-
-    Returns:
-        The transcript parsed out of the timestamped lines
-    """
-    cues: List[Cue] = []
-    # Pattern: [HH:MM:SS.mmm --> HH:MM:SS.mmm] text
-    pattern = re.compile(r"\[(\d{2}:\d{2}:\d{2}\.\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}\.\d{3})\]\s*(.*)")
-
-    for line in output.splitlines():
-        match = pattern.match(line.strip())
-        if match:
-            start_str, end_str, text = match.groups()
-            text = text.strip()
-            if not text:
-                continue
-            cues.append(
-                Cue(
-                    start=_timestamp_to_seconds(start_str),
-                    end=_timestamp_to_seconds(end_str),
-                    text=text,
-                )
-            )
-
-    return Transcript(cues=tuple(cues), language=language)
-
-
-def _timestamp_to_seconds(ts: str) -> float:
-    """Convert HH:MM:SS.mmm timestamp to seconds.
-
-    Args:
-        ts: Timestamp string like "00:01:23.456"
-
-    Returns:
-        Time in seconds as float
-    """
-    try:
-        parts = ts.split(":")
-        hours = int(parts[0])
-        minutes = int(parts[1])
-        seconds = float(parts[2])
-        return hours * 3600 + minutes * 60 + seconds
-    except (IndexError, ValueError):
-        return 0.0
-
-
-def _transcribe_whisper_cpp(
-    path: str,
-    model_size: str,
-    language: Optional[str],
-    model_path: Optional[str],
-    whisper_cpp_path: Optional[str],
-    device: str,
-) -> Transcript:
-    """Transcribe using whisper.cpp (with optional Vulkan GPU support).
-
-    Args:
-        path: Path to audio file
-        model_size: Whisper model size (tiny, base, small, medium, large-v2)
-        language: Optional language code (e.g., "en"). If None, auto-detect.
-        model_path: Path to whisper.cpp model file
-        whisper_cpp_path: Path to whisper-cli binary
-        device: Device to use ("auto", "cpu", "vulkan", "gpu", "cuda")
-
-    Returns:
-        The transcript, with cue times parsed from whisper-cli's output
-
-    Raises:
-        RuntimeError: If whisper-cli binary or model not found, or transcription fails
-    """
-    binary = _resolve_whisper_cpp_binary(whisper_cpp_path)
-    model = _resolve_whisper_cpp_model_path(model_path, model_size)
-
-    # Build command
-    cmd = [binary, "-m", model, "-f", path, "-np"]  # -np = no progress
-
-    # Device selection
-    if device == "cpu":
-        cmd.append("--no-gpu")
-    # For auto/vulkan/gpu/cuda, let whisper.cpp use GPU if available
-
-    if language:
-        cmd.extend(["-l", language])
-
-    logger.debug("Running whisper-cli: %s", " ".join(cmd))
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=WHISPER_CPP_TIMEOUT)
-    except subprocess.TimeoutExpired as e:
-        raise RuntimeError(
-            f"whisper-cli timed out after {WHISPER_CPP_TIMEOUT} seconds "
-            f"(possible GPU hang or malformed audio): {binary}"
-        ) from e
-    except subprocess.CalledProcessError as e:
-        stderr = e.stderr.strip() if e.stderr else "No error output"
-        raise RuntimeError(f"whisper-cli failed: {stderr}") from e
-    except FileNotFoundError as e:
-        raise RuntimeError(f"whisper-cli binary not found: {binary}") from e
-
-    return _parse_whisper_cpp_output(result.stdout, language)
+    engine = get_engine(config.engine.lower())
+    logger.debug("Transcribing %s with engine '%s', model '%s'", path, engine.name, config.model)
+    return engine.transcribe(path, config)

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,0 +1,616 @@
+"""Tests for sys2txt.engines module."""
+
+import os
+import subprocess
+import sys
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from sys2txt.engines import (
+    ENGINE_NAMES,
+    ENGINES,
+    FasterWhisperEngine,
+    OpenAIWhisperEngine,
+    TranscriptionConfig,
+    TranscriptionEngine,
+    WhisperCppEngine,
+    _parse_whisper_cpp_output,
+    _resolve_device,
+    _resolve_whisper_cpp_binary,
+    _resolve_whisper_cpp_model_path,
+    _timestamp_to_seconds,
+    get_engine,
+    unload_engines,
+)
+from sys2txt.formats import Cue
+
+
+def whisper_segment(text, start, end):
+    """Build a mock faster-whisper segment."""
+    segment = MagicMock()
+    segment.text = text
+    segment.start = start
+    segment.end = end
+    return segment
+
+
+class TestRegistry(unittest.TestCase):
+    """Tests for the engine registry and get_engine()."""
+
+    def test_every_registered_engine_satisfies_the_protocol(self):
+        for engine in ENGINES:
+            with self.subTest(engine=engine.name):
+                self.assertIsInstance(engine, TranscriptionEngine)
+
+    def test_engine_names_start_with_auto_and_cover_the_registry(self):
+        self.assertEqual(ENGINE_NAMES, ("auto", "faster", "whisper", "cpp"))
+
+    def test_get_engine_by_name(self):
+        expected_types = {
+            "faster": FasterWhisperEngine,
+            "whisper": OpenAIWhisperEngine,
+            "cpp": WhisperCppEngine,
+        }
+        for name, expected in expected_types.items():
+            with self.subTest(name=name):
+                self.assertIsInstance(get_engine(name), expected)
+
+    def test_get_engine_by_name_skips_the_availability_check(self):
+        """An explicitly named engine runs even when nothing is installed."""
+        with patch.dict("sys.modules", {"faster_whisper": None}):
+            self.assertEqual(get_engine("faster").name, "faster")
+
+    def test_get_engine_unknown(self):
+        with self.assertRaises(ValueError) as cm:
+            get_engine("bogus")
+
+        self.assertIn("Unknown engine", str(cm.exception))
+        self.assertIn("bogus", str(cm.exception))
+
+    def test_auto_prefers_faster_whisper(self):
+        with patch.dict("sys.modules", {"faster_whisper": MagicMock()}):
+            self.assertEqual(get_engine("auto").name, "faster")
+
+    def test_auto_falls_back_to_openai_whisper(self):
+        with patch.dict("sys.modules", {"faster_whisper": None, "whisper": MagicMock()}):
+            self.assertEqual(get_engine("auto").name, "whisper")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_auto_falls_back_to_whisper_cpp(self):
+        with patch.dict("sys.modules", {"faster_whisper": None, "whisper": None}):
+            with patch("shutil.which", return_value="/usr/bin/whisper-cli"):
+                self.assertEqual(get_engine("auto").name, "cpp")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_auto_with_nothing_installed_names_every_engine(self):
+        """Regression for #63: auto used to fall through to cpp and report a missing binary."""
+        with patch.dict("sys.modules", {"faster_whisper": None, "whisper": None}):
+            with patch("shutil.which", return_value=None):
+                with self.assertRaises(RuntimeError) as cm:
+                    get_engine("auto")
+
+        message = str(cm.exception)
+        self.assertIn("No transcription engine is installed", message)
+        for name in ("faster", "whisper", "cpp"):
+            self.assertIn(name, message)
+
+    def test_unload_engines_releases_every_cached_model(self):
+        engine = get_engine("faster")
+        engine._model = object()
+        engine._key = ("small", "cpu", "int8")
+
+        unload_engines()
+
+        self.assertIsNone(engine._model)
+        self.assertIsNone(engine._key)
+
+
+class TestResolveDevice(unittest.TestCase):
+    """Tests for the _resolve_device() helper."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_auto_defaults_to_cpu(self):
+        self.assertEqual(_resolve_device("auto"), "cpu")
+
+    @patch.dict(os.environ, {"SYS2TXT_DEVICE": "cuda"})
+    def test_auto_reads_the_environment(self):
+        self.assertEqual(_resolve_device("auto"), "cuda")
+
+    @patch.dict(os.environ, {"SYS2TXT_DEVICE": "cuda"})
+    def test_explicit_device_beats_the_environment(self):
+        self.assertEqual(_resolve_device("cpu"), "cpu")
+
+    def test_gpu_choices_only_whisper_cpp_understands_fall_back_to_cpu(self):
+        for device in ("vulkan", "gpu"):
+            with self.subTest(device=device):
+                self.assertEqual(_resolve_device(device), "cpu")
+
+
+class TestFasterWhisperEngine(unittest.TestCase):
+    """Tests for FasterWhisperEngine."""
+
+    def setUp(self):
+        self.engine = FasterWhisperEngine()
+        if "faster_whisper" not in sys.modules:
+            patcher = patch.dict("sys.modules", {"faster_whisper": MagicMock()})
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_is_available(self):
+        with patch.dict("sys.modules", {"faster_whisper": MagicMock()}):
+            self.assertTrue(self.engine.is_available())
+
+    def test_is_not_available_when_not_installed(self):
+        with patch.dict("sys.modules", {"faster_whisper": None}):
+            self.assertFalse(self.engine.is_available())
+
+    @patch("faster_whisper.WhisperModel")
+    def test_transcribe_keeps_cue_times(self, mock_model_class):
+        mock_model_class.return_value.transcribe.return_value = (
+            [whisper_segment(" Hello world ", 0.0, 1.5), whisper_segment(" Test audio ", 1.5, 3.0)],
+            None,
+        )
+
+        result = self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig())
+
+        self.assertEqual(result.cues, (Cue(0.0, 1.5, "Hello world"), Cue(1.5, 3.0, "Test audio")))
+        mock_model_class.return_value.transcribe.assert_called_once_with(
+            "/path/to/audio.wav", vad_filter=True, language=None
+        )
+
+    @patch("faster_whisper.WhisperModel")
+    def test_transcribe_passes_the_language_through(self, mock_model_class):
+        mock_model_class.return_value.transcribe.return_value = ([whisper_segment(" Hello ", 0.0, 1.5)], None)
+
+        result = self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(model="base", language="en"))
+
+        self.assertEqual(result.cues, (Cue(0.0, 1.5, "Hello"),))
+        self.assertEqual(result.language, "en")
+        mock_model_class.return_value.transcribe.assert_called_once_with(
+            "/path/to/audio.wav", vad_filter=True, language="en"
+        )
+
+    @patch("faster_whisper.WhisperModel")
+    @patch.dict(os.environ, {"SYS2TXT_DEVICE": "cuda"})
+    def test_cuda_device_from_env(self, mock_model_class):
+        mock_model_class.return_value.transcribe.return_value = ([], None)
+
+        self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(device="auto"))
+
+        mock_model_class.assert_called_once_with("small", device="cuda", compute_type="float16")
+
+    @patch("faster_whisper.WhisperModel")
+    def test_cuda_device_explicit(self, mock_model_class):
+        mock_model_class.return_value.transcribe.return_value = ([], None)
+
+        self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(device="cuda"))
+
+        mock_model_class.assert_called_once_with("small", device="cuda", compute_type="float16")
+
+    @patch("faster_whisper.WhisperModel")
+    def test_cpu_device_explicit(self, mock_model_class):
+        mock_model_class.return_value.transcribe.return_value = ([], None)
+
+        self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(device="cpu"))
+
+        mock_model_class.assert_called_once_with("small", device="cpu", compute_type="int8")
+
+    def test_transcribe_when_not_installed(self):
+        with patch.dict("sys.modules", {"faster_whisper": None}):
+            with self.assertRaises(RuntimeError) as cm:
+                self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig())
+
+        self.assertIn("faster-whisper is not installed", str(cm.exception))
+
+
+class TestOpenAIWhisperEngine(unittest.TestCase):
+    """Tests for OpenAIWhisperEngine."""
+
+    def setUp(self):
+        self.engine = OpenAIWhisperEngine()
+        if "whisper" not in sys.modules:
+            patcher = patch.dict("sys.modules", {"whisper": MagicMock()})
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_is_available(self):
+        with patch.dict("sys.modules", {"whisper": MagicMock()}):
+            self.assertTrue(self.engine.is_available())
+
+    def test_is_not_available_when_not_installed(self):
+        with patch.dict("sys.modules", {"whisper": None}):
+            self.assertFalse(self.engine.is_available())
+
+    @patch("whisper.load_model")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_untimed_result_becomes_one_cue(self, mock_load_model):
+        mock_load_model.return_value.transcribe.return_value = {"text": " Hello world "}
+
+        result = self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig())
+
+        self.assertEqual(result.cues, (Cue(0.0, 0.0, "Hello world"),))
+        mock_load_model.assert_called_once_with("small", device="cpu")
+        mock_load_model.return_value.transcribe.assert_called_once_with("/path/to/audio.wav", language=None)
+
+    @patch("whisper.load_model")
+    def test_segments_keep_their_times(self, mock_load_model):
+        mock_load_model.return_value.transcribe.return_value = {
+            "text": "Hello world",
+            "segments": [
+                {"start": 0.0, "end": 1.5, "text": " Hello "},
+                {"start": 1.5, "end": 3.0, "text": " world "},
+            ],
+        }
+
+        result = self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(model="base", language="en"))
+
+        self.assertEqual(result.cues, (Cue(0.0, 1.5, "Hello"), Cue(1.5, 3.0, "world")))
+        self.assertEqual(result.language, "en")
+        mock_load_model.return_value.transcribe.assert_called_once_with("/path/to/audio.wav", language="en")
+
+    @patch("whisper.load_model")
+    def test_device_reaches_load_model(self, mock_load_model):
+        mock_load_model.return_value.transcribe.return_value = {"text": ""}
+
+        self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(device="cuda"))
+
+        mock_load_model.assert_called_once_with("small", device="cuda")
+
+    @patch("whisper.load_model")
+    def test_device_is_part_of_the_cache_key(self, mock_load_model):
+        """Regression for #63: the cache key used to ignore the device."""
+        mock_load_model.return_value.transcribe.return_value = {"text": ""}
+
+        self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(device="cpu"))
+        self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(device="cuda"))
+
+        self.assertEqual(
+            [call.kwargs["device"] for call in mock_load_model.call_args_list],
+            ["cpu", "cuda"],
+        )
+
+    def test_transcribe_when_not_installed(self):
+        with patch.dict("sys.modules", {"whisper": None}):
+            with self.assertRaises(RuntimeError) as cm:
+                self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig())
+
+        self.assertIn("openai-whisper is not installed", str(cm.exception))
+
+
+class TestModelCache(unittest.TestCase):
+    """Tests for the per-engine model cache."""
+
+    def setUp(self):
+        self.engine = FasterWhisperEngine()
+        if "faster_whisper" not in sys.modules:
+            patcher = patch.dict("sys.modules", {"faster_whisper": MagicMock()})
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    @patch("faster_whisper.WhisperModel")
+    def test_same_config_loads_the_model_once(self, mock_model_class):
+        mock_model_class.return_value.transcribe.return_value = ([], None)
+        config = TranscriptionConfig(device="cpu")
+
+        self.engine.transcribe("/path/to/audio.wav", config)
+        self.engine.transcribe("/path/to/other.wav", config)
+
+        mock_model_class.assert_called_once_with("small", device="cpu", compute_type="int8")
+
+    @patch("faster_whisper.WhisperModel")
+    def test_a_different_model_reloads(self, mock_model_class):
+        mock_model_class.return_value.transcribe.return_value = ([], None)
+
+        self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(model="small", device="cpu"))
+        self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(model="base", device="cpu"))
+
+        self.assertEqual([call.args[0] for call in mock_model_class.call_args_list], ["small", "base"])
+
+    @patch("faster_whisper.WhisperModel")
+    def test_unload_drops_the_cached_model(self, mock_model_class):
+        mock_model_class.return_value.transcribe.return_value = ([], None)
+        config = TranscriptionConfig(device="cpu")
+
+        self.engine.transcribe("/path/to/audio.wav", config)
+        self.engine.unload()
+        self.assertIsNone(self.engine._model)
+        self.assertIsNone(self.engine._key)
+
+        self.engine.transcribe("/path/to/audio.wav", config)
+
+        self.assertEqual(mock_model_class.call_count, 2)
+
+    @patch("faster_whisper.WhisperModel")
+    def test_concurrent_calls_load_model_once(self, mock_model_class):
+        """Concurrent transcriptions with same params should only load the model once."""
+        mock_model_class.return_value.transcribe.return_value = ([whisper_segment(" Hello ", 0.0, 1.0)], None)
+
+        barrier = threading.Barrier(4)
+        errors = []
+
+        def worker():
+            try:
+                barrier.wait(timeout=5)
+                self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(device="cpu"))
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        self.assertEqual(errors, [])
+        mock_model_class.assert_called_once_with("small", device="cpu", compute_type="int8")
+
+
+class TestResolveWhisperCppBinary(unittest.TestCase):
+    """Tests for the _resolve_whisper_cpp_binary() function."""
+
+    def test_explicit_path_valid(self):
+        """Test explicit path that exists."""
+        with patch("os.path.isfile", return_value=True):
+            result = _resolve_whisper_cpp_binary("/path/to/whisper-cli")
+
+        self.assertEqual(result, "/path/to/whisper-cli")
+
+    def test_explicit_path_invalid(self):
+        """Test explicit path that doesn't exist."""
+        with patch("os.path.isfile", return_value=False):
+            with self.assertRaises(RuntimeError) as cm:
+                _resolve_whisper_cpp_binary("/path/to/whisper-cli")
+
+        self.assertIn("not found at", str(cm.exception))
+
+    @patch.dict(os.environ, {"SYS2TXT_WHISPER_CPP": "/env/whisper-cli"})
+    def test_env_var_valid(self):
+        """Test environment variable path that exists."""
+        with patch("os.path.isfile", return_value=True):
+            result = _resolve_whisper_cpp_binary(None)
+
+        self.assertEqual(result, "/env/whisper-cli")
+
+    @patch.dict(os.environ, {"SYS2TXT_WHISPER_CPP": "/env/whisper-cli"})
+    def test_env_var_invalid(self):
+        """Test environment variable path that doesn't exist."""
+        with patch("os.path.isfile", return_value=False):
+            with self.assertRaises(RuntimeError) as cm:
+                _resolve_whisper_cpp_binary(None)
+
+        self.assertIn("SYS2TXT_WHISPER_CPP", str(cm.exception))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_path_lookup_found(self):
+        """Test PATH lookup succeeds."""
+        with patch("shutil.which", return_value="/usr/bin/whisper-cli"):
+            result = _resolve_whisper_cpp_binary(None)
+
+        self.assertEqual(result, "/usr/bin/whisper-cli")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_path_lookup_not_found(self):
+        """Test PATH lookup fails."""
+        with patch("shutil.which", return_value=None):
+            with self.assertRaises(RuntimeError) as cm:
+                _resolve_whisper_cpp_binary(None)
+
+        self.assertIn("whisper-cli binary not found", str(cm.exception))
+
+
+class TestResolveWhisperCppModelPath(unittest.TestCase):
+    """Tests for the _resolve_whisper_cpp_model_path() function."""
+
+    def test_explicit_path_valid(self):
+        """Test explicit model path that exists."""
+        with patch("os.path.isfile", return_value=True):
+            result = _resolve_whisper_cpp_model_path("/path/to/model.bin", "small")
+
+        self.assertEqual(result, "/path/to/model.bin")
+
+    def test_explicit_path_invalid(self):
+        """Test explicit model path that doesn't exist."""
+        with patch("os.path.isfile", return_value=False):
+            with self.assertRaises(RuntimeError) as cm:
+                _resolve_whisper_cpp_model_path("/path/to/model.bin", "small")
+
+        self.assertIn("not found at", str(cm.exception))
+
+    @patch.dict(os.environ, {"SYS2TXT_WHISPER_CPP_MODELS": "/models"})
+    def test_env_var_models_dir(self):
+        """Test models directory from environment variable."""
+        with patch("os.path.isfile", return_value=True):
+            result = _resolve_whisper_cpp_model_path(None, "small")
+
+        self.assertEqual(result, "/models/ggml-small.bin")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_default_path(self):
+        """Test default path in ~/.local/share/whisper.cpp/models/."""
+        expected_path = Path.home() / ".local" / "share" / "whisper.cpp" / "models" / "ggml-tiny.bin"
+
+        with patch.object(Path, "is_file", return_value=True):
+            result = _resolve_whisper_cpp_model_path(None, "tiny")
+
+        self.assertEqual(result, str(expected_path))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_model_not_found(self):
+        """Test model not found anywhere."""
+        with patch("os.path.isfile", return_value=False):
+            with patch.object(Path, "is_file", return_value=False):
+                with self.assertRaises(RuntimeError) as cm:
+                    _resolve_whisper_cpp_model_path(None, "small")
+
+        self.assertIn("ggml-small.bin", str(cm.exception))
+
+
+class TestParseWhisperCppOutput(unittest.TestCase):
+    """Tests for the _parse_whisper_cpp_output() function."""
+
+    def test_parse_keeps_cue_times(self):
+        """Test parsing whisper.cpp output into cues that keep their times."""
+        output = """[00:00:00.000 --> 00:00:05.120]   Hello world
+[00:00:05.120 --> 00:00:10.240]   This is a test"""
+
+        result = _parse_whisper_cpp_output(output)
+
+        self.assertEqual(
+            result.cues,
+            (Cue(0.0, 5.12, "Hello world"), Cue(5.12, 10.24, "This is a test")),
+        )
+
+    def test_parse_records_the_language(self):
+        """Test that the requested language is recorded on the transcript."""
+        result = _parse_whisper_cpp_output("[00:00:00.000 --> 00:00:05.120]   Bonjour", "fr")
+
+        self.assertEqual(result.language, "fr")
+
+    def test_parse_empty_segments_ignored(self):
+        """Test that empty segments are ignored."""
+        output = """[00:00:00.000 --> 00:00:05.120]   Hello
+[00:00:05.120 --> 00:00:10.240]
+[00:00:10.240 --> 00:00:15.000]   World"""
+
+        result = _parse_whisper_cpp_output(output)
+
+        self.assertEqual(result.text, "Hello World")
+
+    def test_parse_non_matching_lines_ignored(self):
+        """Test that non-matching lines are ignored."""
+        output = """whisper_init_from_file_no_state: loading model...
+[00:00:00.000 --> 00:00:05.120]   Hello world
+main: some debug output"""
+
+        result = _parse_whisper_cpp_output(output)
+
+        self.assertEqual(result.text, "Hello world")
+
+
+class TestTimestampToSeconds(unittest.TestCase):
+    """Tests for the _timestamp_to_seconds() function."""
+
+    def test_simple_seconds(self):
+        """Test simple seconds conversion."""
+        self.assertAlmostEqual(_timestamp_to_seconds("00:00:05.120"), 5.12, places=3)
+
+    def test_minutes_and_seconds(self):
+        """Test minutes and seconds conversion."""
+        self.assertAlmostEqual(_timestamp_to_seconds("00:02:30.500"), 150.5, places=3)
+
+    def test_hours_minutes_seconds(self):
+        """Test hours, minutes, and seconds conversion."""
+        self.assertAlmostEqual(_timestamp_to_seconds("01:30:45.750"), 5445.75, places=3)
+
+
+@patch("sys2txt.engines._resolve_whisper_cpp_binary", return_value="/path/to/whisper-cli")
+@patch("sys2txt.engines._resolve_whisper_cpp_model_path", return_value="/path/to/model.bin")
+class TestWhisperCppEngine(unittest.TestCase):
+    """Tests for WhisperCppEngine."""
+
+    def setUp(self):
+        self.engine = WhisperCppEngine()
+
+    @staticmethod
+    def _stdout(mock_run, text="Hello world"):
+        mock_run.return_value = MagicMock(stdout=f"[00:00:00.000 --> 00:00:05.000]   {text}\n", returncode=0)
+
+    @patch("subprocess.run")
+    def test_transcribe_success(self, mock_run, _model_path, _binary):
+        """Test successful transcription."""
+        self._stdout(mock_run)
+
+        result = self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig())
+
+        self.assertEqual(result.cues, (Cue(0.0, 5.0, "Hello world"),))
+        mock_run.assert_called_once()
+
+    @patch("subprocess.run")
+    def test_transcribe_with_language(self, mock_run, _model_path, _binary):
+        """Test transcription with language specified."""
+        self._stdout(mock_run, "Bonjour")
+
+        self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(language="fr"))
+
+        call_args = mock_run.call_args[0][0]
+        self.assertIn("-l", call_args)
+        self.assertIn("fr", call_args)
+
+    @patch("subprocess.run")
+    def test_transcribe_cpu_device(self, mock_run, _model_path, _binary):
+        """Test transcription with CPU device adds --no-gpu flag."""
+        self._stdout(mock_run)
+
+        self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(device="cpu"))
+
+        self.assertIn("--no-gpu", mock_run.call_args[0][0])
+
+    @patch("subprocess.run")
+    def test_transcribe_vulkan_device(self, mock_run, _model_path, _binary):
+        """Test transcription with Vulkan device does not add --no-gpu."""
+        self._stdout(mock_run)
+
+        self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(device="vulkan"))
+
+        self.assertNotIn("--no-gpu", mock_run.call_args[0][0])
+
+    @patch("subprocess.run")
+    def test_transcribe_no_timestamps_does_not_pass_no_timestamps_flag(self, mock_run, _model_path, _binary):
+        """Regression test for #42: --no-timestamps must never be passed to whisper-cli.
+
+        whisper-cli only emits bracketed timestamp lines when timestamps are enabled;
+        with --no-timestamps its plain-text output doesn't match the parser's regex,
+        so the transcript would silently come back empty.
+        """
+        self._stdout(mock_run)
+
+        result = self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig())
+
+        self.assertNotIn("--no-timestamps", mock_run.call_args[0][0])
+        self.assertEqual(result.text, "Hello world")
+
+    @patch("subprocess.run")
+    def test_transcribe_passes_the_configured_paths(self, mock_run, mock_model_path, mock_binary):
+        """The engine resolves the binary and model from the config, not from arguments."""
+        self._stdout(mock_run)
+        config = TranscriptionConfig(model_path="/custom/model.bin", whisper_cpp_path="/custom/whisper-cli")
+
+        self.engine.transcribe("/path/to/audio.wav", config)
+
+        mock_binary.assert_called_once_with("/custom/whisper-cli")
+        mock_model_path.assert_called_once_with("/custom/model.bin", "small")
+
+    @patch("subprocess.run")
+    def test_transcribe_failure(self, mock_run, _model_path, _binary):
+        """Test transcription failure raises RuntimeError."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "whisper-cli", stderr="Error: model not found")
+
+        with self.assertRaises(RuntimeError) as cm:
+            self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig())
+
+        self.assertIn("whisper-cli failed", str(cm.exception))
+
+    @patch("subprocess.run")
+    def test_transcribe_timeout_raises_runtime_error(self, mock_run, _model_path, _binary):
+        """Test that a hung whisper-cli process raises RuntimeError after timeout."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="whisper-cli", timeout=300)
+
+        with self.assertRaises(RuntimeError) as cm:
+            self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig())
+
+        self.assertIn("timed out", str(cm.exception))
+
+    def test_is_available(self, _model_path, _binary):
+        self.assertTrue(self.engine.is_available())
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_is_not_available_without_a_binary(self, _model_path, mock_binary):
+        mock_binary.side_effect = RuntimeError("whisper-cli binary not found")
+
+        self.assertFalse(self.engine.is_available())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -23,10 +23,12 @@ class TestPublicApi(unittest.TestCase):
             [
                 "AudioSegment",
                 "Cue",
+                "ENGINE_NAMES",
                 "OUTPUT_FORMATS",
                 "Transcript",
                 "TranscriptSegment",
                 "TranscriptionConfig",
+                "TranscriptionEngine",
                 "__version__",
                 "get_default_monitor_source",
                 "iter_audio_segments",

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,9 +1,6 @@
 """Tests for sys2txt.transcribe module."""
 
-import os
-import sys
 import unittest
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from sys2txt.formats import Cue, Transcript
@@ -16,89 +13,45 @@ def transcript(*texts, language=None):
     return Transcript(cues=cues, language=language)
 
 
+def fake_engine(name, result):
+    """Build a stand-in engine that returns ``result`` from transcribe()."""
+    engine = MagicMock()
+    engine.name = name
+    engine.transcribe.return_value = result
+    return engine
+
+
 class TestTranscribeFile(unittest.TestCase):
     """Tests for the transcribe_file() function."""
 
-    def test_transcribe_file_auto_selects_faster_whisper(self):
-        """Test transcribe_file() auto-selects faster-whisper when available."""
-        with patch.dict("sys.modules", {"faster_whisper": MagicMock()}):
-            with patch("sys2txt.transcribe._transcribe_faster_whisper") as mock_transcribe:
-                mock_transcribe.return_value = transcript("test transcript")
-                result = transcribe_file("/path/to/audio.wav", TranscriptionConfig())
+    def test_renders_the_engine_transcript_as_text(self):
+        engine = fake_engine("faster", transcript("test transcript"))
+
+        with patch("sys2txt.transcribe.get_engine", return_value=engine) as mock_get_engine:
+            result = transcribe_file("/path/to/audio.wav", TranscriptionConfig())
 
         self.assertEqual(result, "test transcript")
-        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, "auto")
+        mock_get_engine.assert_called_once_with("auto")
 
-    @patch("sys2txt.transcribe._transcribe_faster_whisper")
-    def test_transcribe_file_faster_engine(self, mock_transcribe):
-        """Test transcribe_file() with explicit faster engine."""
-        mock_transcribe.return_value = transcript("faster transcript")
-
+    def test_timestamps_are_rendered_not_asked_of_the_engine(self):
+        """The engine always returns timed cues; --timestamps only affects plain-text rendering."""
+        engine = fake_engine("faster", transcript("faster transcript"))
         config = TranscriptionConfig(engine="faster", model="base", language="en", timestamps=True)
-        result = transcribe_file("/path/to/audio.wav", config)
+
+        with patch("sys2txt.transcribe.get_engine", return_value=engine):
+            result = transcribe_file("/path/to/audio.wav", config)
 
         self.assertEqual(result, "[  0.00-  1.00] faster transcript")
-        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "base", "en", "auto")
 
-    @patch("sys2txt.transcribe._transcribe_openai_whisper")
-    def test_transcribe_file_whisper_engine(self, mock_transcribe):
-        """Test transcribe_file() with explicit whisper engine."""
-        mock_transcribe.return_value = transcript("whisper transcript")
+    def test_the_engine_name_is_lowercased(self):
+        engine = fake_engine("whisper", transcript("whisper transcript"))
 
-        config = TranscriptionConfig(engine="whisper", model="medium", language="fr")
-        result = transcribe_file("/path/to/audio.wav", config)
+        with patch("sys2txt.transcribe.get_engine", return_value=engine) as mock_get_engine:
+            transcribe_file("/path/to/audio.wav", TranscriptionConfig(engine="Whisper"))
 
-        self.assertEqual(result, "whisper transcript")
-        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "medium", "fr")
+        mock_get_engine.assert_called_once_with("whisper")
 
-    @patch("sys2txt.transcribe._transcribe_whisper_cpp")
-    def test_transcribe_file_cpp_engine(self, mock_transcribe):
-        """Test transcribe_file() with cpp engine."""
-        mock_transcribe.return_value = transcript("cpp transcript")
-
-        config = TranscriptionConfig(
-            engine="cpp",
-            model="small",
-            language="en",
-            timestamps=True,
-            model_path="/path/to/model.bin",
-            whisper_cpp_path="/path/to/whisper-cli",
-            device="vulkan",
-        )
-        result = transcribe_file("/path/to/audio.wav", config)
-
-        self.assertEqual(result, "[  0.00-  1.00] cpp transcript")
-        mock_transcribe.assert_called_once_with(
-            "/path/to/audio.wav",
-            "small",
-            "en",
-            "/path/to/model.bin",
-            "/path/to/whisper-cli",
-            "vulkan",
-        )
-
-    def test_transcribe_file_auto_falls_back_to_openai_whisper(self):
-        """Test transcribe_file() auto falls back to openai-whisper when faster-whisper is not installed."""
-        with patch.dict("sys.modules", {"faster_whisper": None, "whisper": MagicMock()}):
-            with patch("sys2txt.transcribe._transcribe_openai_whisper") as mock_transcribe:
-                mock_transcribe.return_value = transcript("fallback transcript")
-                result = transcribe_file("/path/to/audio.wav", TranscriptionConfig())
-
-        self.assertEqual(result, "fallback transcript")
-        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None)
-
-    def test_transcribe_file_auto_falls_back_to_cpp(self):
-        """Test transcribe_file() auto falls back to whisper.cpp when neither Python engine is installed."""
-        with patch.dict("sys.modules", {"faster_whisper": None, "whisper": None}):
-            with patch("sys2txt.transcribe._transcribe_whisper_cpp") as mock_transcribe:
-                mock_transcribe.return_value = transcript("cpp fallback transcript")
-                config = TranscriptionConfig()
-                result = transcribe_file("/path/to/audio.wav", config)
-
-        self.assertEqual(result, "cpp fallback transcript")
-        mock_transcribe.assert_called_once_with("/path/to/audio.wav", "small", None, None, None, "auto")
-
-    def test_transcribe_file_invalid_engine(self):
+    def test_invalid_engine(self):
         """Test transcribe_file() raises ValueError for invalid engine."""
         with self.assertRaises(ValueError) as cm:
             transcribe_file("/path/to/audio.wav", TranscriptionConfig(engine="invalid"))
@@ -110,15 +63,32 @@ class TestTranscribeFile(unittest.TestCase):
 class TestTranscribeFileCues(unittest.TestCase):
     """Tests for the transcribe_file_cues() function."""
 
-    @patch("sys2txt.transcribe._transcribe_faster_whisper")
-    def test_returns_the_engine_transcript_unchanged(self, mock_transcribe):
+    def test_returns_the_engine_transcript_unchanged(self):
         """Test transcribe_file_cues() hands back the engine's cues and language."""
-        mock_transcribe.return_value = transcript("hello", language="en")
+        engine = fake_engine("faster", transcript("hello", language="en"))
 
-        result = transcribe_file_cues("/path/to/audio.wav", TranscriptionConfig(engine="faster"))
+        with patch("sys2txt.transcribe.get_engine", return_value=engine):
+            result = transcribe_file_cues("/path/to/audio.wav", TranscriptionConfig(engine="faster"))
 
         self.assertEqual(result.cues, (Cue(0.0, 1.0, "hello"),))
         self.assertEqual(result.language, "en")
+
+    def test_hands_the_whole_config_to_the_engine(self):
+        """The config travels intact rather than being destructured into positional arguments."""
+        engine = fake_engine("cpp", transcript("cpp transcript"))
+        config = TranscriptionConfig(
+            engine="cpp",
+            model="small",
+            language="en",
+            model_path="/path/to/model.bin",
+            whisper_cpp_path="/path/to/whisper-cli",
+            device="vulkan",
+        )
+
+        with patch("sys2txt.transcribe.get_engine", return_value=engine):
+            transcribe_file_cues("/path/to/audio.wav", config)
+
+        engine.transcribe.assert_called_once_with("/path/to/audio.wav", config)
 
     def test_invalid_engine(self):
         """Test transcribe_file_cues() raises ValueError for an invalid engine."""
@@ -126,572 +96,6 @@ class TestTranscribeFileCues(unittest.TestCase):
             transcribe_file_cues("/path/to/audio.wav", TranscriptionConfig(engine="invalid"))
 
         self.assertIn("Unknown engine", str(cm.exception))
-
-
-class TestTranscribeFasterWhisper(unittest.TestCase):
-    """Tests for the _transcribe_faster_whisper() function."""
-
-    def setUp(self):
-        """Reset cached model between tests."""
-        import sys2txt.transcribe as t
-
-        t._faster_whisper_model = None
-        t._faster_whisper_model_key = None
-
-        if "faster_whisper" not in sys.modules:
-            patcher = patch.dict("sys.modules", {"faster_whisper": MagicMock()})
-            patcher.start()
-            self.addCleanup(patcher.stop)
-
-    @patch("faster_whisper.WhisperModel")
-    def test_transcribe_faster_whisper_no_timestamps(self, mock_model_class):
-        """Test _transcribe_faster_whisper() without timestamps."""
-        from sys2txt.transcribe import _transcribe_faster_whisper
-
-        # Mock segment objects
-        seg1 = MagicMock()
-        seg1.text = " Hello world "
-        seg1.start = 0.0
-        seg1.end = 1.5
-
-        seg2 = MagicMock()
-        seg2.text = " Test audio "
-        seg2.start = 1.5
-        seg2.end = 3.0
-
-        mock_model = mock_model_class.return_value
-        mock_model.transcribe.return_value = ([seg1, seg2], None)
-
-        result = _transcribe_faster_whisper("/path/to/audio.wav", "small", None)
-
-        self.assertEqual(result.cues, (Cue(0.0, 1.5, "Hello world"), Cue(1.5, 3.0, "Test audio")))
-        mock_model.transcribe.assert_called_once_with("/path/to/audio.wav", vad_filter=True, language=None)
-
-    @patch("faster_whisper.WhisperModel")
-    def test_transcribe_faster_whisper_with_timestamps(self, mock_model_class):
-        """Test _transcribe_faster_whisper() with timestamps."""
-        from sys2txt.transcribe import _transcribe_faster_whisper
-
-        # Mock segment objects
-        seg1 = MagicMock()
-        seg1.text = " Hello "
-        seg1.start = 0.0
-        seg1.end = 1.5
-
-        seg2 = MagicMock()
-        seg2.text = " world "
-        seg2.start = 1.5
-        seg2.end = 3.0
-
-        mock_model = mock_model_class.return_value
-        mock_model.transcribe.return_value = ([seg1, seg2], None)
-
-        result = _transcribe_faster_whisper("/path/to/audio.wav", "base", "en")
-
-        self.assertEqual(result.cues, (Cue(0.0, 1.5, "Hello"), Cue(1.5, 3.0, "world")))
-        self.assertEqual(result.language, "en")
-        mock_model.transcribe.assert_called_once_with("/path/to/audio.wav", vad_filter=True, language="en")
-
-    @patch("faster_whisper.WhisperModel")
-    @patch.dict(os.environ, {"SYS2TXT_DEVICE": "cuda"})
-    def test_transcribe_faster_whisper_cuda_device_from_env(self, mock_model_class):
-        """Test _transcribe_faster_whisper() uses CUDA when env var set with auto device."""
-        from sys2txt.transcribe import _transcribe_faster_whisper
-
-        mock_model = mock_model_class.return_value
-        mock_model.transcribe.return_value = ([], None)
-
-        _transcribe_faster_whisper("/path/to/audio.wav", "small", None, device="auto")
-
-        mock_model_class.assert_called_once_with("small", device="cuda", compute_type="float16")
-
-    @patch("faster_whisper.WhisperModel")
-    def test_transcribe_faster_whisper_cuda_device_explicit(self, mock_model_class):
-        """Test _transcribe_faster_whisper() uses CUDA when device=cuda."""
-        from sys2txt.transcribe import _transcribe_faster_whisper
-
-        mock_model = mock_model_class.return_value
-        mock_model.transcribe.return_value = ([], None)
-
-        _transcribe_faster_whisper("/path/to/audio.wav", "small", None, device="cuda")
-
-        mock_model_class.assert_called_once_with("small", device="cuda", compute_type="float16")
-
-    @patch("faster_whisper.WhisperModel")
-    def test_transcribe_faster_whisper_cpu_device_explicit(self, mock_model_class):
-        """Test _transcribe_faster_whisper() uses CPU when device=cpu."""
-        from sys2txt.transcribe import _transcribe_faster_whisper
-
-        mock_model = mock_model_class.return_value
-        mock_model.transcribe.return_value = ([], None)
-
-        _transcribe_faster_whisper("/path/to/audio.wav", "small", None, device="cpu")
-
-        mock_model_class.assert_called_once_with("small", device="cpu", compute_type="int8")
-
-    def test_transcribe_faster_whisper_not_installed(self):
-        """Test _transcribe_faster_whisper() raises RuntimeError when not installed."""
-        from sys2txt.transcribe import _transcribe_faster_whisper
-
-        # Mock the import to fail at the point where it's actually imported in the function
-        with patch.dict("sys.modules", {"faster_whisper": None}):
-            with self.assertRaises(RuntimeError) as cm:
-                _transcribe_faster_whisper("/path/to/audio.wav", "small", None)
-
-            self.assertIn("faster-whisper is not installed", str(cm.exception))
-
-
-class TestTranscribeOpenAIWhisper(unittest.TestCase):
-    """Tests for the _transcribe_openai_whisper() function."""
-
-    def setUp(self):
-        """Reset cached model between tests."""
-        import sys2txt.transcribe as t
-
-        t._openai_whisper_model = None
-        t._openai_whisper_model_key = None
-
-        if "whisper" not in sys.modules:
-            patcher = patch.dict("sys.modules", {"whisper": MagicMock()})
-            patcher.start()
-            self.addCleanup(patcher.stop)
-
-    @patch("whisper.load_model")
-    def test_transcribe_openai_whisper_no_timestamps(self, mock_load_model):
-        """Test _transcribe_openai_whisper() without timestamps."""
-        from sys2txt.transcribe import _transcribe_openai_whisper
-
-        mock_model = MagicMock()
-        mock_load_model.return_value = mock_model
-        mock_model.transcribe.return_value = {"text": " Hello world "}
-
-        result = _transcribe_openai_whisper("/path/to/audio.wav", "small", None)
-
-        self.assertEqual(result.cues, (Cue(0.0, 0.0, "Hello world"),))
-        mock_load_model.assert_called_once_with("small")
-        mock_model.transcribe.assert_called_once_with("/path/to/audio.wav", language=None)
-
-    @patch("whisper.load_model")
-    def test_transcribe_openai_whisper_with_timestamps(self, mock_load_model):
-        """Test _transcribe_openai_whisper() with timestamps."""
-        from sys2txt.transcribe import _transcribe_openai_whisper
-
-        mock_model = MagicMock()
-        mock_load_model.return_value = mock_model
-        mock_model.transcribe.return_value = {
-            "text": "Hello world",
-            "segments": [
-                {"start": 0.0, "end": 1.5, "text": " Hello "},
-                {"start": 1.5, "end": 3.0, "text": " world "},
-            ],
-        }
-
-        result = _transcribe_openai_whisper("/path/to/audio.wav", "base", "en")
-
-        self.assertEqual(result.cues, (Cue(0.0, 1.5, "Hello"), Cue(1.5, 3.0, "world")))
-        self.assertEqual(result.language, "en")
-        mock_model.transcribe.assert_called_once_with("/path/to/audio.wav", language="en")
-
-    def test_transcribe_openai_whisper_not_installed(self):
-        """Test _transcribe_openai_whisper() raises RuntimeError when not installed."""
-        from sys2txt.transcribe import _transcribe_openai_whisper
-
-        # Mock the import to fail at the point where it's actually imported in the function
-        with patch.dict("sys.modules", {"whisper": None}):
-            with self.assertRaises(RuntimeError) as cm:
-                _transcribe_openai_whisper("/path/to/audio.wav", "small", None)
-
-            self.assertIn("openai-whisper is not installed", str(cm.exception))
-
-
-class TestResolveWhisperCppBinary(unittest.TestCase):
-    """Tests for the _resolve_whisper_cpp_binary() function."""
-
-    def test_explicit_path_valid(self):
-        """Test explicit path that exists."""
-        from sys2txt.transcribe import _resolve_whisper_cpp_binary
-
-        with patch("os.path.isfile", return_value=True):
-            result = _resolve_whisper_cpp_binary("/path/to/whisper-cli")
-
-        self.assertEqual(result, "/path/to/whisper-cli")
-
-    def test_explicit_path_invalid(self):
-        """Test explicit path that doesn't exist."""
-        from sys2txt.transcribe import _resolve_whisper_cpp_binary
-
-        with patch("os.path.isfile", return_value=False):
-            with self.assertRaises(RuntimeError) as cm:
-                _resolve_whisper_cpp_binary("/path/to/whisper-cli")
-
-        self.assertIn("not found at", str(cm.exception))
-
-    @patch.dict(os.environ, {"SYS2TXT_WHISPER_CPP": "/env/whisper-cli"})
-    def test_env_var_valid(self):
-        """Test environment variable path that exists."""
-        from sys2txt.transcribe import _resolve_whisper_cpp_binary
-
-        with patch("os.path.isfile", return_value=True):
-            result = _resolve_whisper_cpp_binary(None)
-
-        self.assertEqual(result, "/env/whisper-cli")
-
-    @patch.dict(os.environ, {"SYS2TXT_WHISPER_CPP": "/env/whisper-cli"})
-    def test_env_var_invalid(self):
-        """Test environment variable path that doesn't exist."""
-        from sys2txt.transcribe import _resolve_whisper_cpp_binary
-
-        with patch("os.path.isfile", return_value=False):
-            with self.assertRaises(RuntimeError) as cm:
-                _resolve_whisper_cpp_binary(None)
-
-        self.assertIn("SYS2TXT_WHISPER_CPP", str(cm.exception))
-
-    @patch.dict(os.environ, {}, clear=True)
-    def test_path_lookup_found(self):
-        """Test PATH lookup succeeds."""
-        from sys2txt.transcribe import _resolve_whisper_cpp_binary
-
-        with patch("shutil.which", return_value="/usr/bin/whisper-cli"):
-            result = _resolve_whisper_cpp_binary(None)
-
-        self.assertEqual(result, "/usr/bin/whisper-cli")
-
-    @patch.dict(os.environ, {}, clear=True)
-    def test_path_lookup_not_found(self):
-        """Test PATH lookup fails."""
-        from sys2txt.transcribe import _resolve_whisper_cpp_binary
-
-        with patch("shutil.which", return_value=None):
-            with self.assertRaises(RuntimeError) as cm:
-                _resolve_whisper_cpp_binary(None)
-
-        self.assertIn("whisper-cli binary not found", str(cm.exception))
-
-
-class TestResolveWhisperCppModelPath(unittest.TestCase):
-    """Tests for the _resolve_whisper_cpp_model_path() function."""
-
-    def test_explicit_path_valid(self):
-        """Test explicit model path that exists."""
-        from sys2txt.transcribe import _resolve_whisper_cpp_model_path
-
-        with patch("os.path.isfile", return_value=True):
-            result = _resolve_whisper_cpp_model_path("/path/to/model.bin", "small")
-
-        self.assertEqual(result, "/path/to/model.bin")
-
-    def test_explicit_path_invalid(self):
-        """Test explicit model path that doesn't exist."""
-        from sys2txt.transcribe import _resolve_whisper_cpp_model_path
-
-        with patch("os.path.isfile", return_value=False):
-            with self.assertRaises(RuntimeError) as cm:
-                _resolve_whisper_cpp_model_path("/path/to/model.bin", "small")
-
-        self.assertIn("not found at", str(cm.exception))
-
-    @patch.dict(os.environ, {"SYS2TXT_WHISPER_CPP_MODELS": "/models"})
-    def test_env_var_models_dir(self):
-        """Test models directory from environment variable."""
-        from sys2txt.transcribe import _resolve_whisper_cpp_model_path
-
-        with patch("os.path.isfile", return_value=True):
-            result = _resolve_whisper_cpp_model_path(None, "small")
-
-        self.assertEqual(result, "/models/ggml-small.bin")
-
-    @patch.dict(os.environ, {}, clear=True)
-    def test_default_path(self):
-        """Test default path in ~/.local/share/whisper.cpp/models/."""
-        from sys2txt.transcribe import _resolve_whisper_cpp_model_path
-
-        expected_path = Path.home() / ".local" / "share" / "whisper.cpp" / "models" / "ggml-tiny.bin"
-
-        with patch.object(Path, "is_file", return_value=True):
-            result = _resolve_whisper_cpp_model_path(None, "tiny")
-
-        self.assertEqual(result, str(expected_path))
-
-    @patch.dict(os.environ, {}, clear=True)
-    def test_model_not_found(self):
-        """Test model not found anywhere."""
-        from sys2txt.transcribe import _resolve_whisper_cpp_model_path
-
-        with patch("os.path.isfile", return_value=False):
-            with patch.object(Path, "is_file", return_value=False):
-                with self.assertRaises(RuntimeError) as cm:
-                    _resolve_whisper_cpp_model_path(None, "small")
-
-        self.assertIn("ggml-small.bin", str(cm.exception))
-
-
-class TestParseWhisperCppOutput(unittest.TestCase):
-    """Tests for the _parse_whisper_cpp_output() function."""
-
-    def test_parse_keeps_cue_times(self):
-        """Test parsing whisper.cpp output into cues that keep their times."""
-        from sys2txt.transcribe import _parse_whisper_cpp_output
-
-        output = """[00:00:00.000 --> 00:00:05.120]   Hello world
-[00:00:05.120 --> 00:00:10.240]   This is a test"""
-
-        result = _parse_whisper_cpp_output(output)
-
-        self.assertEqual(
-            result.cues,
-            (Cue(0.0, 5.12, "Hello world"), Cue(5.12, 10.24, "This is a test")),
-        )
-
-    def test_parse_records_the_language(self):
-        """Test that the requested language is recorded on the transcript."""
-        from sys2txt.transcribe import _parse_whisper_cpp_output
-
-        result = _parse_whisper_cpp_output("[00:00:00.000 --> 00:00:05.120]   Bonjour", "fr")
-
-        self.assertEqual(result.language, "fr")
-
-    def test_parse_empty_segments_ignored(self):
-        """Test that empty segments are ignored."""
-        from sys2txt.transcribe import _parse_whisper_cpp_output
-
-        output = """[00:00:00.000 --> 00:00:05.120]   Hello
-[00:00:05.120 --> 00:00:10.240]
-[00:00:10.240 --> 00:00:15.000]   World"""
-
-        result = _parse_whisper_cpp_output(output)
-
-        self.assertEqual(result.text, "Hello World")
-
-    def test_parse_non_matching_lines_ignored(self):
-        """Test that non-matching lines are ignored."""
-        from sys2txt.transcribe import _parse_whisper_cpp_output
-
-        output = """whisper_init_from_file_no_state: loading model...
-[00:00:00.000 --> 00:00:05.120]   Hello world
-main: some debug output"""
-
-        result = _parse_whisper_cpp_output(output)
-
-        self.assertEqual(result.text, "Hello world")
-
-
-class TestTimestampToSeconds(unittest.TestCase):
-    """Tests for the _timestamp_to_seconds() function."""
-
-    def test_simple_seconds(self):
-        """Test simple seconds conversion."""
-        from sys2txt.transcribe import _timestamp_to_seconds
-
-        result = _timestamp_to_seconds("00:00:05.120")
-        self.assertAlmostEqual(result, 5.12, places=3)
-
-    def test_minutes_and_seconds(self):
-        """Test minutes and seconds conversion."""
-        from sys2txt.transcribe import _timestamp_to_seconds
-
-        result = _timestamp_to_seconds("00:02:30.500")
-        self.assertAlmostEqual(result, 150.5, places=3)
-
-    def test_hours_minutes_seconds(self):
-        """Test hours, minutes, and seconds conversion."""
-        from sys2txt.transcribe import _timestamp_to_seconds
-
-        result = _timestamp_to_seconds("01:30:45.750")
-        self.assertAlmostEqual(result, 5445.75, places=3)
-
-
-class TestTranscribeWhisperCpp(unittest.TestCase):
-    """Tests for the _transcribe_whisper_cpp() function."""
-
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
-    @patch("subprocess.run")
-    def test_transcribe_success(self, mock_run, mock_model_path, mock_binary):
-        """Test successful transcription."""
-        from sys2txt.transcribe import _transcribe_whisper_cpp
-
-        mock_binary.return_value = "/path/to/whisper-cli"
-        mock_model_path.return_value = "/path/to/model.bin"
-        mock_run.return_value = MagicMock(
-            stdout="[00:00:00.000 --> 00:00:05.000]   Hello world\n",
-            returncode=0,
-        )
-
-        result = _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, None, None, "auto")
-
-        self.assertEqual(result.cues, (Cue(0.0, 5.0, "Hello world"),))
-        mock_run.assert_called_once()
-
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
-    @patch("subprocess.run")
-    def test_transcribe_with_language(self, mock_run, mock_model_path, mock_binary):
-        """Test transcription with language specified."""
-        from sys2txt.transcribe import _transcribe_whisper_cpp
-
-        mock_binary.return_value = "/path/to/whisper-cli"
-        mock_model_path.return_value = "/path/to/model.bin"
-        mock_run.return_value = MagicMock(
-            stdout="[00:00:00.000 --> 00:00:05.000]   Bonjour\n",
-            returncode=0,
-        )
-
-        _transcribe_whisper_cpp("/path/to/audio.wav", "small", "fr", None, None, "auto")
-
-        # Check -l fr is in the command
-        call_args = mock_run.call_args[0][0]
-        self.assertIn("-l", call_args)
-        self.assertIn("fr", call_args)
-
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
-    @patch("subprocess.run")
-    def test_transcribe_cpu_device(self, mock_run, mock_model_path, mock_binary):
-        """Test transcription with CPU device adds --no-gpu flag."""
-        from sys2txt.transcribe import _transcribe_whisper_cpp
-
-        mock_binary.return_value = "/path/to/whisper-cli"
-        mock_model_path.return_value = "/path/to/model.bin"
-        mock_run.return_value = MagicMock(
-            stdout="[00:00:00.000 --> 00:00:05.000]   Hello\n",
-            returncode=0,
-        )
-
-        _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, None, None, "cpu")
-
-        call_args = mock_run.call_args[0][0]
-        self.assertIn("--no-gpu", call_args)
-
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
-    @patch("subprocess.run")
-    def test_transcribe_vulkan_device(self, mock_run, mock_model_path, mock_binary):
-        """Test transcription with Vulkan device does not add --no-gpu."""
-        from sys2txt.transcribe import _transcribe_whisper_cpp
-
-        mock_binary.return_value = "/path/to/whisper-cli"
-        mock_model_path.return_value = "/path/to/model.bin"
-        mock_run.return_value = MagicMock(
-            stdout="[00:00:00.000 --> 00:00:05.000]   Hello\n",
-            returncode=0,
-        )
-
-        _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, None, None, "vulkan")
-
-        call_args = mock_run.call_args[0][0]
-        self.assertNotIn("--no-gpu", call_args)
-
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
-    @patch("subprocess.run")
-    def test_transcribe_no_timestamps_does_not_pass_no_timestamps_flag(self, mock_run, mock_model_path, mock_binary):
-        """Regression test for #42: --no-timestamps must never be passed to whisper-cli.
-
-        whisper-cli only emits bracketed timestamp lines when timestamps are enabled;
-        with --no-timestamps its plain-text output doesn't match the parser's regex,
-        so the transcript would silently come back empty.
-        """
-        from sys2txt.transcribe import _transcribe_whisper_cpp
-
-        mock_binary.return_value = "/path/to/whisper-cli"
-        mock_model_path.return_value = "/path/to/model.bin"
-        mock_run.return_value = MagicMock(
-            stdout="[00:00:00.000 --> 00:00:05.000]   Hello world\n",
-            returncode=0,
-        )
-
-        result = _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, None, None, "auto")
-
-        call_args = mock_run.call_args[0][0]
-        self.assertNotIn("--no-timestamps", call_args)
-        self.assertEqual(result.text, "Hello world")
-
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
-    @patch("subprocess.run")
-    def test_transcribe_failure(self, mock_run, mock_model_path, mock_binary):
-        """Test transcription failure raises RuntimeError."""
-        import subprocess
-
-        from sys2txt.transcribe import _transcribe_whisper_cpp
-
-        mock_binary.return_value = "/path/to/whisper-cli"
-        mock_model_path.return_value = "/path/to/model.bin"
-        mock_run.side_effect = subprocess.CalledProcessError(1, "whisper-cli", stderr="Error: model not found")
-
-        with self.assertRaises(RuntimeError) as cm:
-            _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, None, None, "auto")
-
-        self.assertIn("whisper-cli failed", str(cm.exception))
-
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_binary")
-    @patch("sys2txt.transcribe._resolve_whisper_cpp_model_path")
-    @patch("subprocess.run")
-    def test_transcribe_timeout_raises_runtime_error(self, mock_run, mock_model_path, mock_binary):
-        """Test that a hung whisper-cli process raises RuntimeError after timeout."""
-        import subprocess
-
-        from sys2txt.transcribe import _transcribe_whisper_cpp
-
-        mock_binary.return_value = "/path/to/whisper-cli"
-        mock_model_path.return_value = "/path/to/model.bin"
-        mock_run.side_effect = subprocess.TimeoutExpired(cmd="whisper-cli", timeout=300)
-
-        with self.assertRaises(RuntimeError) as cm:
-            _transcribe_whisper_cpp("/path/to/audio.wav", "small", None, None, None, "auto")
-
-        self.assertIn("timed out", str(cm.exception))
-
-
-class TestModelCacheThreadSafety(unittest.TestCase):
-    """Tests that model caching is thread-safe."""
-
-    def setUp(self):
-        """Reset cached model between tests."""
-        import sys2txt.transcribe as t
-
-        t._faster_whisper_model = None
-        t._faster_whisper_model_key = None
-
-        if "faster_whisper" not in sys.modules:
-            patcher = patch.dict("sys.modules", {"faster_whisper": MagicMock()})
-            patcher.start()
-            self.addCleanup(patcher.stop)
-
-    @patch("faster_whisper.WhisperModel")
-    def test_concurrent_calls_load_model_once(self, mock_model_class):
-        """Concurrent transcriptions with same params should only load the model once."""
-        import threading
-
-        from sys2txt.transcribe import _transcribe_faster_whisper
-
-        seg = MagicMock()
-        seg.text = " Hello "
-        seg.start = 0.0
-        seg.end = 1.0
-
-        mock_model = mock_model_class.return_value
-        mock_model.transcribe.return_value = ([seg], None)
-
-        barrier = threading.Barrier(4)
-        errors = []
-
-        def worker():
-            try:
-                barrier.wait(timeout=5)
-                _transcribe_faster_whisper("/path/to/audio.wav", "small", None, device="cpu")
-            except Exception as e:
-                errors.append(e)
-
-        threads = [threading.Thread(target=worker) for _ in range(4)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join(timeout=10)
-
-        self.assertEqual(errors, [])
-        mock_model_class.assert_called_once_with("small", device="cpu", compute_type="int8")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The three backends were three private functions with three different positional
signatures, chosen by an if/elif chain that destructured TranscriptionConfig back
into the arguments it was introduced to bundle. Availability was an inline import
ladder, so `auto` fell through to whisper.cpp with nothing installed and reported a
missing whisper-cli binary rather than a missing engine. Cached models lived in four
module-level globals, which meant one cache for all engines, an openai-whisper key
that ignored the device, no way to release a model, and tests that reset state by
assigning to module privates.

Engines now live in sys2txt/engines.py behind a TranscriptionEngine protocol of
name, is_available(), transcribe(path, config) and unload(), walked by a registry:

- Each engine takes the config whole, so adding one is writing a class and adding it
  to ENGINES; the --engine choices derive from the registry via ENGINE_NAMES.
- `auto` returns the first available engine and, when none is, raises a RuntimeError
  naming all three and how to install them. A named engine skips the probe, so an
  explicit --engine still yields that backend's own diagnostic.
- Each engine owns its cached model, keyed on everything that determines it, with
  unload() to release it. openai-whisper now resolves --device/SYS2TXT_DEVICE the
  same way faster-whisper does and passes it to load_model(), which both fixes the
  cache key and makes --device cuda reach the engine instead of being ignored.

transcribe.py keeps transcribe_file/transcribe_file_cues and re-exports
TranscriptionConfig, so the public API is unchanged apart from two additions:
TranscriptionEngine and ENGINE_NAMES.

Closes #63

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018LboCHysr6cdZvUPDBk69u