### PR TITLE
fix: bound ffmpeg shutdown, stop live transcription racing temp-dir cleanup

### DIFF
--- a/src/sys2txt/audio.py
+++ b/src/sys2txt/audio.py
@@ -64,8 +64,30 @@ def _drain_stderr(proc: subprocess.Popen, lines: Optional[List[str]] = None) -> 
                 lines.append(text)
 
 
+def _wait_or_escalate(proc: subprocess.Popen) -> None:
+    """Wait for ffmpeg to exit, escalating from terminate() to kill() if it ignores each.
+
+    Bounded at two grace periods total, so a wedged ffmpeg (see #52) cannot hang shutdown
+    indefinitely: a process that ignores SIGTERM is killed outright rather than waited on
+    forever.
+    """
+    try:
+        proc.wait(timeout=FFMPEG_SHUTDOWN_GRACE)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    proc.terminate()
+    try:
+        proc.wait(timeout=FFMPEG_SHUTDOWN_GRACE)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    proc.kill()
+    proc.wait()
+
+
 def _stop_ffmpeg(proc: subprocess.Popen) -> None:
-    """Ask ffmpeg to quit, then terminate it if it does not exit in time."""
+    """Ask ffmpeg to quit, then terminate/kill it if it does not exit in time."""
     try:
         if proc.poll() is not None:
             return
@@ -73,11 +95,7 @@ def _stop_ffmpeg(proc: subprocess.Popen) -> None:
             proc.stdin.write(b"q")
             proc.stdin.flush()
             proc.stdin.close()
-        try:
-            proc.wait(timeout=FFMPEG_SHUTDOWN_GRACE)
-        except subprocess.TimeoutExpired:
-            proc.terminate()
-            proc.wait()
+        _wait_or_escalate(proc)
     except OSError:
         pass
 
@@ -144,7 +162,7 @@ def record_once(
             proc.send_signal(signal.SIGINT)
         except OSError:
             pass
-        proc.wait()
+        _wait_or_escalate(proc)
     stderr_thread.join()
 
     if not interrupted and proc.returncode != 0:

--- a/src/sys2txt/pipeline.py
+++ b/src/sys2txt/pipeline.py
@@ -122,43 +122,54 @@ def transcribe_live(
     segments = iter_audio_segments(source, segment_seconds, sample_rate=sample_rate, channels=channels, max_lag=max_lag)
     executor = _new_executor()
     warned_at = 0.0
+    future = None
     try:
-        with contextlib.closing(segments):
-            for segment in segments:
-                warned_at = _warn_lag(segment.lag, segment_seconds, warned_at)
-                future = executor.submit(transcribe_file_cues, segment.path, config)
-                error = None
-                try:
-                    transcript = future.result(timeout=timeout)
-                except FuturesTimeoutError:
-                    logger.warning("Segment %d transcription timed out, skipping", segment.index)
-                    transcript = Transcript()
-                    error = f"transcription timed out after {timeout:.0f}s"
-                    # The worker cannot be cancelled and keeps running, so the next segment
-                    # would queue behind it and time out without ever being transcribed.
-                    # Abandon the pool and give the next segment a worker of its own.
-                    executor.shutdown(wait=False)
-                    executor = _new_executor()
-                except Exception as e:
-                    logger.warning("Segment %d transcription failed: %s", segment.index, e)
-                    transcript = Transcript()
-                    error = f"transcription failed: {e}"
-                start = segment.index * segment_seconds
-                # The engine times each segment from zero, so shift its cues onto the
-                # timeline of the recording as a whole.
-                cues = tuple(cue.shifted(float(start)) for cue in transcript.cues)
-                yield TranscriptSegment(
-                    index=segment.index,
-                    text=render_transcript(transcript.cues, "txt", timestamps=config.timestamps),
-                    start=float(start),
-                    end=float(start + segment_seconds),
-                    cues=cues,
-                    error=error,
-                    lag=segment.lag,
-                    dropped=segment.dropped,
-                )
+        for segment in segments:
+            warned_at = _warn_lag(segment.lag, segment_seconds, warned_at)
+            future = executor.submit(transcribe_file_cues, segment.path, config)
+            error = None
+            try:
+                transcript = future.result(timeout=timeout)
+                future = None
+            except FuturesTimeoutError:
+                logger.warning("Segment %d transcription timed out, skipping", segment.index)
+                transcript = Transcript()
+                error = f"transcription timed out after {timeout:.0f}s"
+                # The worker cannot be cancelled and keeps running, so the next segment
+                # would queue behind it and time out without ever being transcribed.
+                # Abandon the pool and give the next segment a worker of its own.
+                executor.shutdown(wait=False)
+                executor = _new_executor()
+                future = None
+            except Exception as e:
+                logger.warning("Segment %d transcription failed: %s", segment.index, e)
+                transcript = Transcript()
+                error = f"transcription failed: {e}"
+                future = None
+            start = segment.index * segment_seconds
+            # The engine times each segment from zero, so shift its cues onto the
+            # timeline of the recording as a whole.
+            cues = tuple(cue.shifted(float(start)) for cue in transcript.cues)
+            yield TranscriptSegment(
+                index=segment.index,
+                text=render_transcript(transcript.cues, "txt", timestamps=config.timestamps),
+                start=float(start),
+                end=float(start + segment_seconds),
+                cues=cues,
+                error=error,
+                lag=segment.lag,
+                dropped=segment.dropped,
+            )
     finally:
+        # A worker can still be transcribing here if we were interrupted (e.g. Ctrl-C)
+        # while future.result() was blocked above. Give it a bounded chance to finish
+        # before closing the segment generator, whose cleanup removes the temporary
+        # directory the worker is reading from.
+        if future is not None and not future.done():
+            with contextlib.suppress(FuturesTimeoutError):
+                future.result(timeout=timeout)
         executor.shutdown(wait=False)
+        segments.close()
 
 
 def transcribe_once(

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -2,13 +2,14 @@
 
 import os
 import signal
+import subprocess
 import tempfile
 import threading
 import unittest
 from itertools import chain, repeat
 from unittest.mock import MagicMock, patch
 
-from sys2txt.audio import AudioSegment, iter_audio_segments, record_once
+from sys2txt.audio import AudioSegment, _stop_ffmpeg, iter_audio_segments, record_once
 
 
 def _mock_proc(returncode: int = 0, stderr_lines: list = ()) -> MagicMock:
@@ -120,6 +121,67 @@ class TestRecordOnce(unittest.TestCase):
             record_once("test.monitor", "/tmp/test.wav")
 
         self.assertIn("1", str(ctx.exception))
+
+
+class TestStopFfmpeg(unittest.TestCase):
+    """Tests for the _stop_ffmpeg() shutdown helper."""
+
+    def test_already_exited_does_nothing(self):
+        """A process that has already exited is left alone."""
+        proc = MagicMock()
+        proc.poll.return_value = 0
+
+        _stop_ffmpeg(proc)
+
+        proc.stdin.write.assert_not_called()
+        proc.wait.assert_not_called()
+
+    def test_quits_on_q(self):
+        """The common path: ffmpeg exits after being asked to quit."""
+        proc = MagicMock()
+        proc.poll.return_value = None
+        proc.wait.return_value = None
+
+        _stop_ffmpeg(proc)
+
+        proc.stdin.write.assert_called_once_with(b"q")
+        proc.terminate.assert_not_called()
+        proc.kill.assert_not_called()
+
+    def test_escalates_to_terminate_then_kill(self):
+        """A process that ignores both the quit signal and SIGTERM is killed, not waited on forever."""
+        proc = MagicMock()
+        proc.poll.return_value = None
+        proc.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="ffmpeg", timeout=3.0),
+            subprocess.TimeoutExpired(cmd="ffmpeg", timeout=3.0),
+            None,
+        ]
+
+        _stop_ffmpeg(proc)
+
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+        self.assertEqual(proc.wait.call_count, 3)
+
+    def test_stops_after_terminate_without_escalating_to_kill(self):
+        """A process that responds to SIGTERM is not also killed."""
+        proc = MagicMock()
+        proc.poll.return_value = None
+        proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="ffmpeg", timeout=3.0), None]
+
+        _stop_ffmpeg(proc)
+
+        proc.terminate.assert_called_once()
+        proc.kill.assert_not_called()
+
+    def test_swallows_oserror(self):
+        """A broken pipe (ffmpeg already gone) does not propagate."""
+        proc = MagicMock()
+        proc.poll.return_value = None
+        proc.stdin.write.side_effect = OSError("broken pipe")
+
+        _stop_ffmpeg(proc)  # Should not raise
 
 
 def _write_segments(directory, count, size=1024):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -196,6 +196,38 @@ class TestTranscribeLive(unittest.TestCase):
 
         self.assertTrue(source.closed)
 
+    @patch("sys2txt.pipeline.ThreadPoolExecutor")
+    @patch("sys2txt.pipeline.iter_audio_segments")
+    def test_interrupt_waits_for_the_in_flight_worker_before_closing_the_source(self, mock_iter, mock_executor_cls):
+        """Ctrl-C during future.result() must not let the source's cleanup outrun the worker.
+
+        The generator's close() removes the temp directory the worker is reading from, so the
+        worker must be given a chance to finish first (issue #55).
+        """
+        source = ClosableSegments(make_segments(1))
+        mock_iter.return_value = source
+        future = MagicMock()
+        future.done.return_value = False
+        future.result.side_effect = [KeyboardInterrupt(), spoken("hello")]
+        executor = mock_executor_cls.return_value
+        executor.submit.return_value = future
+
+        events = []
+        source.close = lambda: events.append("closed")
+        executor.shutdown.side_effect = lambda **_: events.append("shutdown")
+        orig_result = future.result
+
+        def tracked_result(*a, **kw):
+            events.append("result")
+            return orig_result(*a, **kw)
+
+        future.result = tracked_result
+
+        with self.assertRaises(KeyboardInterrupt):
+            list(transcribe_live("test.monitor", self.config, segment_seconds=8))
+
+        self.assertEqual(events, ["result", "result", "shutdown", "closed"])
+
 
 class TestLiveBackpressure(unittest.TestCase):
     """Tests for reporting and capping how far transcription falls behind recording."""


### PR DESCRIPTION
## Summary
- `_stop_ffmpeg()` (used by live mode's segment recorder) now escalates from the quit signal to `SIGTERM` to `SIGKILL`, each bounded by `FFMPEG_SHUTDOWN_GRACE`, instead of an unbounded `proc.wait()` after `terminate()`. A wedged ffmpeg (#52) can no longer hang shutdown.
- `record_once()`'s `KeyboardInterrupt` handler uses the same bounded escalation instead of an unbounded `proc.wait()`.
- `transcribe_live()` now waits (bounded by the segment's own transcription timeout) for an in-flight worker to finish before closing the audio segment generator, so a Ctrl-C that lands mid-transcription can no longer let the generator's temp-directory cleanup delete a WAV file a worker is still reading.
- The executor was already released on every exit path via `try/finally` (this was fixed in an earlier refactor split out from `audio.py` into `pipeline.py`), so that part of #55 needed no change here — confirmed by test coverage instead.

Fixes #55

## Test plan
- [x] `python -m unittest discover -s tests -p "test_*.py"` (242 tests, all passing)
- [x] `ruff format --check src/ tests/` and `ruff check src/ tests/`
- [x] Added `TestStopFfmpeg` covering the already-exited, normal-quit, terminate→kill escalation, terminate-without-kill, and `OSError`-swallowing paths (previously untested per the issue)
- [x] Added a `transcribe_live()` test asserting the in-flight worker is waited on before the audio source is closed when interrupted mid-transcription

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KoAtf4d5wsJZvkiQUwB2a