### PR TITLE
fix: drop dead RuntimeError clause and avoid double pactl call in pulse.py

### DIFF
--- a/src/sys2txt/pulse.py
+++ b/src/sys2txt/pulse.py
@@ -38,18 +38,20 @@ def get_default_monitor_source() -> str:
     """Pick the default sink's .monitor if available; otherwise the first *.monitor source; else 'default'."""
     try:
         code, sink_name, _ = run_command(["pactl", "get-default-sink"])
-        sink_name = sink_name.strip()
-        if code == 0 and sink_name:
-            candidate = f"{sink_name}.monitor"
-            sources = [s for s, _ in list_pulse_sources()]
-            if candidate in sources:
-                return candidate
-        # fallback: first *.monitor source
-        for s, _ in list_pulse_sources():
-            if s.endswith(".monitor"):
-                logger.debug("Default sink has no monitor source, falling back to '%s'", s)
-                return s
-    except (FileNotFoundError, RuntimeError) as e:
+    except FileNotFoundError as e:
         logger.debug("Could not query PulseAudio for a monitor source: %s", e)
+        logger.debug("No monitor source found, falling back to 'default'")
+        return "default"
+    sink_name = sink_name.strip()
+    sources = [s for s, _ in list_pulse_sources()]
+    if code == 0 and sink_name:
+        candidate = f"{sink_name}.monitor"
+        if candidate in sources:
+            return candidate
+    # fallback: first *.monitor source
+    for s in sources:
+        if s.endswith(".monitor"):
+            logger.debug("Default sink has no monitor source, falling back to '%s'", s)
+            return s
     logger.debug("No monitor source found, falling back to 'default'")
     return "default"

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -119,14 +119,15 @@ class TestGetDefaultMonitorSource(unittest.TestCase):
 
     @patch("sys2txt.pulse.list_pulse_sources")
     @patch("sys2txt.pulse.run_command")
-    def test_get_default_monitor_source_exception(self, mock_run, mock_list):
-        """Test get_default_monitor_source() handles exceptions gracefully."""
-        mock_run.side_effect = RuntimeError("Unexpected error")
+    def test_get_default_monitor_source_no_pactl(self, mock_run, mock_list):
+        """Test get_default_monitor_source() handles a missing pactl gracefully."""
+        mock_run.side_effect = FileNotFoundError("pactl not found")
         mock_list.return_value = []
 
         source = get_default_monitor_source()
 
         self.assertEqual(source, "default")
+        mock_list.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `get_default_monitor_source()` no longer catches `RuntimeError`, since `run_command()` (built on `subprocess.Popen`/`communicate()`) can never raise it — only `FileNotFoundError` is reachable.
- `list_pulse_sources()` is now called once per `get_default_monitor_source()` invocation instead of up to twice, avoiding a redundant `pactl` subprocess spawn.
- Logging of fallback paths (missing `pactl`, no monitor found) was already in place and is preserved.

Addresses points 1 (partially — logging already existed) and 2/3 of #61. Left `list_pulse_sources()`'s `(name, name)` tuple return shape alone since that's called out as a separate minor/optional cleanup with broader API/test impact.

## Test plan
- [x] `pytest tests/test_pulse.py` — 9 passed
- [x] Full suite: `pytest` — 254 passed
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KoAtf4d5wsJZvkiQUwB2a