### PR TITLE
fix: only create output/ directory when it will actually be used

### DIFF
--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -81,9 +81,9 @@ def _resolve_output_path(output_arg: Optional[str], output_format: str = DEFAULT
     A generated name takes the extension of the output format; an explicit path is used
     as given, on the assumption the caller named it deliberately.
     """
-    output_dir = ensure_output_dir()
     if output_arg:
         return output_arg
+    output_dir = ensure_output_dir()
     return os.path.join(output_dir, get_timestamp_filename(FORMAT_EXTENSIONS[output_format]))
 
 

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -84,8 +84,10 @@ def live_segments(*items, segment_seconds=8, indices=None, lags=(), dropped=()):
 
 class TestResolveOutputPath(unittest.TestCase):
     def test_explicit_arg_returned_as_is(self):
-        result = _resolve_output_path("/tmp/my_output.txt")
+        with patch("sys2txt.__main__.ensure_output_dir") as mock_ensure_output_dir:
+            result = _resolve_output_path("/tmp/my_output.txt")
         self.assertEqual(result, "/tmp/my_output.txt")
+        mock_ensure_output_dir.assert_not_called()
 
     def test_none_generates_timestamped_path(self):
         with (


### PR DESCRIPTION
## Summary
- `_resolve_output_path()` called `ensure_output_dir()` unconditionally, so `./output/` was created in the working directory even when an explicit `--output` path was given.
- Move the `ensure_output_dir()` call inside the branch that generates the timestamped default path, so it only runs when actually needed.
- Updated the existing test to assert `ensure_output_dir` is not called when an explicit path is provided.

Fixes #60

## Test plan
- [x] `pytest -q` — 254 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] Verified no `output/` directory is created when running the test suite or when `--output` is passed an explicit path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KoAtf4d5wsJZvkiQUwB2a