### PR TITLE
fix: drain ffmpeg's stderr in live mode to prevent deadlock

### DIFF
--- a/src/sys2txt/audio.py
+++ b/src/sys2txt/audio.py
@@ -6,6 +6,7 @@ import os
 import signal
 import subprocess
 import tempfile
+import threading
 import time
 from dataclasses import dataclass
 from typing import Iterator, List, Optional
@@ -41,6 +42,21 @@ class AudioSegment:
     path: str
     lag: float = 0.0
     dropped: int = 0
+
+
+def _drain_stderr(proc: subprocess.Popen) -> None:
+    """Read ffmpeg's stderr to completion, logging each line.
+
+    ffmpeg's stderr is a pipe with a finite OS buffer; if nothing reads it, ffmpeg blocks on
+    write once that buffer fills and the process wedges without exiting. This runs in its own
+    thread so the pipe is always drained, and stops when it hits EOF (ffmpeg has exited).
+    """
+    if proc.stderr is None:
+        return
+    for line in proc.stderr:
+        text = line.decode("utf-8", errors="replace").rstrip()
+        if text:
+            logger.warning("ffmpeg: %s", text)
 
 
 def _stop_ffmpeg(proc: subprocess.Popen) -> None:
@@ -190,6 +206,7 @@ def iter_audio_segments(
 
         logger.info("Live mode: segmenting every %ds from '%s'.", segment_seconds, source)
         proc = subprocess.Popen(args, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+        threading.Thread(target=_drain_stderr, args=(proc,), daemon=True).start()
         seen: set[str] = set()
         queue: List[str] = []
         next_index = 0

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -3,6 +3,7 @@
 import os
 import signal
 import tempfile
+import threading
 import unittest
 from itertools import chain, repeat
 from unittest.mock import MagicMock, patch
@@ -87,7 +88,7 @@ def _write_segments(directory, count, size=1024):
 class TestIterAudioSegments(unittest.TestCase):
     """Tests for the iter_audio_segments() generator."""
 
-    def _ffmpeg_proc(self, poll_results=None, poll_return=None):
+    def _ffmpeg_proc(self, poll_results=None, poll_return=None, stderr_lines=()):
         """Build a mock ffmpeg process, whose last poll result repeats for as long as asked."""
         proc = MagicMock()
         if poll_results is not None:
@@ -95,6 +96,7 @@ class TestIterAudioSegments(unittest.TestCase):
         else:
             proc.poll.return_value = poll_return
         proc.stdin = MagicMock()
+        proc.stderr = iter(stderr_lines)
         proc.wait.return_value = None
         return proc
 
@@ -288,6 +290,27 @@ class TestIterAudioSegments(unittest.TestCase):
                 # Asking for the next segment says the consumer is done with the last one
                 self.assertFalse(os.path.exists(first.path))
                 segments.close()
+
+    @patch("sys2txt.audio.which", return_value="/usr/bin/ffmpeg")
+    @patch("sys2txt.audio.subprocess.Popen")
+    @patch("sys2txt.audio.time.sleep")
+    def test_ffmpeg_stderr_is_drained_and_logged(self, _sleep, mock_popen, _which):
+        """ffmpeg's stderr is read in the background and logged, rather than left to fill up."""
+        proc = self._ffmpeg_proc(poll_return=0, stderr_lines=[b"Error: something bad\n"])
+        mock_popen.return_value = proc
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_segments(tmpdir, 1)
+            with patch("sys2txt.audio.tempfile.TemporaryDirectory") as mock_tmpdir:
+                mock_tmpdir.return_value.__enter__.return_value = tmpdir
+                with self.assertLogs("sys2txt.audio", level="WARNING") as logs:
+                    list(iter_audio_segments("test.monitor", 8))
+                    # The drainer runs on its own thread; give it a moment to log.
+                    for thread in threading.enumerate():
+                        if thread is not threading.current_thread() and thread.daemon:
+                            thread.join(timeout=1)
+
+        self.assertTrue(any("ffmpeg: Error: something bad" in line for line in logs.output))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `iter_audio_segments()` piped ffmpeg's stderr but never read it; once ffmpeg wrote enough error output over a sustained error condition, the OS pipe buffer filled and ffmpeg blocked on write, wedging the process without exiting — the live session hung silently with `proc.poll()` still returning `None`.
- A daemon thread now continuously drains stderr and logs each line at `WARNING`, so the pipe can never block ffmpeg and its diagnostics are surfaced instead of discarded.

## Test plan
- [x] `python -m unittest tests/test_audio.py -v` — new `test_ffmpeg_stderr_is_drained_and_logged` covers the drain-and-log behavior; all existing tests still pass
- [x] `python -m unittest discover -s tests -p "test_*.py"` — full suite (233 tests) passes
- [x] `ruff format --check` / `ruff check` — clean

Fixes #52