### PR TITLE
docs: recommend pipx for installation instead of venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,26 +35,34 @@ failing part-way through one of them.
 
 ```bash
 sudo apt update
-sudo apt install -y ffmpeg python3-venv python3-pip
+sudo apt install -y ffmpeg pipx
+pipx ensurepath
 ```
 
-2) Create a virtual environment and install sys2txt from [PyPI](https://pypi.org/project/sys2txt/)
+2) Install sys2txt from [PyPI](https://pypi.org/project/sys2txt/) with [pipx](https://pipx.pypa.io/), which installs the CLI into its own isolated environment automatically (no manual venv needed):
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
-```
-
-Install with your preferred engine:
-
-```bash
-pip install sys2txt[faster]   # faster-whisper (recommended, best for CPU and NVIDIA)
-pip install sys2txt[openai]   # openai-whisper (reference implementation)
-pip install sys2txt[all]      # install both engines
-pip install sys2txt           # no Python engine (use whisper.cpp instead)
+pipx install "sys2txt[faster]"   # faster-whisper (recommended, best for CPU and NVIDIA)
+pipx install "sys2txt[openai]"   # openai-whisper (reference implementation)
+pipx install "sys2txt[all]"      # install both engines
+pipx install sys2txt             # no Python engine (use whisper.cpp instead)
 ```
 
 The tool auto-selects `faster-whisper` when available, falls back to `openai-whisper`, then falls back to `whisper.cpp`.
+
+<details>
+<summary>Alternative: install into a virtual environment</summary>
+
+If you're contributing to sys2txt or want it installed into a shared/managed environment instead of pipx's isolated one:
+
+```bash
+sudo apt install -y python3-venv python3-pip
+python3 -m venv .venv
+source .venv/bin/activate
+pip install sys2txt[faster]   # or [openai], [all], or no extras
+```
+
+</details>
 
 **AMD GPU (or other non-CUDA GPU)?** `faster-whisper`/`openai-whisper` only accelerate on CPU or
 NVIDIA CUDA — skip the extras above (`pip install sys2txt` with no extras is enough) and use the


### PR DESCRIPTION
## Summary
- Default the installation instructions to `pipx install sys2txt`, which manages an isolated environment per tool automatically
- Keep the manual venv approach as a collapsible "Alternative" section for contributors or shared-environment installs

Closes #70

## Test plan
- [x] Reviewed rendered README manually