### PR TITLE
Add pytest-cov coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
         run: |
           ruff check src/
 
-      - name: Run unit tests
+      - name: Run unit tests with coverage
         run: |
-          python -m unittest discover -s tests -p "test_*.py" -v
+          pytest --cov=sys2txt --cov-report=term-missing --cov-report=xml -v
+
+      - name: Upload coverage report
+        if: matrix.python-version == '3.13'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ Pipeline includes:
 - Testing on Python 3.10, 3.11, 3.12, 3.13, and 3.14
 - Code formatting check with `ruff format --check`
 - Linting with `ruff check`
-- Unit tests with `python -m unittest`
+- Unit tests with `pytest` and coverage reporting (`pytest-cov`); coverage.xml is uploaded as a build artifact on the Python 3.13 job
 
 ### Publishing Workflows
 
@@ -222,6 +222,9 @@ python -m unittest tests/test_audio.py
 
 # Run a specific test class
 python -m unittest tests.test_audio.TestRecordOnce
+
+# Run tests with a coverage report
+pytest --cov=sys2txt --cov-report=term-missing
 
 # Format code with ruff
 ruff format src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ sys2txt = "sys2txt.__main__:main"
 faster = ["faster-whisper>=1.0.0"]
 openai = ["openai-whisper>=20231117"]
 all = ["faster-whisper>=1.0.0", "openai-whisper>=20231117"]
-dev = ["ruff>=0.8.0"]
+dev = ["ruff>=0.8.0", "pytest>=8.0.0", "pytest-cov>=5.0.0"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -35,3 +35,15 @@ target-version = "py39"
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
 ignore = []
+
+[tool.coverage.run]
+source = ["sys2txt"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+]


### PR DESCRIPTION
## Summary
- CI now runs the test suite via `pytest --cov=sys2txt` instead of plain `unittest`, producing a terminal coverage summary and `coverage.xml`
- `coverage.xml` is uploaded as a build artifact on the Python 3.13 job so it can be downloaded/reviewed
- Added `pytest`/`pytest-cov` to the `dev` extra and `[tool.coverage.*]` config in `pyproject.toml`
- Documented the coverage command and CI change in CLAUDE.md

Current coverage is ~97%.

## Test plan
- [x] `pytest --cov=sys2txt --cov-report=term-missing` passes locally (236 tests, 97% coverage)
- [x] `ruff format --check src/` and `ruff check src/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKAjHgy2G9zpmRgAyctY5H