### PR TITLE
feat: report and cap how far live transcription falls behind recording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ Common flags:
 - `--duration <seconds>`: (once mode) Fixed recording duration
 - `--segment-seconds <n>`: (live mode) Segment length (default: 8)
 - `--silence-timeout <seconds>`: (live mode) Auto-stop after N consecutive seconds of silence (0=disabled, default: 0)
+- `--max-lag <seconds>`: (live mode) Untranscribed audio tolerated before `--on-lag` applies (0=unlimited, default: 0)
+- `--on-lag {drop,fail}`: (live mode) What to do past `--max-lag` (default: drop). Requires `--max-lag`
 - `--timestamps`: Include timestamps in output
 - `--model-path <path>`: Path to whisper.cpp model file (for cpp engine)
 - `--whisper-cpp-path <path>`: Path to whisper-cli binary (for cpp engine)
@@ -76,9 +78,9 @@ The codebase is organized into focused modules by functionality:
 ### Core Modules
 
 **audio.py** - Audio recording, and nothing else:
-- `AudioSegment`: Frozen dataclass of `(index, path)` for one finalized chunk of recorded audio
+- `AudioSegment`: Frozen dataclass of `(index, path, lag, dropped)` for one finalized chunk of recorded audio. `lag` is the seconds of finalized audio still queued behind it; `dropped` counts the segments discarded immediately before it
 - `record_once()`: Spawns ffmpeg subprocess to record from PulseAudio/PipeWire source to WAV file. `sample_rate`/`channels` are keyword-only and default to the constants.
-- `iter_audio_segments()`: Generator. Spawns ffmpeg with the segment muxer, polls the temporary directory for finalized segments, and yields an `AudioSegment` for each. Indices are tracked by a counter (a segment holding no audio is skipped but still consumes its index). A consumer that breaks out of the loop or closes the generator triggers the `finally` that sends `q` to ffmpeg and removes the temporary directory. No transcription, no printing, no file writing.
+- `iter_audio_segments()`: Generator. Spawns ffmpeg with the segment muxer, polls the temporary directory for finalized segments, and yields one `AudioSegment` per pass of the loop, so the queue is re-measured every time the consumer comes back. Indices are tracked by a counter (a segment holding no audio, or one dropped to catch up, is skipped but still consumes its index, so `index * segment_seconds` always lands on the recording's timeline). `max_lag` caps the queue by discarding the oldest segments; 0 keeps everything. A yielded file is removed once the consumer asks for the next one, so the temporary directory holds the backlog rather than the whole session. A consumer that breaks out of the loop or closes the generator triggers the `finally` that sends `q` to ffmpeg and removes the temporary directory. No transcription, no printing, no file writing.
 
 **formats.py** - Transcript data types and output formats:
 - `Cue`: Frozen dataclass of `(start, end, text)`; one timed span of speech, in seconds from the start of the recording. `shifted(offset)` moves it along the timeline
@@ -90,8 +92,8 @@ The codebase is organized into focused modules by functionality:
 - Pure formatting: no engine imports, no printing, no file writing
 
 **pipeline.py** - Recording and transcription combined:
-- `TranscriptSegment`: Frozen dataclass of `(index, text, start, end, cues, error)` with a `failed` property. `start`/`end` are the segment's fixed window on the recording clock; `cues` are the engine's own per-utterance spans, rebased onto that timeline by adding the segment's start. `error` is `None` on success and holds the reason on failure, which is what distinguishes a failed segment from a silent one (both have empty `text`).
-- `transcribe_live()`: Generator over `iter_audio_segments()`, transcribing each segment on a single-worker `ThreadPoolExecutor` with a timeout. A segment that fails or times out is yielded with empty text and an `error`, and logged as a warning. A timed-out worker cannot be cancelled, so the pool is abandoned (`_new_executor()` builds a replacement) rather than letting the next segment queue behind it and time out too.
+- `TranscriptSegment`: Frozen dataclass of `(index, text, start, end, cues, error, lag, dropped)` with a `failed` property. `start`/`end` are the segment's fixed window on the recording clock; `cues` are the engine's own per-utterance spans, rebased onto that timeline by adding the segment's start. `error` is `None` on success and holds the reason on failure, which is what distinguishes a failed segment from a silent one (both have empty `text`). `lag` and `dropped` come straight from the `AudioSegment` and say how far behind recording transcription has fallen.
+- `transcribe_live()`: Generator over `iter_audio_segments()`, transcribing each segment on a single-worker `ThreadPoolExecutor` with a timeout. `max_lag` is passed straight through to the recorder, since the backlog it caps is the recorder's. `_warn_lag()` warns once the backlog passes `LAG_WARN_FACTOR` segments and then only as it grows by another segment, so a slow run reports its drift without filling the log. A segment that fails or times out is yielded with empty text and an `error`, and logged as a warning. A timed-out worker cannot be cancelled, so the pool is abandoned (`_new_executor()` builds a replacement) rather than letting the next segment queue behind it and time out too.
 - `transcribe_once()`: Records to a temporary WAV and returns its transcript as text
 - `transcribe_once_cues()`: The structured form of `transcribe_once()`, returning a `Transcript`
 
@@ -121,7 +123,7 @@ The codebase is organized into focused modules by functionality:
 - `transcribe_file(path, config)`: The text form, `render_transcript(..., "txt", timestamps=config.timestamps)` over the above. Output is unchanged from before formats existed
 - Re-exports `TranscriptionConfig` from `engines.py`, so `from sys2txt.transcribe import TranscriptionConfig` keeps working
 
-**constants.py** - Configuration shared by library and CLI: default model, capture `SAMPLE_RATE`/`CHANNELS`, segment length and poll interval, minimum segment size, ffmpeg shutdown grace, transcription timeouts, `MAX_CONSECUTIVE_SEGMENT_FAILURES`, default output format.
+**constants.py** - Configuration shared by library and CLI: default model, capture `SAMPLE_RATE`/`CHANNELS`, segment length and poll interval, minimum segment size, ffmpeg shutdown grace, transcription timeouts, `LAG_WARN_FACTOR`, `MAX_CONSECUTIVE_SEGMENT_FAILURES`, default output format.
 
 **utils.py** - Utility functions:
 - `which()`: Find command in PATH or raise RuntimeError
@@ -130,9 +132,9 @@ The codebase is organized into focused modules by functionality:
 
 **__main__.py** - CLI entry point, and the only module that prints:
 - argparse with subcommands: `once` and `live`, built by `_build_parser()`
-- `Options`: Frozen dataclass; `_build_options(args)` converts the argparse `Namespace` once and validates it (missing `--input` file, non-positive `--duration`/`--segment-seconds`, `--silence-timeout` shorter than a segment), raising `ValueError` that `main()` turns into a usage error (exit 2)
+- `Options`: Frozen dataclass; `_build_options(args)` converts the argparse `Namespace` once and validates it (missing `--input` file, non-positive `--duration`/`--segment-seconds`, `--silence-timeout` or `--max-lag` shorter than a segment, `--on-lag` without a `--max-lag`), raising `ValueError` that `main()` turns into a usage error (exit 2)
 - `_run_once()`: Transcribes to cues, renders them in `--format`, and prints and writes the document
-- `_run_live()`: Consumes `transcribe_live()`, formatting and printing each segment, and applying the stop policies by breaking out of the loop. Plain text keeps its per-segment line format and appends to the output file; the timed formats stream a document through `get_formatter()`, opening the file for writing and emitting the footer after the loop so Ctrl-C and the silence timeout both close it. Silence is measured along the segment timeline (`segment.end` minus the start of the silent stretch), so skipped segments are accounted for. Failed segments never count as silence; `MAX_CONSECUTIVE_SEGMENT_FAILURES` of them in a row save the transcript and raise `RuntimeError`, which `main()` turns into an error and exit 1
+- `_run_live()`: Consumes `transcribe_live()`, formatting and printing each segment, and applying the stop policies by breaking out of the loop. Plain text keeps its per-segment line format and appends to the output file; the timed formats stream a document through `get_formatter()`, opening the file for writing and emitting the footer after the loop so Ctrl-C and the silence timeout both close it. Silence is measured along the segment timeline (`segment.end` minus the start of the silent stretch), so skipped segments are accounted for. Failed segments never count as silence; `MAX_CONSECUTIVE_SEGMENT_FAILURES` of them in a row save the transcript and raise `RuntimeError`, which `main()` turns into an error and exit 1. Backpressure policy lives here too: `--on-lag drop` forwards `--max-lag` to `transcribe_live()`, while `--on-lag fail` withholds it and instead breaks out of the loop once `segment.lag` passes it, taking the same save-then-`RuntimeError` path so the document is still closed. Dropped audio resets the silence stretch without counting as a failure
 
 ### Key Dependencies
 - **ffmpeg**: System command for audio recording (checked via shutil.which)

--- a/README.md
+++ b/README.md
@@ -88,8 +88,43 @@ sys2txt live --model small.en --segment-seconds 8
 - `--duration <seconds>` - (once mode) Record fixed duration instead of waiting for Ctrl-C
 - `--segment-seconds <n>` - (live mode) Segment length in seconds (default: 8)
 - `--silence-timeout <seconds>` - (live mode) Stop automatically after N consecutive seconds of silence (0=disabled, default: 0). Segments that fail to transcribe do not count as silence
+- `--max-lag <seconds>` - (live mode) Untranscribed audio to tolerate before `--on-lag` applies
+  (0=unlimited, default: 0). See [Keeping up with real time](#keeping-up-with-real-time)
+- `--on-lag <drop|fail>` - (live mode) What to do once the backlog passes `--max-lag`: drop the oldest
+  audio to catch up, or stop with an error (default: drop). Requires `--max-lag`
 - `--timestamps` - Print timestamps alongside text (plain text only; the timed formats always carry
   their own)
+
+### Keeping up with real time
+
+Recording never waits for transcription. ffmpeg finalizes a segment every `--segment-seconds` whatever
+the transcriber is doing, so a model that takes longer than that per segment — a large model on CPU, a
+busy machine, or a short `--segment-seconds` chosen for latency — falls further behind every segment,
+and "live" output quietly stops being live.
+
+Live mode measures that backlog and warns once it is more than a couple of segments deep:
+
+```
+WARNING: Transcription is not keeping up: 32s of audio (4 segments) waiting to be transcribed
+```
+
+By default nothing is discarded: the backlog is transcribed in full, just late. To bound it, set a
+tolerance and a policy:
+
+```bash
+# stay close to live, discarding the oldest audio when more than 30s is queued
+sys2txt live --model medium --segment-seconds 5 --max-lag 30
+
+# or refuse to run behind: save what was transcribed and exit non-zero
+sys2txt live --model medium --segment-seconds 5 --max-lag 30 --on-lag fail
+```
+
+`drop` keeps the newest audio, so the transcript has a hole where the dropped segments were. Timestamps
+stay true to the recording, so a gap in them is exactly that hole. Dropped audio is never counted as
+silence by `--silence-timeout`, since nobody transcribed it.
+
+Segment files are removed as soon as they have been transcribed, so the temporary directory holds the
+backlog rather than the whole session either way.
 
 ### Output formats
 
@@ -131,6 +166,12 @@ Produce subtitles for a recording, ready to drop next to a video:
 ```bash
 sys2txt once --input talk.wav --format srt --output talk.srt
 sys2txt once --input talk.wav --format vtt --output talk.vtt
+```
+
+Keep a slow model close to live, dropping audio rather than falling more than a minute behind:
+
+```bash
+sys2txt live --model medium --segment-seconds 5 --max-lag 60
 ```
 
 Capture a meeting live as WebVTT, stopping after 30 seconds of silence:
@@ -210,10 +251,21 @@ the failure (`segment.failed` is `True`) and a warning in the log, so a failure 
 and is never mistaken for silence. A segment that times out does not hold up the ones after it: its
 worker is abandoned and the next segment is transcribed on a fresh one.
 
-To handle the audio yourself, `iter_audio_segments()` yields `AudioSegment(index, path)` values without
-transcribing them, and `transcribe_file(path, config)` transcribes any audio file. Nothing in the library
-prints or writes files, and every module logs through the standard `logging` module under the `sys2txt`
-logger.
+Each segment also reports how far behind recording it is. `segment.lag` is the seconds of audio still
+waiting to be transcribed — zero while you keep up — and `segment.dropped` counts segments discarded
+just before it. Pass `max_lag=` to cap the backlog by dropping the oldest audio:
+
+```python
+for segment in transcribe_live(source, config, segment_seconds=8, max_lag=30):
+    if segment.dropped:
+        print(f"... {segment.dropped} segment(s) of audio dropped ...")
+```
+
+To handle the audio yourself, `iter_audio_segments()` yields `AudioSegment(index, path, lag, dropped)`
+values without transcribing them, and `transcribe_file(path, config)` transcribes any audio file. A
+segment's file is removed as soon as you ask for the next one, so copy it if you need it later. Nothing
+in the library prints or writes files, and every module logs through the standard `logging` module under
+the `sys2txt` logger.
 
 For timed output, use the `_cues` variants and render them yourself. They return a `Transcript` of
 `Cue(start, end, text)` values plus the detected language, which `render_transcript()` turns into any

--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -45,6 +45,8 @@ class Options:
     input_path: Optional[str] = None
     segment_seconds: int = DEFAULT_SEGMENT_SECONDS
     silence_timeout: int = 0
+    max_lag: float = 0.0
+    on_lag: str = "drop"
     output_format: str = DEFAULT_OUTPUT_FORMAT
 
 
@@ -93,6 +95,8 @@ def _build_options(args: argparse.Namespace) -> Options:
     duration = getattr(args, "duration", None)
     segment_seconds = getattr(args, "segment_seconds", DEFAULT_SEGMENT_SECONDS)
     silence_timeout = getattr(args, "silence_timeout", 0)
+    max_lag = getattr(args, "max_lag", 0.0)
+    on_lag = getattr(args, "on_lag", None)
 
     if input_path and not os.path.isfile(input_path):
         raise ValueError(f"--input file not found: {input_path}")
@@ -107,6 +111,15 @@ def _build_options(args: argparse.Namespace) -> Options:
             f"--silence-timeout ({silence_timeout}s) must be at least --segment-seconds "
             f"({segment_seconds}s), since silence is only measured a whole segment at a time"
         )
+    if max_lag < 0:
+        raise ValueError(f"--max-lag must not be negative, got {max_lag}")
+    if 0 < max_lag < segment_seconds:
+        raise ValueError(
+            f"--max-lag ({max_lag:g}s) must be at least --segment-seconds ({segment_seconds}s), "
+            "since the backlog is only measured a whole segment at a time"
+        )
+    if on_lag is not None and max_lag <= 0:
+        raise ValueError(f"--on-lag {on_lag} needs a --max-lag to say how far behind is too far")
 
     output_format = getattr(args, "output_format", DEFAULT_OUTPUT_FORMAT)
     if args.timestamps and output_format in TIMED_FORMATS:
@@ -134,6 +147,8 @@ def _build_options(args: argparse.Namespace) -> Options:
         input_path=input_path,
         segment_seconds=segment_seconds,
         silence_timeout=silence_timeout,
+        max_lag=max_lag,
+        on_lag=on_lag or "drop",
         output_format=output_format,
     )
 
@@ -289,6 +304,25 @@ def _build_parser() -> argparse.ArgumentParser:
         default=0,
         help="Auto-stop after N consecutive seconds of silence (0=disabled, default: 0)",
     )
+    live.add_argument(
+        "--max-lag",
+        type=float,
+        default=0.0,
+        metavar="SECONDS",
+        help=(
+            "Seconds of untranscribed audio to tolerate before --on-lag applies "
+            "(0=unlimited, default: 0). Falling behind is always warned about"
+        ),
+    )
+    live.add_argument(
+        "--on-lag",
+        choices=["drop", "fail"],
+        default=None,
+        help=(
+            "What to do once the backlog exceeds --max-lag: drop the oldest segments to catch "
+            "up, or stop with an error (default: drop). Requires --max-lag"
+        ),
+    )
 
     return parser
 
@@ -367,7 +401,9 @@ def _run_live(options: Options, source: str) -> None:
         None if options.output_format == "txt" else get_formatter(options.output_format, language=options.language)
     )
 
-    segments = transcribe_live(source, config, segment_seconds=options.segment_seconds)
+    # Only the drop policy is the recorder's business; failing is a decision about the run.
+    max_lag = options.max_lag if options.on_lag == "drop" else 0.0
+    segments = transcribe_live(source, config, segment_seconds=options.segment_seconds, max_lag=max_lag)
     silence_start: Optional[float] = None
     failures = 0
     failure: Optional[str] = None
@@ -385,6 +421,18 @@ def _run_live(options: Options, source: str) -> None:
                     else:
                         for cue in segment.cues:
                             _emit(formatter.cue(cue), handle)
+
+                    if segment.dropped:
+                        # Dropped audio says nothing about what was said in it, so it neither
+                        # counts as speech nor accumulates towards the silence timeout.
+                        silence_start = None
+
+                    if options.on_lag == "fail" and 0 < options.max_lag < segment.lag:
+                        failure = (
+                            f"Transcription fell {segment.lag:.0f}s behind, past the "
+                            f"--max-lag of {options.max_lag:g}s, stopping."
+                        )
+                        break
 
                     if segment.failed:
                         # A failure says nothing about what the segment held, so it neither

--- a/src/sys2txt/audio.py
+++ b/src/sys2txt/audio.py
@@ -1,5 +1,6 @@
 """Audio recording functionality using ffmpeg and PulseAudio/PipeWire."""
 
+import contextlib
 import logging
 import os
 import signal
@@ -28,12 +29,18 @@ class AudioSegment:
 
     Attributes:
         index: Position of the segment in the recording, counting from 0
-        path: Path to the segment's WAV file. It lives in a temporary directory that is
-            removed once the producing generator is closed, so copy it if you need it later.
+        path: Path to the segment's WAV file. It is removed as soon as the consumer asks for
+            the next segment, so copy it if you need it later.
+        lag: Seconds of finalized audio recorded but not yet handed out, queued behind this
+            segment. Zero while transcription keeps up with recording.
+        dropped: Segments discarded immediately before this one to catch up, so a consumer can
+            see the hole. Always 0 unless ``max_lag`` is set.
     """
 
     index: int
     path: str
+    lag: float = 0.0
+    dropped: int = 0
 
 
 def _stop_ffmpeg(proc: subprocess.Popen) -> None:
@@ -116,12 +123,19 @@ def _segment_files(directory: str) -> List[str]:
     return sorted(f for f in os.listdir(directory) if f.startswith("seg_") and f.endswith(".wav"))
 
 
+def _discard(path: str) -> None:
+    """Remove a segment file we are done with, ignoring one that has already gone."""
+    with contextlib.suppress(OSError):
+        os.remove(path)
+
+
 def iter_audio_segments(
     source: str,
     segment_seconds: int = DEFAULT_SEGMENT_SECONDS,
     *,
     sample_rate: int = SAMPLE_RATE,
     channels: int = CHANNELS,
+    max_lag: float = 0.0,
 ) -> Iterator[AudioSegment]:
     """Record continuously and yield each segment of audio as ffmpeg finalizes it.
 
@@ -129,18 +143,27 @@ def iter_audio_segments(
     generator, or letting it be garbage collected shuts ffmpeg down gracefully and removes the
     temporary directory holding the segments.
 
+    ffmpeg finalizes a segment every ``segment_seconds`` whatever the consumer is doing, so a
+    consumer slower than realtime falls behind. Each segment reports how much audio is queued
+    behind it as its ``lag``; ``max_lag`` caps that queue by discarding the oldest segments,
+    trading audio for staying close to live.
+
     Args:
         source: PulseAudio source name
         segment_seconds: Length of each segment in seconds
         sample_rate: Sample rate in Hz
         channels: Number of audio channels
+        max_lag: Seconds of queued audio to tolerate before dropping the oldest segments,
+            or 0 to keep everything however far behind the consumer falls
 
     Yields:
         AudioSegment values in chronological order. Segment files that hold no audio are
-        skipped, but their index is still consumed so an index always maps to the same
-        position on the recording's timeline.
+        skipped, and dropped ones are never yielded, but their indices are still consumed so an
+        index always maps to the same position on the recording's timeline.
     """
     ffmpeg = which("ffmpeg")
+    # Keeping fewer than one segment would drop every segment as soon as it was finalized
+    keep = max(1, int(max_lag // segment_seconds)) if max_lag > 0 else 0
     with tempfile.TemporaryDirectory(prefix="sys2txt_") as tmp:
         pattern = os.path.join(tmp, "seg_%05d.wav")
         args = [
@@ -168,34 +191,59 @@ def iter_audio_segments(
         logger.info("Live mode: segmenting every %ds from '%s'.", segment_seconds, source)
         proc = subprocess.Popen(args, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
         seen: set[str] = set()
+        queue: List[str] = []
         next_index = 0
-
-        def emit(names):
-            """Yield an AudioSegment for each name not seen before."""
-            nonlocal next_index
-            for name in names:
-                if name in seen:
-                    continue
-                seen.add(name)
-                index = next_index
-                next_index += 1
-                path = os.path.join(tmp, name)
-                if os.path.getsize(path) < MIN_SEGMENT_BYTES:
-                    logger.debug("Segment %s holds no audio, skipping", name)
-                    continue
-                yield AudioSegment(index=index, path=path)
+        dropped = 0
 
         try:
+            # One segment is handed out per pass, so the queue is re-measured, and the drop
+            # policy re-applied, every time the consumer comes back for more.
             while True:
+                # Poll before listing, so a listing taken after ffmpeg exited is complete
+                finished = proc.poll() is not None
                 files = _segment_files(tmp)
-                # While ffmpeg is running, the last file is always the one currently
-                # being written. Only process files that have been finalized, which is
-                # guaranteed when a newer segment exists after them.
-                yield from emit(files[:-1] if len(files) > 1 else [])
+                # While ffmpeg is running, the last file is always the one currently being
+                # written. Only process files that have been finalized, which is guaranteed
+                # when a newer segment exists after them.
+                for name in files if finished else files[:-1]:
+                    if name not in seen:
+                        seen.add(name)
+                        queue.append(name)
 
-                if proc.poll() is not None:
-                    # ffmpeg has exited, so every remaining file is finalized
-                    yield from emit(_segment_files(tmp))
+                if keep and len(queue) > keep:
+                    stale, queue = queue[:-keep], queue[-keep:]
+                    for name in stale:
+                        next_index += 1
+                        dropped += 1
+                        _discard(os.path.join(tmp, name))
+                    logger.warning(
+                        "Transcription is behind: dropped %d segment(s), %ds of audio, to catch up",
+                        len(stale),
+                        len(stale) * segment_seconds,
+                    )
+
+                if queue:
+                    name = queue.pop(0)
+                    index = next_index
+                    next_index += 1
+                    path = os.path.join(tmp, name)
+                    if os.path.getsize(path) < MIN_SEGMENT_BYTES:
+                        logger.debug("Segment %s holds no audio, skipping", name)
+                        _discard(path)
+                        continue
+                    yield AudioSegment(
+                        index=index,
+                        path=path,
+                        lag=len(queue) * float(segment_seconds),
+                        dropped=dropped,
+                    )
+                    dropped = 0
+                    # The consumer has moved on, so the temporary directory holds the backlog
+                    # rather than every segment of the session.
+                    _discard(path)
+                    continue
+
+                if finished:
                     break
                 time.sleep(SEGMENT_POLL_INTERVAL)
         finally:

--- a/src/sys2txt/constants.py
+++ b/src/sys2txt/constants.py
@@ -32,6 +32,9 @@ MIN_TRANSCRIBE_TIMEOUT = 60
 WHISPER_CPP_TIMEOUT = 300
 "Seconds to wait for whisper-cli before assuming a GPU hang or malformed audio"
 
+LAG_WARN_FACTOR = 2
+"Live mode warns that it is falling behind once the backlog exceeds this many segments"
+
 MAX_CONSECUTIVE_SEGMENT_FAILURES = 3
 "Consecutive live-mode transcription failures tolerated before giving up"
 

--- a/src/sys2txt/pipeline.py
+++ b/src/sys2txt/pipeline.py
@@ -13,6 +13,7 @@ from .audio import iter_audio_segments, record_once
 from .constants import (
     CHANNELS,
     DEFAULT_SEGMENT_SECONDS,
+    LAG_WARN_FACTOR,
     MIN_TRANSCRIBE_TIMEOUT,
     SAMPLE_RATE,
     TRANSCRIBE_TIMEOUT_FACTOR,
@@ -37,6 +38,10 @@ class TranscriptSegment:
             Empty when the segment held no speech or transcription failed.
         error: Why transcription failed, or None when it succeeded. Silence and failure both
             leave ``text`` empty, so this is what tells them apart.
+        lag: Seconds of recorded audio waiting to be transcribed behind this segment. Zero
+            while transcription keeps up with recording.
+        dropped: Segments discarded immediately before this one to catch up, leaving a hole in
+            the transcript. Always 0 unless ``max_lag`` is set.
     """
 
     index: int
@@ -45,6 +50,8 @@ class TranscriptSegment:
     end: float
     cues: Tuple[Cue, ...] = ()
     error: Optional[str] = None
+    lag: float = 0.0
+    dropped: int = 0
 
     @property
     def failed(self) -> bool:
@@ -62,6 +69,25 @@ def _new_executor() -> ThreadPoolExecutor:
     return ThreadPoolExecutor(max_workers=1)
 
 
+def _warn_lag(lag: float, segment_seconds: int, warned_at: float) -> float:
+    """Warn that transcription is falling behind, and return the lag last warned about.
+
+    Recording carries on at its own pace, so a consumer slower than realtime falls further
+    behind every segment. Warn once the backlog is worth noticing, then only as it grows by
+    another segment, so a slow run reports its drift without filling the log.
+    """
+    if lag <= LAG_WARN_FACTOR * segment_seconds:
+        return 0.0
+    if lag < warned_at + segment_seconds:
+        return warned_at
+    logger.warning(
+        "Transcription is not keeping up: %.0fs of audio (%d segments) waiting to be transcribed",
+        lag,
+        round(lag / segment_seconds),
+    )
+    return lag
+
+
 def transcribe_live(
     source: str,
     config: TranscriptionConfig,
@@ -69,6 +95,7 @@ def transcribe_live(
     segment_seconds: int = DEFAULT_SEGMENT_SECONDS,
     sample_rate: int = SAMPLE_RATE,
     channels: int = CHANNELS,
+    max_lag: float = 0.0,
 ) -> Iterator[TranscriptSegment]:
     """Record continuously and yield the transcript of each segment as it becomes available.
 
@@ -82,18 +109,23 @@ def transcribe_live(
         segment_seconds: Length of each segment in seconds
         sample_rate: Sample rate in Hz
         channels: Number of audio channels
+        max_lag: Seconds of untranscribed audio to tolerate before dropping the oldest
+            segments, or 0 to keep everything however far behind transcription falls
 
     Yields:
         TranscriptSegment values in chronological order. A segment whose transcription times
         out or fails is yielded with empty text, an ``error`` describing the failure, and a
-        warning in the log.
+        warning in the log. Each segment reports how far transcription is behind as its
+        ``lag``, which is warned about in the log as it grows.
     """
     timeout = _segment_timeout(segment_seconds)
-    segments = iter_audio_segments(source, segment_seconds, sample_rate=sample_rate, channels=channels)
+    segments = iter_audio_segments(source, segment_seconds, sample_rate=sample_rate, channels=channels, max_lag=max_lag)
     executor = _new_executor()
+    warned_at = 0.0
     try:
         with contextlib.closing(segments):
             for segment in segments:
+                warned_at = _warn_lag(segment.lag, segment_seconds, warned_at)
                 future = executor.submit(transcribe_file_cues, segment.path, config)
                 error = None
                 try:
@@ -122,6 +154,8 @@ def transcribe_live(
                     end=float(start + segment_seconds),
                     cues=cues,
                     error=error,
+                    lag=segment.lag,
+                    dropped=segment.dropped,
                 )
     finally:
         executor.shutdown(wait=False)

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -39,6 +39,8 @@ def make_args(**overrides):
         output=None,
         segment_seconds=8,
         silence_timeout=0,
+        max_lag=0.0,
+        on_lag=None,
         output_format="txt",
     )
     values.update(overrides)
@@ -52,13 +54,14 @@ class Failure:
         self.reason = reason
 
 
-def live_segments(*items, segment_seconds=8, indices=None):
+def live_segments(*items, segment_seconds=8, indices=None, lags=(), dropped=()):
     """Yield TranscriptSegment values the way transcribe_live does.
 
     Each item is either transcript text or a Failure marker. A spoken segment carries one cue
     two seconds long, already rebased onto the recording timeline; a silent or failed segment
     carries none. Pass indices to place the segments on the timeline non-contiguously, as
-    happens when empty segments are skipped.
+    happens when empty segments are skipped, and lags/dropped to say how far behind
+    transcription had fallen and how much audio was discarded before each segment.
     """
     for position, item in enumerate(items):
         index = indices[position] if indices else position
@@ -73,6 +76,8 @@ def live_segments(*items, segment_seconds=8, indices=None):
             end=float(start + segment_seconds),
             cues=cues,
             error=item.reason if failed else None,
+            lag=lags[position] if position < len(lags) else 0.0,
+            dropped=dropped[position] if position < len(dropped) else 0,
         )
 
 
@@ -155,6 +160,33 @@ class TestBuildOptions(unittest.TestCase):
     def test_silence_timeout_equal_to_segment_length_is_accepted(self):
         options = _build_options(make_args(segment_seconds=8, silence_timeout=8))
         self.assertEqual(options.silence_timeout, 8)
+
+    def test_lag_options_default_to_warning_only(self):
+        options = _build_options(make_args())
+        self.assertEqual(options.max_lag, 0.0)
+        self.assertEqual(options.on_lag, "drop")
+
+    def test_lag_options_are_copied_onto_options(self):
+        options = _build_options(make_args(segment_seconds=8, max_lag=24.0, on_lag="fail"))
+        self.assertEqual(options.max_lag, 24.0)
+        self.assertEqual(options.on_lag, "fail")
+
+    def test_negative_max_lag_is_rejected(self):
+        with self.assertRaises(ValueError):
+            _build_options(make_args(max_lag=-1.0))
+
+    def test_max_lag_shorter_than_a_segment_is_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            _build_options(make_args(segment_seconds=8, max_lag=3.0))
+        self.assertIn("--max-lag", str(ctx.exception))
+
+    def test_max_lag_equal_to_segment_length_is_accepted(self):
+        self.assertEqual(_build_options(make_args(segment_seconds=8, max_lag=8.0)).max_lag, 8.0)
+
+    def test_on_lag_without_max_lag_is_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            _build_options(make_args(on_lag="fail"))
+        self.assertIn("--max-lag", str(ctx.exception))
 
     def test_output_format_defaults_to_txt(self):
         self.assertEqual(_build_options(make_args()).output_format, "txt")
@@ -346,12 +378,15 @@ class TestArgumentParsing(unittest.TestCase):
                     "/tmp/live.txt",
                     "--silence-timeout",
                     "30",
+                    "--max-lag",
+                    "45",
                 ],
             ):
                 main()
         mock_live.assert_called_once()
         self.assertEqual(mock_live.call_args[0][0], "my.monitor")
         self.assertEqual(mock_live.call_args[1]["segment_seconds"], 15)
+        self.assertEqual(mock_live.call_args[1]["max_lag"], 45.0)
         config = mock_live.call_args[0][1]
         self.assertEqual(config.model, "tiny")
         self.assertEqual(config.engine, "cpp")
@@ -401,6 +436,12 @@ class TestInvalidArguments(unittest.TestCase):
 
     def test_silence_timeout_shorter_than_segment(self):
         self._assert_usage_error(["sys2txt", "live", "--segment-seconds", "8", "--silence-timeout", "3"])
+
+    def test_max_lag_shorter_than_segment(self):
+        self._assert_usage_error(["sys2txt", "live", "--segment-seconds", "8", "--max-lag", "3"])
+
+    def test_on_lag_without_max_lag(self):
+        self._assert_usage_error(["sys2txt", "live", "--on-lag", "drop"])
 
     def test_unknown_output_format(self):
         self._assert_usage_error(["sys2txt", "once", "--format", "docx"])
@@ -613,8 +654,8 @@ class TestLiveOutputFormats(unittest.TestCase):
                 self.assertNotIn("stale content", f.read())
 
 
-class TestModeDispatchLive(unittest.TestCase):
-    """Tests for live mode consumption of the transcript stream."""
+class LiveRun:
+    """Runs the CLI in live mode against a canned segment stream."""
 
     def setUp(self):
         self.exit_code = 0
@@ -642,6 +683,10 @@ class TestModeDispatchLive(unittest.TestCase):
             with open(output_file, encoding="utf-8") as f:
                 written = f.read()
         return mock_live, mock_print, written
+
+
+class TestModeDispatchLive(LiveRun, unittest.TestCase):
+    """Tests for live mode consumption of the transcript stream."""
 
     def test_prints_and_saves_each_segment(self):
         _, mock_print, written = self._run_live(
@@ -766,6 +811,74 @@ class TestModeDispatchLive(unittest.TestCase):
                 main()
         with self.assertRaises(StopIteration):
             next(segments)
+
+
+class TestLiveBackpressure(LiveRun, unittest.TestCase):
+    """Tests for what live mode does when transcription cannot keep up with recording."""
+
+    def test_no_cap_is_passed_by_default(self):
+        mock_live, _, _ = self._run_live(["sys2txt", "live"], live_segments("hello"))
+        self.assertEqual(mock_live.call_args[1]["max_lag"], 0.0)
+
+    def test_drop_policy_hands_the_cap_to_the_recorder(self):
+        mock_live, _, _ = self._run_live(
+            ["sys2txt", "live", "--max-lag", "24"],
+            live_segments("hello"),
+        )
+        self.assertEqual(mock_live.call_args[1]["max_lag"], 24.0)
+
+    def test_fail_policy_keeps_every_segment(self):
+        """Failing is a decision about the run, so nothing is dropped on the way to it."""
+        mock_live, _, _ = self._run_live(
+            ["sys2txt", "live", "--max-lag", "24", "--on-lag", "fail"],
+            live_segments("hello", lags=(8.0,)),
+        )
+        self.assertEqual(mock_live.call_args[1]["max_lag"], 0.0)
+
+    def test_fail_policy_stops_once_the_lag_is_past_the_maximum(self):
+        segments = live_segments("hello", "behind", "should never be reached", lags=(0.0, 32.0))
+        with self.assertLogs("sys2txt.__main__", level="ERROR") as logs:
+            _, mock_print, written = self._run_live(
+                ["sys2txt", "live", "--max-lag", "24", "--on-lag", "fail"],
+                segments,
+            )
+
+        self.assertEqual(self.exit_code, 1)
+        self.assertEqual(mock_print.call_count, 2)
+        self.assertIn("32s behind", logs.output[0])
+        self.assertIn("--max-lag of 24s", logs.output[0])
+        # The transcript produced before giving up is still saved
+        self.assertEqual(written, "hello\nbehind\n")
+
+    def test_lag_within_the_maximum_does_not_stop_the_run(self):
+        _, mock_print, _ = self._run_live(
+            ["sys2txt", "live", "--max-lag", "24", "--on-lag", "fail"],
+            live_segments("hello", "world", lags=(8.0, 24.0)),
+        )
+        self.assertEqual(mock_print.call_count, 2)
+        self.assertEqual(self.exit_code, 0)
+
+    def test_dropped_audio_does_not_count_as_silence(self):
+        """A hole in the recording says nothing about whether anyone was speaking."""
+        segments = live_segments("", "", "", "should never be reached", dropped=(0, 2, 0, 0))
+        _, mock_print, _ = self._run_live(
+            ["sys2txt", "live", "--max-lag", "24", "--silence-timeout", "16"],
+            segments,
+        )
+        # Without the reset the second segment would already have reached the timeout
+        self.assertEqual(mock_print.call_count, 3)
+        self.assertEqual(self.exit_code, 0)
+
+    def test_dropped_audio_is_not_a_transcription_failure(self):
+        """Dropping is a deliberate policy, so it never trips the consecutive-failure limit."""
+        segments = live_segments("", "", "", "", "hello", dropped=(1, 1, 1, 1, 0))
+        _, mock_print, written = self._run_live(
+            ["sys2txt", "live", "--max-lag", "16"],
+            segments,
+        )
+        self.assertEqual(mock_print.call_count, 5)
+        self.assertEqual(written, "\n\n\n\n" + "hello\n")
+        self.assertEqual(self.exit_code, 0)
 
 
 class TestConfigureLogging(unittest.TestCase):

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -4,6 +4,7 @@ import os
 import signal
 import tempfile
 import unittest
+from itertools import chain, repeat
 from unittest.mock import MagicMock, patch
 
 from sys2txt.audio import AudioSegment, iter_audio_segments, record_once
@@ -76,14 +77,21 @@ class TestRecordOnce(unittest.TestCase):
         self.assertEqual(mock_proc.wait.call_count, 2)
 
 
+def _write_segments(directory, count, size=1024):
+    """Fill a directory with finalized segment files, as ffmpeg would leave them."""
+    for i in range(count):
+        with open(os.path.join(directory, f"seg_{i:05d}.wav"), "wb") as f:
+            f.write(b"x" * size)
+
+
 class TestIterAudioSegments(unittest.TestCase):
     """Tests for the iter_audio_segments() generator."""
 
     def _ffmpeg_proc(self, poll_results=None, poll_return=None):
-        """Build a mock ffmpeg process."""
+        """Build a mock ffmpeg process, whose last poll result repeats for as long as asked."""
         proc = MagicMock()
         if poll_results is not None:
-            proc.poll.side_effect = poll_results
+            proc.poll.side_effect = chain(poll_results, repeat(poll_results[-1]))
         else:
             proc.poll.return_value = poll_return
         proc.stdin = MagicMock()
@@ -98,14 +106,13 @@ class TestIterAudioSegments(unittest.TestCase):
     def test_yields_finalized_segments_in_order(self, mock_getsize, mock_listdir, _sleep, mock_popen, mock_which):
         """Segments are yielded in order, the newest deferred until ffmpeg exits."""
         mock_which.return_value = "/usr/bin/ffmpeg"
-        # Three loop polls plus one from the shutdown helper
-        mock_popen.return_value = self._ffmpeg_proc(poll_results=[None, None, 0, 0])
-        mock_listdir.side_effect = [
+        mock_popen.return_value = self._ffmpeg_proc(poll_results=[None, None, 0])
+        listings = [
             [],
             ["seg_00000.wav"],  # only one file: still being written
             ["seg_00000.wav", "seg_00001.wav"],  # seg_00000 is finalized
-            ["seg_00000.wav", "seg_00001.wav"],  # flush path picks up seg_00001
         ]
+        mock_listdir.side_effect = chain(listings, repeat(listings[-1]))
         mock_getsize.return_value = 1024
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -129,7 +136,7 @@ class TestIterAudioSegments(unittest.TestCase):
     def test_skips_empty_segments_but_keeps_index_on_the_timeline(self, _sleep, mock_popen, mock_which):
         """A segment holding no audio is skipped, but still consumes its index."""
         mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_popen.return_value = self._ffmpeg_proc(poll_results=[None, 0, 0])
+        mock_popen.return_value = self._ffmpeg_proc(poll_return=0)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, "seg_00000.wav"), "wb") as f:
@@ -149,7 +156,7 @@ class TestIterAudioSegments(unittest.TestCase):
     def test_no_segments_when_all_files_are_empty(self, _sleep, mock_popen, mock_which):
         """Nothing is yielded when every segment file is header-only."""
         mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_popen.return_value = self._ffmpeg_proc(poll_results=[0, 0])
+        mock_popen.return_value = self._ffmpeg_proc(poll_return=0)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, "seg_00000.wav"), "wb") as f:
@@ -209,6 +216,78 @@ class TestIterAudioSegments(unittest.TestCase):
 
         self.assertEqual([s.index for s in segments], [0])
         proc.stdin.write.assert_not_called()
+
+    @patch("sys2txt.audio.which", return_value="/usr/bin/ffmpeg")
+    @patch("sys2txt.audio.subprocess.Popen")
+    @patch("sys2txt.audio.time.sleep")
+    def test_lag_reports_the_audio_waiting_behind_a_segment(self, _sleep, mock_popen, _which):
+        """Lag is the recorded audio still queued, so it falls to zero as the queue drains."""
+        mock_popen.return_value = self._ffmpeg_proc(poll_return=0)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_segments(tmpdir, 3)
+            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
+                mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                segments = list(iter_audio_segments("test.monitor", 8))
+
+        self.assertEqual([s.lag for s in segments], [16.0, 8.0, 0.0])
+        self.assertEqual([s.dropped for s in segments], [0, 0, 0])
+
+    @patch("sys2txt.audio.which", return_value="/usr/bin/ffmpeg")
+    @patch("sys2txt.audio.subprocess.Popen")
+    @patch("sys2txt.audio.time.sleep")
+    def test_backlog_is_kept_when_no_maximum_lag_is_given(self, _sleep, mock_popen, _which):
+        """Without a cap, a backlog is handed over in full however far behind it is."""
+        mock_popen.return_value = self._ffmpeg_proc(poll_return=0)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_segments(tmpdir, 5)
+            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
+                mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                segments = list(iter_audio_segments("test.monitor", 8))
+
+        self.assertEqual([s.index for s in segments], [0, 1, 2, 3, 4])
+
+    @patch("sys2txt.audio.which", return_value="/usr/bin/ffmpeg")
+    @patch("sys2txt.audio.subprocess.Popen")
+    @patch("sys2txt.audio.time.sleep")
+    def test_oldest_segments_are_dropped_to_stay_within_max_lag(self, _sleep, mock_popen, _which):
+        """The newest audio is kept, and the dropped indices are still consumed."""
+        mock_popen.return_value = self._ffmpeg_proc(poll_return=0)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_segments(tmpdir, 5)
+            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
+                mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                with self.assertLogs("sys2txt.audio", level="WARNING") as logs:
+                    segments = list(iter_audio_segments("test.monitor", 8, max_lag=16))
+            remaining = os.listdir(tmpdir)
+
+        # Indices survive the drop, so index * segment_seconds still lands on the timeline
+        self.assertEqual([s.index for s in segments], [3, 4])
+        self.assertEqual([s.dropped for s in segments], [3, 0])
+        self.assertIn("dropped 3 segment(s), 24s of audio", logs.output[0])
+        # Dropped segments are deleted rather than left filling the temporary directory
+        self.assertEqual(remaining, [])
+
+    @patch("sys2txt.audio.which", return_value="/usr/bin/ffmpeg")
+    @patch("sys2txt.audio.subprocess.Popen")
+    @patch("sys2txt.audio.time.sleep")
+    def test_segment_file_is_removed_once_the_consumer_moves_on(self, _sleep, mock_popen, _which):
+        """The temporary directory holds the backlog, not every segment of the session."""
+        mock_popen.return_value = self._ffmpeg_proc(poll_return=0)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_segments(tmpdir, 2)
+            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
+                mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                segments = iter_audio_segments("test.monitor", 8)
+                first = next(segments)
+                self.assertTrue(os.path.exists(first.path))
+                next(segments)
+                # Asking for the next segment says the consumer is done with the last one
+                self.assertFalse(os.path.exists(first.path))
+                segments.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 from sys2txt.audio import AudioSegment
 from sys2txt.formats import Cue, Transcript
 from sys2txt.pipeline import (
-    TranscriptSegment,
     _segment_timeout,
     transcribe_live,
     transcribe_once,
@@ -16,10 +15,15 @@ from sys2txt.pipeline import (
 from sys2txt.transcribe import TranscriptionConfig
 
 
-def make_segments(count, start=0):
+def make_segments(count, start=0, lags=(), dropped=()):
     """Yield AudioSegment values the way iter_audio_segments does."""
-    for i in range(start, start + count):
-        yield AudioSegment(index=i, path=f"/tmp/seg_{i:05d}.wav")
+    for offset, i in enumerate(range(start, start + count)):
+        yield AudioSegment(
+            index=i,
+            path=f"/tmp/seg_{i:05d}.wav",
+            lag=lags[offset] if offset < len(lags) else 0.0,
+            dropped=dropped[offset] if offset < len(dropped) else 0,
+        )
 
 
 def spoken(text, start=0.0, end=1.0):
@@ -68,7 +72,7 @@ class TestTranscribeLive(unittest.TestCase):
 
         self.assertEqual([s.text for s in segments], ["hello", "world"])
         self.assertEqual([(s.index, s.start, s.end) for s in segments], [(0, 0.0, 8.0), (1, 8.0, 16.0)])
-        mock_iter.assert_called_once_with("test.monitor", 8, sample_rate=16000, channels=1)
+        mock_iter.assert_called_once_with("test.monitor", 8, sample_rate=16000, channels=1, max_lag=0.0)
         self.assertEqual(mock_transcribe.call_args_list[0][0], ("/tmp/seg_00000.wav", self.config))
 
     @patch("sys2txt.pipeline.transcribe_file_cues")
@@ -191,6 +195,67 @@ class TestTranscribeLive(unittest.TestCase):
         list(transcribe_live("test.monitor", self.config, segment_seconds=8))
 
         self.assertTrue(source.closed)
+
+
+class TestLiveBackpressure(unittest.TestCase):
+    """Tests for reporting and capping how far transcription falls behind recording."""
+
+    def setUp(self):
+        self.config = TranscriptionConfig(model="tiny")
+
+    @patch("sys2txt.pipeline.transcribe_file_cues", return_value=spoken("hello"))
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_max_lag_is_passed_to_the_recorder(self, mock_iter, _transcribe):
+        """Dropping happens where the backlog is, so the cap is handed to the audio source."""
+        mock_iter.return_value = make_segments(1)
+
+        list(transcribe_live("test.monitor", self.config, segment_seconds=8, max_lag=24))
+
+        self.assertEqual(mock_iter.call_args[1]["max_lag"], 24)
+
+    @patch("sys2txt.pipeline.transcribe_file_cues", return_value=spoken("hello"))
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_lag_and_drops_reach_the_transcript_segment(self, mock_iter, _transcribe):
+        """A consumer can see how far behind it is and where audio was dropped."""
+        mock_iter.return_value = make_segments(2, lags=(8.0, 0.0), dropped=(3, 0))
+
+        segments = list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+        self.assertEqual([(s.lag, s.dropped) for s in segments], [(8.0, 3), (0.0, 0)])
+
+    @patch("sys2txt.pipeline.transcribe_file_cues", return_value=spoken("hello"))
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_no_warning_while_transcription_keeps_up(self, mock_iter, _transcribe):
+        """A backlog within the tolerated margin is not worth telling the user about."""
+        mock_iter.return_value = make_segments(2, lags=(8.0, 16.0))
+
+        with self.assertNoLogs("sys2txt.pipeline", level="WARNING"):
+            list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+    @patch("sys2txt.pipeline.transcribe_file_cues", return_value=spoken("hello"))
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_warns_once_and_then_only_as_the_backlog_grows(self, mock_iter, _transcribe):
+        """A slow run reports its drift without a warning on every single segment."""
+        # Over the threshold, flat, one segment further behind, then caught up again
+        mock_iter.return_value = make_segments(5, lags=(24.0, 24.0, 32.0, 0.0, 0.0))
+
+        with self.assertLogs("sys2txt.pipeline", level="WARNING") as logs:
+            list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+        self.assertEqual(len(logs.output), 2)
+        self.assertIn("24s of audio (3 segments)", logs.output[0])
+        self.assertIn("32s of audio (4 segments)", logs.output[1])
+
+    @patch("sys2txt.pipeline.transcribe_file_cues", return_value=spoken("hello"))
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_warns_again_after_catching_up(self, mock_iter, _transcribe):
+        """Falling behind a second time is news, even if it is no worse than the first time."""
+        mock_iter.return_value = make_segments(3, lags=(24.0, 0.0, 24.0))
+
+        with self.assertLogs("sys2txt.pipeline", level="WARNING") as logs:
+            list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+        self.assertEqual(len(logs.output), 2)
 
 
 class TestTranscribeOnce(unittest.TestCase):


### PR DESCRIPTION
ffmpeg finalizes a segment every --segment-seconds whatever the transcriber
is doing, so a model slower than realtime fell further behind every segment
with nothing to say so. The backlog grew unbounded in /tmp — which nothing
emptied even for segments already transcribed — and Ctrl-C threw it away.

Live capture now measures the backlog and reports it. Each AudioSegment and
TranscriptSegment carries the seconds of audio queued behind it as `lag`,
plus a `dropped` count, and the pipeline warns once the queue is more than a
couple of segments deep, repeating only as it grows.

By default nothing is discarded. `--max-lag SECONDS` caps the queue, with
`--on-lag drop` (the default) discarding the oldest audio to stay close to
live, or `--on-lag fail` saving the transcript and exiting non-zero rather
than running behind. Dropped segments still consume their indices, so
timestamps stay true to the recording and the gap shows the hole; dropped
audio never counts as silence towards --silence-timeout.

Segment files are also removed once the consumer moves past them, so the
temporary directory holds the backlog rather than the whole session.

Closes #66

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KBerFgcfpvdFeUeRFqh64r