### PR TITLE
docs: fix documentation drift (requirements.txt, release pipeline, Python version)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
       - "src/**"
       - "tests/**"
       - "pyproject.toml"
-      - "requirements.txt"
       - ".github/workflows/ci.yml"
   pull_request:
     branches: [main]
@@ -15,7 +14,6 @@ on:
       - "src/**"
       - "tests/**"
       - "pyproject.toml"
-      - "requirements.txt"
       - ".github/workflows/ci.yml"
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ sudo apt update && sudo apt install -y ffmpeg python3-venv python3-pip
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+pip install -e ".[dev]"
 ```
 
 ## Running the Application
@@ -55,7 +55,8 @@ Alternatively, run as a module without installing: `python -m sys2txt once --mod
 
 Common flags:
 - `--source <name>`: Specify PulseAudio/PipeWire source (e.g., `alsa_output.pci-0000_00_1f.3.analog-stereo.monitor`)
-- `--model {tiny,base,small,medium,large-v2}`: Whisper model size (default: small)
+- `--model <size>`: Whisper model size, no fixed set of choices, e.g. tiny|base|small|medium|large-v2,
+  optionally suffixed `.en` for English-only (default: small.en)
 - `--engine {auto,faster,whisper,cpp}`: Force specific engine (default: auto)
 - `--device {auto,cpu,vulkan,gpu,cuda}`: Device for transcription (default: auto)
 - `--language <code>`: Force language code (e.g., en)
@@ -69,6 +70,8 @@ Common flags:
 - `--timestamps`: Include timestamps in output
 - `--model-path <path>`: Path to whisper.cpp model file (for cpp engine)
 - `--whisper-cpp-path <path>`: Path to whisper-cli binary (for cpp engine)
+- `--verbose`/`-v`: Enable debug logging
+- `--quiet`/`-q`: Suppress informational log messages
 
 ## Architecture
 
@@ -157,6 +160,8 @@ The codebase is organized into focused modules by functionality:
 - `SYS2TXT_DEVICE`: Device selection for faster-whisper (`cpu`, `cuda`)
 - `SYS2TXT_WHISPER_CPP`: Path to whisper-cli binary
 - `SYS2TXT_WHISPER_CPP_MODELS`: Directory containing whisper.cpp model files (e.g., `ggml-small.bin`)
+- `WHISPER_MODEL`: Default for `--model` (falls back to `small.en`)
+- `LOG_LEVEL`: Overrides `--verbose`/`--quiet` with an explicit logging level (e.g. `DEBUG`, `INFO`, `WARNING`)
 
 ## Continuous Integration & Deployment
 
@@ -168,7 +173,7 @@ Runs on:
 - Pull requests to `main` branch
 
 Pipeline includes:
-- Testing on Python 3.9, 3.10, 3.11, and 3.12
+- Testing on Python 3.10, 3.11, 3.12, 3.13, and 3.14
 - Code formatting check with `ruff format --check`
 - Linting with `ruff check`
 - Unit tests with `python -m unittest`
@@ -181,10 +186,8 @@ Pipeline includes:
 - Uses trusted publishing (no API tokens needed)
 
 **PyPI** (`.github/workflows/publish-to-pypi.yml`):
-- Triggered when a GitHub release is published
+- Triggered by pushing a tag matching `v*` or `sys2txt-v*`
 - Publishes to https://pypi.org
-- Signs packages with Sigstore
-- Uploads signed artifacts to GitHub release
 - Uses trusted publishing (no API tokens needed)
 
 ### Setup Required for Publishing
@@ -254,14 +257,13 @@ ruff check --fix src/
   - `tests/test_init.py`: Tests for the public API surface
 - `.github/workflows/`:
   - `ci.yml`: CI workflow (tests, linting, formatting)
-  - `publish-to-pypi.yml`: Publish to PyPI on release
+  - `publish-to-pypi.yml`: Publish to PyPI on tag push
   - `publish-to-testpypi.yml`: Publish to TestPyPI on RC tags
 - `pyproject.toml`: Project metadata, dependencies, and build config
-- `requirements.txt`: Python dependencies (faster-whisper, openai-whisper)
 - `README.md`: User documentation with installation, usage, examples
 
 ## Platform Requirements
 - Ubuntu (or Linux with PulseAudio/PipeWire)
-- Python 3.9+
+- Python 3.10+
 - ffmpeg
 - PulseAudio or PipeWire (for monitor source capture)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,92 +71,16 @@ python -m sys2txt once --model small
 
 ## Release Process
 
-### Version Numbering
-
-We follow [PEP 440](https://peps.python.org/pep-0440/) versioning:
-- Standard releases: `0.1.0`, `0.2.0`, `1.0.0`
-- Post releases (patches after a release): `0.1.0.post1`, `0.1.0.post2`
-- Release candidates (for testing): `0.1.0rc1`, `0.1.0rc2`
-
-### Creating a Release
-
-#### 1. Update Version
-
-Update the version in `pyproject.toml`:
-
-```toml
-[project]
-version = "0.1.2"  # or "0.1.1.post1" for post-release
-```
-
-#### 2. Commit Version Bump
-
-```bash
-git add pyproject.toml
-git commit -m "chore: bump version to 0.1.2"
-git push origin main
-```
-
-#### 3. Create and Push Git Tag
-
-```bash
-# Create annotated tag
-git tag -a v0.1.2 -m "Release v0.1.2"
-
-# Push tag to GitHub
-git push origin v0.1.2
-```
-
-**Important**: The tag name must match the version in `pyproject.toml` with a `v` prefix:
-- Version `0.1.2` → Tag `v0.1.2`
-- Version `0.1.1.post1` → Tag `v0.1.1post1`
-
-#### 4. Create GitHub Release
-
-1. Go to https://github.com/Joe-Heffer/sys2txt/releases/new
-2. Select the tag you just pushed (e.g., `v0.1.2`)
-3. Set release title (e.g., "Release v0.1.2")
-4. Add release notes describing changes
-5. Click "Publish release"
-
-This will automatically trigger the PyPI publishing workflow.
-
-### Testing a Release (TestPyPI)
-
-For release candidates, you can test the publishing process using TestPyPI:
-
-#### 1. Update Version to RC
-
-```toml
-[project]
-version = "0.1.2rc1"  # Release candidate
-```
-
-#### 2. Create RC Tag and Push
-
-```bash
-git add pyproject.toml
-git commit -m "chore: prepare release candidate 0.1.2rc1"
-git push origin main
-
-git tag -a v0.1.2-rc1 -m "Release candidate v0.1.2rc1"
-git push origin v0.1.2-rc1
-```
-
-This will publish to TestPyPI at https://test.pypi.org/project/sys2txt/
-
-#### 3. Test Installation from TestPyPI
-
-```bash
-pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ sys2txt
-```
+Releases are automated with release-please; see [RELEASING.md](RELEASING.md) for the full
+process, including test releases via TestPyPI. Do not bump the version in `pyproject.toml`
+by hand — release-please manages it from Conventional Commit messages.
 
 ### CI/CD Workflows
 
 The project uses GitHub Actions for automated testing and publishing:
 
 - **CI** (`.github/workflows/ci.yml`): Runs on every push and PR
-  - Tests on Python 3.9, 3.10, 3.11, 3.12
+  - Tests on Python 3.10, 3.11, 3.12, 3.13, 3.14
   - Formatting check with `ruff format --check`
   - Linting with `ruff check`
   - Unit tests
@@ -166,10 +90,8 @@ The project uses GitHub Actions for automated testing and publishing:
   - Publishes to https://test.pypi.org
 
 - **PyPI** (`.github/workflows/publish-to-pypi.yml`):
-  - Triggered when a GitHub release is published
-  - Publishes to https://pypi.org
-  - Signs packages with Sigstore
-  - Uploads signed artifacts to release
+  - Triggered by pushing a tag matching `v*` or `sys2txt-v*`
+  - Publishes to https://pypi.org via trusted publishing
 
 ## Pull Request Guidelines
 
@@ -185,7 +107,7 @@ The project uses GitHub Actions for automated testing and publishing:
 
 - Follow PEP 8 (enforced by Ruff)
 - Line length: 120 characters
-- Target Python 3.9+ compatibility
+- Target Python 3.10+ compatibility
 - Use type hints where beneficial
 - Write docstrings for public functions
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ failing part-way through one of them.
 
 - Modern linux distribution with PulseAudio or PipeWire (default on modern Ubuntu)
 - ffmpeg
-- Python 3.10+ (recommended)
+- Python 3.10+
 
 ### Install
 
@@ -88,14 +88,17 @@ sys2txt live --model small.en --segment-seconds 8
 
 - `--source <pulse_source_name>` - Explicit PulseAudio/PipeWire source (e.g., alsa_output.pci-0000_00_1f.3.analog-stereo.monitor)
 - `--list-sources` - List available Pulse sources and exit
-- `--model <size>` - tiny|base|small|medium|large-v2 (default: small)
+- `--model <size>` - any Whisper model size accepted by the engine, e.g. tiny|base|small|medium|large-v2,
+  optionally suffixed `.en` for an English-only model (default: small.en). `--language` auto-detection
+  is meaningless with an `.en` model, since it only ever transcribes English
 - `--engine <auto|faster|whisper|cpp>` - Force a specific engine (default: auto)
 - `--device <auto|cpu|vulkan|gpu|cuda>` - Device for transcription (default: auto). `cuda` applies to the
   Python engines (`faster`, `whisper`), `vulkan`/`gpu` to `cpp`; `auto` reads `SYS2TXT_DEVICE`, else CPU
 - `--language <code>` - Force language code (e.g., en). Omit to auto-detect
 - `--format <txt|srt|vtt|json|tsv>` - Transcript format (default: txt). See [Output formats](#output-formats)
 - `--output <path>` - Write the transcript to a file. Without it, one is written to
-  `./output/<timestamp>.<ext>`. In live mode `txt` appends to an existing file; the timed formats
+  `./output/<timestamp>.<ext>` (the `output` directory is created in the current working directory
+  if it doesn't exist). In live mode `txt` appends to an existing file; the timed formats
   replace it, since a subtitle or JSON document cannot resume mid-file
 - `--duration <seconds>` - (once mode) Record fixed duration instead of waiting for Ctrl-C
 - `--segment-seconds <n>` - (live mode) Segment length in seconds (default: 8)
@@ -106,6 +109,16 @@ sys2txt live --model small.en --segment-seconds 8
   audio to catch up, or stop with an error (default: drop). Requires `--max-lag`
 - `--timestamps` - Print timestamps alongside text (plain text only; the timed formats always carry
   their own)
+- `--verbose` / `-v` - Enable debug logging
+- `--quiet` / `-q` - Suppress informational log messages (warnings and errors still show)
+
+### Environment variables
+
+- `SYS2TXT_DEVICE` - Default for `--device` (`cpu`, `cuda`, `vulkan`, `gpu`)
+- `SYS2TXT_WHISPER_CPP` - Path to the `whisper-cli` binary, used when `--whisper-cpp-path` is omitted
+- `SYS2TXT_WHISPER_CPP_MODELS` - Directory containing whisper.cpp model files, used when `--model-path` is omitted
+- `WHISPER_MODEL` - Default for `--model` (falls back to `small.en`)
+- `LOG_LEVEL` - Overrides `--verbose`/`--quiet` with an explicit logging level (e.g. `DEBUG`, `INFO`, `WARNING`)
 
 ### Keeping up with real time
 
@@ -301,7 +314,7 @@ The full public API is `AudioSegment`, `Cue`, `OUTPUT_FORMATS`, `Transcript`, `T
 
 ## AMD GPU (Vulkan)
 
-For AMD GPUs (or other GPUs not supported by CUDA), you can use whisper.cpp with Vulkan acceleration for ~8x speedup over CPU.
+For AMD GPUs (or other GPUs not supported by CUDA), you can use whisper.cpp with Vulkan acceleration, which is substantially faster than CPU-only transcription (the exact speedup depends on your GPU and model size).
 
 ### Build whisper.cpp with Vulkan
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,9 +9,8 @@ Releases are automated with [release-please](https://github.com/googleapis/relea
    it when you're ready to release.
 3. Merging that PR triggers release-please to bump the version in `pyproject.toml`, update
    `CHANGELOG.md`, tag the commit, and publish a GitHub release.
-4. Publishing the GitHub release triggers `.github/workflows/publish-to-pypi.yml`, which
-   builds, signs (Sigstore), and publishes the package to [PyPI](https://pypi.org/project/sys2txt/)
-   via trusted publishing.
+4. Tagging the commit (as `v*`) triggers `.github/workflows/publish-to-pypi.yml`, which builds
+   and publishes the package to [PyPI](https://pypi.org/project/sys2txt/) via trusted publishing.
 
 ## Release candidates
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,7 +52,10 @@ sys2txt records system audio, which may capture sensitive information:
 
 The tool uses system commands (`ffmpeg`, `pactl`):
 
-- **Source Names**: PulseAudio source names are passed to `ffmpeg` - only use trusted source names
+- **Source Names**: PulseAudio source names are passed to `ffmpeg` as separate process arguments
+  (never through a shell), so this is argument injection risk rather than shell injection. sys2txt
+  does not validate `--source` itself; only pass source names you trust, such as those returned by
+  `--list-sources`
 - **File Paths**: User-provided file paths are used in system commands - validate paths before use
 - **Environment**: Run the tool in a controlled environment if processing untrusted input
 


### PR DESCRIPTION
## Summary
- Removes references to the nonexistent `requirements.txt` (setup instructions, CI path filters, file structure listings) in favor of `pip install -e ".[dev]"`
- Corrects the PyPI publish trigger (tag push, not GitHub release publication) and removes the false Sigstore signing/artifact-upload claims from CLAUDE.md, RELEASING.md, CONTRIBUTING.md
- Replaces CONTRIBUTING.md's manual release runbook (which contradicted release-please) with a pointer to RELEASING.md
- Standardizes on Python 3.10+ across README/CLAUDE.md/CONTRIBUTING.md to match `pyproject.toml` and `ci.yml`
- Corrects the documented default model to `small.en`, documents `--model` as free-form (no fixed choices), and notes what `.en` implies for `--language` auto-detection
- Documents previously-missing `--verbose`/`-v`, `--quiet`/`-q`, `LOG_LEVEL`, `WHISPER_MODEL`, and the default `./output` directory behavior
- Rewords SECURITY.md's source-name policy to describe the actual boundary (argument injection, no validation) instead of an unimplemented check
- Softens the unsourced "~8x speedup" Vulkan claim

Fixes #68

## Test plan
- [x] Docs-only change; no code behavior affected
- [x] Verified claims against current repo state (`pyproject.toml`, `ci.yml`, `publish-to-pypi.yml`, `constants.py`, `__main__.py`) before editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RccjPWu1BMq2LGSYKbdzMU