### PR TITLE
fix: prevent release-candidate tags from publishing to production PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,7 +5,6 @@ name: Publish to PyPI
 on:
   push:
     tags:
-      - "sys2txt-v*"
       - "v*"
   workflow_dispatch: # Allow manual triggering of the workflow
 
@@ -41,6 +40,9 @@ jobs:
     name: Publish to PyPI
     needs:
       - build
+    # Release-candidate tags (v*-rc*) and non-tag refs (e.g. manual workflow_dispatch
+    # from a branch) must never reach production PyPI; only final release tags do.
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc') }}
     runs-on: ubuntu-24.04
     environment:
       name: pypi


### PR DESCRIPTION
## Summary
- The PyPI publish workflow's `v*` tag trigger was a superset of the TestPyPI workflow's `v*-rc*` trigger, so pushing an RC tag (the documented way to test a release) published it to production PyPI as well.
- Guards `publish-to-pypi` job with `if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')`, so only a genuine final-release tag push reaches PyPI — RC tags and `workflow_dispatch` from a branch are excluded.
- Drops the leftover `sys2txt-v*` tag glob, unused since the release-please component prefix was removed.

## Test plan
- [x] `git diff` reviewed — no functional change beyond the `if:` guard and glob removal
- [ ] Push a `v*-rc*` tag and confirm only TestPyPI publish workflow runs (production PyPI job is skipped)
- [ ] Push a final `v*` release tag and confirm PyPI publish still runs as before

Fixes #51

https://claude.ai/code/session_01RccjPWu1BMq2LGSYKbdzMU