### PR TITLE
fix: logging precedence, record mutation, duplicate handlers, unprefixed env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,8 +160,8 @@ The codebase is organized into focused modules by functionality:
 - `SYS2TXT_DEVICE`: Device selection for faster-whisper (`cpu`, `cuda`)
 - `SYS2TXT_WHISPER_CPP`: Path to whisper-cli binary
 - `SYS2TXT_WHISPER_CPP_MODELS`: Directory containing whisper.cpp model files (e.g., `ggml-small.bin`)
-- `WHISPER_MODEL`: Default for `--model` (falls back to `small.en`)
-- `LOG_LEVEL`: Overrides `--verbose`/`--quiet` with an explicit logging level (e.g. `DEBUG`, `INFO`, `WARNING`)
+- `SYS2TXT_WHISPER_MODEL`: Default for `--model` (falls back to `small.en`)
+- `SYS2TXT_LOG_LEVEL`: Used when neither `--verbose` nor `--quiet` is given, otherwise the flag wins (e.g. `DEBUG`, `INFO`, `WARNING`)
 
 ## Continuous Integration & Deployment
 

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ sys2txt live --model small.en --segment-seconds 8
 - `SYS2TXT_DEVICE` - Default for `--device` (`cpu`, `cuda`, `vulkan`, `gpu`)
 - `SYS2TXT_WHISPER_CPP` - Path to the `whisper-cli` binary, used when `--whisper-cpp-path` is omitted
 - `SYS2TXT_WHISPER_CPP_MODELS` - Directory containing whisper.cpp model files, used when `--model-path` is omitted
-- `WHISPER_MODEL` - Default for `--model` (falls back to `small.en`)
-- `LOG_LEVEL` - Overrides `--verbose`/`--quiet` with an explicit logging level (e.g. `DEBUG`, `INFO`, `WARNING`)
+- `SYS2TXT_WHISPER_MODEL` - Default for `--model` (falls back to `small.en`)
+- `SYS2TXT_LOG_LEVEL` - Used when neither `--verbose` nor `--quiet` is given, otherwise the flag wins (e.g. `DEBUG`, `INFO`, `WARNING`)
 
 ### Keeping up with real time
 

--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -3,6 +3,7 @@
 
 import argparse
 import contextlib
+import copy
 import logging
 import os
 import sys
@@ -14,8 +15,9 @@ from . import __version__
 from .constants import (
     DEFAULT_OUTPUT_FORMAT,
     DEFAULT_SEGMENT_SECONDS,
+    DEFAULT_WHISPER_MODEL,
     MAX_CONSECUTIVE_SEGMENT_FAILURES,
-    WHISPER_MODEL,
+    get_default_whisper_model,
 )
 from .engines import ENGINE_NAMES
 from .formats import FORMAT_EXTENSIONS, OUTPUT_FORMATS, TIMED_FORMATS, get_formatter, render_transcript
@@ -32,7 +34,7 @@ class Options:
 
     mode: str
     source: Optional[str] = None
-    model: str = WHISPER_MODEL
+    model: str = DEFAULT_WHISPER_MODEL
     engine: str = "auto"
     device: str = "auto"
     language: Optional[str] = None
@@ -225,21 +227,29 @@ class _ColorFormatter(logging.Formatter):
 
     def format(self, record):
         color = self.COLORS.get(record.levelno, "")
+        record = copy.copy(record)
         record.levelname = f"{color}{record.levelname}{self.RESET}"
         return super().format(record)
 
 
+_LEVEL_NAMES = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+
 def _configure_logging(verbose: bool, quiet: bool) -> None:
-    """Configure logging based on CLI flags and LOG_LEVEL environment variable."""
-    level_name = os.environ.get("LOG_LEVEL", "").upper()
-    if level_name and hasattr(logging, level_name):
-        level = getattr(logging, level_name)
-    elif quiet:
+    """Configure logging based on CLI flags, falling back to SYS2TXT_LOG_LEVEL, then a default.
+
+    Precedence: explicit --verbose/--quiet > SYS2TXT_LOG_LEVEL > default (WARNING).
+    """
+    if quiet:
         level = logging.WARNING
     elif verbose:
         level = logging.DEBUG
     else:
-        level = logging.WARNING
+        level_name = os.environ.get("SYS2TXT_LOG_LEVEL", "").upper()
+        if level_name in _LEVEL_NAMES:
+            level = getattr(logging, level_name)
+        else:
+            level = logging.WARNING
 
     handler = logging.StreamHandler(sys.stderr)
     fmt = "%(levelname)s: %(message)s"
@@ -250,6 +260,8 @@ def _configure_logging(verbose: bool, quiet: bool) -> None:
 
     root = logging.getLogger()
     root.setLevel(level)
+    for existing in list(root.handlers):
+        root.removeHandler(existing)
     root.addHandler(handler)
 
 
@@ -265,11 +277,12 @@ def _build_parser() -> argparse.ArgumentParser:
     common.add_argument(
         "--source", help="PulseAudio source name (e.g., <sink>.monitor). Defaults to auto.", default=None
     )
+    default_model = get_default_whisper_model()
     common.add_argument(
         "--model",
         dest="model_size",
-        default=WHISPER_MODEL,
-        help=f"Whisper model size (default: {WHISPER_MODEL})",
+        default=default_model,
+        help=f"Whisper model size (default: {default_model})",
     )
     common.add_argument(
         "--engine",

--- a/src/sys2txt/constants.py
+++ b/src/sys2txt/constants.py
@@ -2,8 +2,14 @@
 
 import os
 
-WHISPER_MODEL = os.getenv("WHISPER_MODEL", "small.en")
-"Default Whisper model"
+DEFAULT_WHISPER_MODEL = "small.en"
+"Fallback Whisper model when SYS2TXT_WHISPER_MODEL is not set"
+
+
+def get_default_whisper_model() -> str:
+    """Return the default Whisper model, read fresh from SYS2TXT_WHISPER_MODEL each call."""
+    return os.getenv("SYS2TXT_WHISPER_MODEL", DEFAULT_WHISPER_MODEL)
+
 
 SAMPLE_RATE = 16000
 "Capture sample rate in Hz. Whisper models expect 16 kHz audio."

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -962,21 +962,44 @@ class TestConfigureLogging(unittest.TestCase):
         root.level = self._original_level
 
     def test_verbose_sets_debug(self):
-        _configure_logging(verbose=True, quiet=False)
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SYS2TXT_LOG_LEVEL", None)
+            _configure_logging(verbose=True, quiet=False)
         self.assertEqual(logging.getLogger().level, logging.DEBUG)
 
     def test_quiet_sets_warning(self):
-        _configure_logging(verbose=False, quiet=True)
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SYS2TXT_LOG_LEVEL", None)
+            _configure_logging(verbose=False, quiet=True)
         self.assertEqual(logging.getLogger().level, logging.WARNING)
 
     def test_default_sets_warning(self):
-        _configure_logging(verbose=False, quiet=False)
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SYS2TXT_LOG_LEVEL", None)
+            _configure_logging(verbose=False, quiet=False)
         self.assertEqual(logging.getLogger().level, logging.WARNING)
 
-    def test_log_level_env_overrides_flags(self):
-        with patch.dict(os.environ, {"LOG_LEVEL": "ERROR"}):
+    def test_explicit_flags_override_log_level_env(self):
+        with patch.dict(os.environ, {"SYS2TXT_LOG_LEVEL": "ERROR"}):
             _configure_logging(verbose=True, quiet=False)
+        self.assertEqual(logging.getLogger().level, logging.DEBUG)
+
+    def test_log_level_env_used_when_no_flags(self):
+        with patch.dict(os.environ, {"SYS2TXT_LOG_LEVEL": "ERROR"}):
+            _configure_logging(verbose=False, quiet=False)
         self.assertEqual(logging.getLogger().level, logging.ERROR)
+
+    def test_log_level_env_invalid_value_falls_back_to_default(self):
+        with patch.dict(os.environ, {"SYS2TXT_LOG_LEVEL": "RAISEEXCEPTIONS"}):
+            _configure_logging(verbose=False, quiet=False)
+        self.assertEqual(logging.getLogger().level, logging.WARNING)
+
+    def test_configure_logging_does_not_duplicate_handlers(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SYS2TXT_LOG_LEVEL", None)
+            _configure_logging(verbose=False, quiet=False)
+            _configure_logging(verbose=False, quiet=False)
+        self.assertEqual(len(logging.getLogger().handlers), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `--verbose`/`--quiet` now beat `SYS2TXT_LOG_LEVEL` (was checked first, so an exported var silently overrode explicit flags)
- `SYS2TXT_LOG_LEVEL` is validated against real level names, not `hasattr(logging, ...)` (previously `RAISEEXCEPTIONS` etc. would resolve to non-level attributes)
- `_ColorFormatter.format` now formats a copy of the `LogRecord` instead of mutating the shared one (avoids leaking ANSI codes into other handlers, or nesting them on reuse)
- `_configure_logging` removes existing root handlers before adding a new one, so calling it twice no longer duplicates log lines
- `LOG_LEVEL` / `WHISPER_MODEL` renamed to `SYS2TXT_LOG_LEVEL` / `SYS2TXT_WHISPER_MODEL` for consistency with other `SYS2TXT_*` vars; the model default is now resolved lazily via `get_default_whisper_model()` rather than read at import time
- Updated/added tests in `tests/test___main__.py` to cover the new precedence, invalid env values, and handler de-duplication, and to no longer leak the env var across runs

Closes #59

## Test plan
- [x] `pytest -q` — 254 passed
- [x] `ruff check` / `ruff format --check` — clean