### PR TITLE
fix: gate publishing on tests and stop dropping releases via path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
-    paths:
-      - "src/**"
-      - "tests/**"
-      - "pyproject.toml"
-      - ".github/workflows/ci.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "src/**"
-      - "tests/**"
-      - "pyproject.toml"
-      - ".github/workflows/ci.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,8 +12,34 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: Run test suite
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg pulseaudio
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run ruff format check
+        run: ruff format --check src/
+      - name: Run ruff linting
+        run: ruff check src/
+      - name: Run unit tests
+        run: pytest
+
   build:
     name: Build distribution
+    needs:
+      - test
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -39,6 +65,7 @@ jobs:
   publish-to-pypi:
     name: Publish to PyPI
     needs:
+      - test
       - build
     # Release-candidate tags (v*-rc*) and non-tag refs (e.g. manual workflow_dispatch
     # from a branch) must never reach production PyPI; only final release tags do.

--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -10,8 +10,41 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: Run test suite
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg pulseaudio
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run ruff format check
+        run: ruff format --check src/
+
+      - name: Run ruff linting
+        run: ruff check src/
+
+      - name: Run unit tests
+        run: pytest
+
   build:
     name: Build distribution
+    needs:
+      - test
     runs-on: ubuntu-24.04
 
     steps:
@@ -38,6 +71,7 @@ jobs:
   publish-to-testpypi:
     name: Publish to TestPyPI
     needs:
+      - test
       - build
     runs-on: ubuntu-24.04
     environment:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'src/**'
-      - 'pyproject.toml'
-      - 'release-please-config.json'
-      - '.release-please-manifest.json'
-      - '.github/workflows/release-please.yml'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Publish workflows (`publish-to-pypi.yml`, `publish-to-testpypi.yml`) now run a `test` job (ruff format/lint + pytest) that `build` and the publish jobs depend on, so a release can no longer ship from a red tree.
- `release-please.yml` drops its `paths:` filter — a `fix:`/`feat:` commit touching only `tests/` or `.github/workflows/` no longer has its changelog entry silently dropped.
- `ci.yml` drops the mirror-image `paths:` filter — docs-only or workflow-only PRs now run the `test` check instead of being permanently blocked on a required status check that never runs.

## Test plan
- [ ] `git push`/tag flow triggers `test` → `build` → publish in order on the publish workflows
- [ ] A commit touching only `.github/workflows/` triggers release-please
- [ ] A PR touching only docs/tests runs CI

Fixes #57

https://claude.ai/code/session_018KoAtf4d5wsJZvkiQUwB2a