### PR TITLE
fix: raise on ffmpeg failure in record_once instead of discarding it

### DIFF
--- a/src/sys2txt/audio.py
+++ b/src/sys2txt/audio.py
@@ -44,12 +44,15 @@ class AudioSegment:
     dropped: int = 0
 
 
-def _drain_stderr(proc: subprocess.Popen) -> None:
+def _drain_stderr(proc: subprocess.Popen, lines: Optional[List[str]] = None) -> None:
     """Read ffmpeg's stderr to completion, logging each line.
 
     ffmpeg's stderr is a pipe with a finite OS buffer; if nothing reads it, ffmpeg blocks on
     write once that buffer fills and the process wedges without exiting. This runs in its own
     thread so the pipe is always drained, and stops when it hits EOF (ffmpeg has exited).
+
+    ``lines``, if given, additionally collects each line so a caller can report ffmpeg's own
+    diagnostic on failure rather than just discarding it into the log.
     """
     if proc.stderr is None:
         return
@@ -57,6 +60,8 @@ def _drain_stderr(proc: subprocess.Popen) -> None:
         text = line.decode("utf-8", errors="replace").rstrip()
         if text:
             logger.warning("ffmpeg: %s", text)
+            if lines is not None:
+                lines.append(text)
 
 
 def _stop_ffmpeg(proc: subprocess.Popen) -> None:
@@ -93,6 +98,10 @@ def record_once(
         duration: Optional recording duration in seconds. If None, records until interrupted.
         sample_rate: Sample rate in Hz
         channels: Number of audio channels (1 for mono, 2 for stereo)
+
+    Raises:
+        RuntimeError: ffmpeg exited with a non-zero status for a reason other than the
+            interrupt this function sent it to stop recording, naming ffmpeg's own diagnostic.
     """
     ffmpeg = which("ffmpeg")
     args = [
@@ -122,15 +131,26 @@ def record_once(
     else:
         logger.info("Recording for %d seconds...", duration)
 
-    proc = subprocess.Popen(args)
+    stderr_lines: List[str] = []
+    proc = subprocess.Popen(args, stderr=subprocess.PIPE)
+    stderr_thread = threading.Thread(target=_drain_stderr, args=(proc, stderr_lines), daemon=True)
+    stderr_thread.start()
+    interrupted = False
     try:
         proc.wait()
     except KeyboardInterrupt:
+        interrupted = True
         try:
             proc.send_signal(signal.SIGINT)
         except OSError:
             pass
         proc.wait()
+    stderr_thread.join()
+
+    if not interrupted and proc.returncode != 0:
+        detail = "\n".join(stderr_lines) or f"ffmpeg exited with code {proc.returncode}"
+        raise RuntimeError(f"ffmpeg failed while recording: {detail}")
+
     logger.info("Recording finished.")
 
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -11,6 +11,15 @@ from unittest.mock import MagicMock, patch
 from sys2txt.audio import AudioSegment, iter_audio_segments, record_once
 
 
+def _mock_proc(returncode: int = 0, stderr_lines: list = ()) -> MagicMock:
+    """Build a mock ffmpeg process with a real (empty by default) stderr stream."""
+    mock_proc = MagicMock()
+    mock_proc.wait.return_value = None
+    mock_proc.returncode = returncode
+    mock_proc.stderr = iter(line.encode("utf-8") for line in stderr_lines)
+    return mock_proc
+
+
 class TestRecordOnce(unittest.TestCase):
     """Tests for the record_once() function."""
 
@@ -19,8 +28,7 @@ class TestRecordOnce(unittest.TestCase):
     def test_record_once_with_duration(self, mock_popen, mock_which):
         """Test record_once() with fixed duration."""
         mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_proc = MagicMock()
-        mock_proc.wait.return_value = None
+        mock_proc = _mock_proc()
         mock_popen.return_value = mock_proc
 
         record_once("test.monitor", "/tmp/test.wav", 30)
@@ -40,8 +48,7 @@ class TestRecordOnce(unittest.TestCase):
     def test_record_once_without_duration(self, mock_popen, mock_which):
         """Test record_once() without duration (Ctrl-C to stop)."""
         mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_proc = MagicMock()
-        mock_proc.wait.return_value = None
+        mock_proc = _mock_proc()
         mock_popen.return_value = mock_proc
 
         record_once("test.monitor", "/tmp/test.wav")
@@ -55,7 +62,7 @@ class TestRecordOnce(unittest.TestCase):
     def test_record_once_uses_default_sample_rate_and_channels(self, mock_popen, mock_which):
         """Sample rate and channels default to the Whisper-compatible constants."""
         mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_popen.return_value = MagicMock()
+        mock_popen.return_value = _mock_proc()
 
         record_once("test.monitor", "/tmp/test.wav")
 
@@ -68,7 +75,7 @@ class TestRecordOnce(unittest.TestCase):
     def test_record_once_keyboard_interrupt(self, mock_popen, mock_which):
         """Test record_once() handles KeyboardInterrupt gracefully."""
         mock_which.return_value = "/usr/bin/ffmpeg"
-        mock_proc = MagicMock()
+        mock_proc = _mock_proc()
         mock_proc.wait.side_effect = [KeyboardInterrupt(), None]
         mock_popen.return_value = mock_proc
 
@@ -76,6 +83,43 @@ class TestRecordOnce(unittest.TestCase):
 
         mock_proc.send_signal.assert_called_once_with(signal.SIGINT)
         self.assertEqual(mock_proc.wait.call_count, 2)
+
+    @patch("sys2txt.audio.which")
+    @patch("sys2txt.audio.subprocess.Popen")
+    def test_record_once_keyboard_interrupt_nonzero_exit_does_not_raise(self, mock_popen, mock_which):
+        """A non-zero exit caused by our own SIGINT is not a genuine failure."""
+        mock_which.return_value = "/usr/bin/ffmpeg"
+        mock_proc = _mock_proc(returncode=255)
+        mock_proc.wait.side_effect = [KeyboardInterrupt(), None]
+        mock_popen.return_value = mock_proc
+
+        record_once("test.monitor", "/tmp/test.wav")
+
+    @patch("sys2txt.audio.which")
+    @patch("sys2txt.audio.subprocess.Popen")
+    def test_record_once_raises_on_ffmpeg_failure(self, mock_popen, mock_which):
+        """A non-zero, non-interrupted exit raises with ffmpeg's stderr."""
+        mock_which.return_value = "/usr/bin/ffmpeg"
+        mock_proc = _mock_proc(returncode=1, stderr_lines=["Failed to open source"])
+        mock_popen.return_value = mock_proc
+
+        with self.assertRaises(RuntimeError) as ctx:
+            record_once("test.monitor", "/tmp/test.wav")
+
+        self.assertIn("Failed to open source", str(ctx.exception))
+
+    @patch("sys2txt.audio.which")
+    @patch("sys2txt.audio.subprocess.Popen")
+    def test_record_once_raises_on_ffmpeg_failure_without_stderr(self, mock_popen, mock_which):
+        """A non-zero exit with no stderr output still raises, naming the exit code."""
+        mock_which.return_value = "/usr/bin/ffmpeg"
+        mock_proc = _mock_proc(returncode=1)
+        mock_popen.return_value = mock_proc
+
+        with self.assertRaises(RuntimeError) as ctx:
+            record_once("test.monitor", "/tmp/test.wav")
+
+        self.assertIn("1", str(ctx.exception))
 
 
 def _write_segments(directory, count, size=1024):


### PR DESCRIPTION
## Summary
- `record_once()` waited on ffmpeg but never inspected its exit status or captured stderr, so a bad `--source`, PulseAudio not running, or a full disk silently produced an empty/missing WAV that was then handed to transcription with no useful error.
- ffmpeg's stderr is now drained on a background thread (matching the pattern already used by `iter_audio_segments`), and a non-zero, non-interrupted exit raises a `RuntimeError` carrying ffmpeg's own diagnostic.
- The `--duration` path's legitimate SIGINT-driven exit (Ctrl-C or the duration timer) stays silent and does not raise.
- No `__main__.py` changes needed — `main()` already catches `RuntimeError` and exits 1.

Fixes #54

## Test plan
- [x] `python -m unittest tests.test_audio` — updated existing `TestRecordOnce` tests and added coverage for: SIGINT-driven non-zero exit (no raise), ffmpeg failure with stderr detail, ffmpeg failure with no stderr (falls back to exit code)
- [x] `python -m unittest discover -s tests -p "test_*.py"` — full suite (236 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KoAtf4d5wsJZvkiQUwB2a