### PR TITLE
fix: validate --output path is writable before recording or transcription

### DIFF
--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -166,6 +166,22 @@ def _build_transcription_config(options: Options) -> TranscriptionConfig:
     )
 
 
+def _check_output_writable(output_file: str) -> None:
+    """Fail fast if output_file cannot be written to, before recording or transcription starts.
+
+    Raises:
+        RuntimeError: If the path's directory is missing or the file cannot be opened for writing
+    """
+    directory = os.path.dirname(output_file) or "."
+    if not os.path.isdir(directory):
+        raise RuntimeError(f"--output directory does not exist: {directory}")
+    try:
+        with open(output_file, "a", encoding="utf-8"):
+            pass
+    except OSError as e:
+        raise RuntimeError(f"--output path is not writable: {output_file} ({e})") from e
+
+
 def _save_transcript(text: str, output_file: str) -> None:
     """Print transcript, write it to output_file, and log the saved path.
 
@@ -363,6 +379,7 @@ def _list_sources() -> None:
 def _run_once(options: Options, source: str) -> None:
     """Record (or read) a single audio file, transcribe it, and save the transcript."""
     output_file = _resolve_output_path(options.output, options.output_format)
+    _check_output_writable(output_file)
     config = _build_transcription_config(options)
 
     if options.input_path:
@@ -391,6 +408,7 @@ def _emit(chunk: str, handle: TextIO) -> None:
 def _run_live(options: Options, source: str) -> None:
     """Consume live transcript segments, printing and saving each one as it arrives."""
     output_file = _resolve_output_path(options.output, options.output_format)
+    _check_output_writable(output_file)
     config = _build_transcription_config(options)
     logger.info("Live transcript will be saved to: %s", output_file)
     logger.info("Press Ctrl-C once to stop live capture and save the transcript.")

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -12,6 +12,7 @@ from sys2txt.__main__ import (
     Options,
     _build_options,
     _build_transcription_config,
+    _check_output_writable,
     _configure_logging,
     _format_segment,
     _resolve_output_path,
@@ -263,6 +264,24 @@ class TestSaveTranscript(unittest.TestCase):
         mock_logger.info.assert_called_once_with("Transcript saved to: %s", "/out/transcript.txt")
 
 
+class TestCheckOutputWritable(unittest.TestCase):
+    def test_missing_directory_raises_without_touching_disk(self):
+        with self.assertRaisesRegex(RuntimeError, "directory does not exist"):
+            _check_output_writable("/does/not/exist/transcript.txt")
+
+    def test_writable_path_creates_and_leaves_empty_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_file = os.path.join(tmp, "transcript.txt")
+            _check_output_writable(output_file)
+            self.assertTrue(os.path.isfile(output_file))
+            self.assertEqual(os.path.getsize(output_file), 0)
+
+    def test_unwritable_file_raises_runtime_error(self):
+        with patch("builtins.open", side_effect=OSError("Permission denied")):
+            with self.assertRaisesRegex(RuntimeError, "not writable"):
+                _check_output_writable("/tmp/transcript.txt")
+
+
 class TestArgumentParsing(unittest.TestCase):
     """Tests for CLI argument parsing."""
 
@@ -497,6 +516,17 @@ class TestModeDispatchOnce(unittest.TestCase):
             self.assertEqual(mock_trans.call_args[0][0], audio.name)
         mock_save.assert_called_once_with("from file", "/tmp/out.txt")
 
+    @patch("sys2txt.__main__._configure_logging")
+    @patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor")
+    @patch("sys2txt.__main__.transcribe_once_cues")
+    @patch("sys2txt.__main__._resolve_output_path", return_value="/does/not/exist/out.txt")
+    def test_unwritable_output_fails_before_recording(self, _res, mock_once, _src, _log):
+        with patch("sys.argv", ["sys2txt", "once"]):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        self.assertEqual(ctx.exception.code, 1)
+        mock_once.assert_not_called()
+
 
 class TestOnceOutputFormats(unittest.TestCase):
     """once mode renders the transcript in the format the user asked for."""
@@ -687,6 +717,19 @@ class LiveRun:
 
 class TestModeDispatchLive(LiveRun, unittest.TestCase):
     """Tests for live mode consumption of the transcript stream."""
+
+    def test_unwritable_output_fails_before_capture(self):
+        with (
+            patch("sys2txt.__main__._configure_logging"),
+            patch("sys2txt.__main__.get_default_monitor_source", return_value="default.monitor"),
+            patch("sys2txt.__main__._resolve_output_path", return_value="/does/not/exist/out.txt"),
+            patch("sys2txt.__main__.transcribe_live") as mock_live,
+            patch("sys.argv", ["sys2txt", "live"]),
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        self.assertEqual(ctx.exception.code, 1)
+        mock_live.assert_not_called()
 
     def test_prints_and_saves_each_segment(self):
         _, mock_print, written = self._run_live(


### PR DESCRIPTION
## Summary
- Fixes #56: an unwritable `--output` path was discovered too late — once mode only found out after transcription completed (discarding the result), and live mode raised an unhandled `OSError` with a raw traceback instead of a clean error.
- Adds `_check_output_writable()`, called at the top of both `_run_once` and `_run_live`, which fails fast with a `RuntimeError` (handled the same way as other CLI errors, exit 1) before any audio is captured or transcribed.

## Test plan
- [x] `python -m unittest discover -s tests -p "test_*.py"` — 247 tests pass
- [x] `ruff check src/ tests/` and `ruff format --check src/ tests/` pass
- [x] New unit tests cover: missing output directory, unwritable file (mocked `OSError`), and that `once`/`live` mode dispatch fails before `transcribe_once_cues`/`transcribe_live` are ever called

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KoAtf4d5wsJZvkiQUwB2a