### PR TITLE
Warn on --device/--engine combinations that silently fall back to CPU

### DIFF
--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -131,6 +131,15 @@ def _build_options(args: argparse.Namespace) -> Options:
         if args.whisper_cpp_path:
             logger.warning("--whisper-cpp-path is only used with --engine cpp")
 
+    if args.device in ("vulkan", "gpu") and args.engine != "cpp":
+        logger.warning(
+            "--device %s is only honoured by --engine cpp; engine %s will fall back to CPU",
+            args.device,
+            args.engine,
+        )
+    if args.device == "cuda" and args.engine == "cpp":
+        logger.warning("--device cuda is not a whisper.cpp device; --engine cpp will use GPU if available, else CPU")
+
     return Options(
         mode=args.mode,
         source=args.source,

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -212,6 +212,29 @@ class TestBuildOptions(unittest.TestCase):
             _build_options(args)
         self.assertEqual(len(logs.output), 2)
 
+    def test_warns_that_vulkan_device_falls_back_to_cpu_on_non_cpp_engine(self):
+        args = make_args(engine="faster", device="vulkan")
+        with self.assertLogs("sys2txt.__main__", level="WARNING") as logs:
+            _build_options(args)
+        self.assertIn("--device vulkan", logs.output[0])
+
+    def test_warns_that_gpu_device_falls_back_to_cpu_on_auto_engine(self):
+        args = make_args(engine="auto", device="gpu")
+        with self.assertLogs("sys2txt.__main__", level="WARNING") as logs:
+            _build_options(args)
+        self.assertIn("--device gpu", logs.output[0])
+
+    def test_no_warning_for_vulkan_device_with_cpp_engine(self):
+        with self.assertRaises(AssertionError):
+            with self.assertLogs("sys2txt.__main__", level="WARNING"):
+                _build_options(make_args(engine="cpp", device="vulkan"))
+
+    def test_warns_that_cuda_device_is_not_a_whisper_cpp_device(self):
+        args = make_args(engine="cpp", device="cuda")
+        with self.assertLogs("sys2txt.__main__", level="WARNING") as logs:
+            _build_options(args)
+        self.assertIn("--device cuda", logs.output[0])
+
 
 class TestBuildTranscriptionConfig(unittest.TestCase):
     def test_returns_config_with_correct_values(self):


### PR DESCRIPTION
## Summary
- `--device vulkan`/`gpu` is only honoured by `--engine cpp`; every other engine (including `auto`, which may resolve to faster-whisper) silently transcribed on CPU with no indication other than being slow
- `--engine cpp --device cuda` has the same class of mismatch in reverse
- Both combinations now log a loud warning at argument-validation time, in the same place `--model-path`/`--whisper-cpp-path` cross-flag warnings already live

Fixes #58

## Test plan
- [x] `uv run pytest -q` — 251 passed
- [x] `uv run ruff format --check src/ tests/`
- [x] `uv run ruff check src/ tests/`
- [x] Added unit tests covering vulkan/gpu with faster/auto engines (warns), vulkan with cpp engine (no warning), and cuda with cpp engine (warns)

https://claude.ai/code/session_018KoAtf4d5wsJZvkiQUwB2a