### PR TITLE
fix: whisper.cpp engine parses -oj JSON instead of scraping console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,11 @@ The full public API is `AudioSegment`, `Cue`, `OUTPUT_FORMATS`, `Transcript`, `T
 
 For AMD GPUs (or other GPUs not supported by CUDA), you can use whisper.cpp with Vulkan acceleration, which is substantially faster than CPU-only transcription (the exact speedup depends on your GPU and model size).
 
+sys2txt drives `whisper-cli` with `-oj`/`-of` and reads back its structured JSON output rather than
+scraping the console's human-readable timestamps, so any `whisper-cli` build with `-oj` support works;
+this has been present since well before Vulkan support was added, so a build following the instructions
+below is sufficient.
+
 ### Build whisper.cpp with Vulkan
 
 ```bash

--- a/src/sys2txt/engines.py
+++ b/src/sys2txt/engines.py
@@ -18,11 +18,12 @@ nothing and an uninstalled backend is a ``False`` from :meth:`is_available`, not
 ``ImportError`` at import time.
 """
 
+import json
 import logging
 import os
-import re
 import shutil
 import subprocess
+import tempfile
 import threading
 from dataclasses import dataclass
 from pathlib import Path
@@ -288,58 +289,40 @@ def _resolve_whisper_cpp_model_path(model_path: Optional[str], model_size: str) 
     )
 
 
-def _timestamp_to_seconds(ts: str) -> float:
-    """Convert HH:MM:SS.mmm timestamp to seconds.
+def _parse_whisper_cpp_json(raw: str, language: Optional[str] = None) -> Transcript:
+    """Parse whisper-cli's ``-oj`` JSON output.
 
-    Args:
-        ts: Timestamp string like "00:01:23.456"
+    Each entry under ``transcription`` carries ``offsets.from``/``offsets.to`` in
+    milliseconds alongside the display-only ``timestamps.from``/``timestamps.to``
+    strings; the offsets are used since they need no format parsing of their own.
+    ``result.language`` is whisper.cpp's own detected/used language and is preferred
+    over the caller's requested language, which may have been ``None`` (auto-detect).
 
-    Returns:
-        Time in seconds as float
+    Raises:
+        RuntimeError: If ``raw`` is not the JSON object whisper-cli is documented to emit
     """
     try:
-        parts = ts.split(":")
-        hours = int(parts[0])
-        minutes = int(parts[1])
-        seconds = float(parts[2])
-        return hours * 3600 + minutes * 60 + seconds
-    except (IndexError, ValueError):
-        return 0.0
+        data = json.loads(raw)
+        segments = data["transcription"]
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        raise RuntimeError(f"whisper-cli produced unparseable JSON output: {e}") from e
 
-
-def _parse_whisper_cpp_output(output: str, language: Optional[str] = None) -> Transcript:
-    """Parse whisper.cpp stdout format.
-
-    Whisper.cpp outputs lines like:
-    [00:00:00.000 --> 00:00:05.120]   Hello world
-
-    Args:
-        output: Raw stdout from whisper-cli
-        language: Language code the caller asked for, recorded on the transcript
-
-    Returns:
-        The transcript parsed out of the timestamped lines
-    """
     cues: List[Cue] = []
-    # Pattern: [HH:MM:SS.mmm --> HH:MM:SS.mmm] text
-    pattern = re.compile(r"\[(\d{2}:\d{2}:\d{2}\.\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}\.\d{3})\]\s*(.*)")
-
-    for line in output.splitlines():
-        match = pattern.match(line.strip())
-        if match:
-            start_str, end_str, text = match.groups()
-            text = text.strip()
-            if not text:
-                continue
-            cues.append(
-                Cue(
-                    start=_timestamp_to_seconds(start_str),
-                    end=_timestamp_to_seconds(end_str),
-                    text=text,
-                )
+    for segment in segments:
+        text = segment["text"].strip()
+        if not text:
+            continue
+        offsets = segment["offsets"]
+        cues.append(
+            Cue(
+                start=offsets["from"] / 1000.0,
+                end=offsets["to"] / 1000.0,
+                text=text,
             )
+        )
 
-    return Transcript(cues=tuple(cues), language=language)
+    detected_language = data.get("result", {}).get("language")
+    return Transcript(cues=tuple(cues), language=detected_language or language)
 
 
 class WhisperCppEngine:
@@ -366,7 +349,11 @@ class WhisperCppEngine:
         """No cached model to release."""
 
     def transcribe(self, path: str, config: TranscriptionConfig) -> Transcript:
-        """Transcribe by running whisper-cli and parsing its timestamped output.
+        """Transcribe by running whisper-cli and parsing its ``-oj`` JSON output.
+
+        The JSON is a structured interface (segment start/end/text as typed fields)
+        rather than a display format, so it survives changes to whisper-cli's
+        human-readable console output that broke #42.
 
         Raises:
             RuntimeError: If whisper-cli or its model cannot be found, or it fails
@@ -374,32 +361,40 @@ class WhisperCppEngine:
         binary = _resolve_whisper_cpp_binary(config.whisper_cpp_path)
         model = _resolve_whisper_cpp_model_path(config.model_path, config.model)
 
-        # Build command
-        cmd = [binary, "-m", model, "-f", path, "-np"]  # -np = no progress
+        with tempfile.TemporaryDirectory(prefix="sys2txt-whisper-cpp-") as tmpdir:
+            output_prefix = os.path.join(tmpdir, "output")
+            json_path = output_prefix + ".json"
 
-        # Device selection
-        if config.device == "cpu":
-            cmd.append("--no-gpu")
-        # For auto/vulkan/gpu/cuda, let whisper.cpp use GPU if available
+            cmd = [binary, "-m", model, "-f", path, "-np", "-oj", "-of", output_prefix]
 
-        if config.language:
-            cmd.extend(["-l", config.language])
+            # Device selection
+            if config.device == "cpu":
+                cmd.append("--no-gpu")
+            # For auto/vulkan/gpu/cuda, let whisper.cpp use GPU if available
 
-        logger.debug("Running whisper-cli: %s", " ".join(cmd))
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=WHISPER_CPP_TIMEOUT)
-        except subprocess.TimeoutExpired as e:
-            raise RuntimeError(
-                f"whisper-cli timed out after {WHISPER_CPP_TIMEOUT} seconds "
-                f"(possible GPU hang or malformed audio): {binary}"
-            ) from e
-        except subprocess.CalledProcessError as e:
-            stderr = e.stderr.strip() if e.stderr else "No error output"
-            raise RuntimeError(f"whisper-cli failed: {stderr}") from e
-        except FileNotFoundError as e:
-            raise RuntimeError(f"whisper-cli binary not found: {binary}") from e
+            if config.language:
+                cmd.extend(["-l", config.language])
 
-        return _parse_whisper_cpp_output(result.stdout, config.language)
+            logger.debug("Running whisper-cli: %s", " ".join(cmd))
+            try:
+                subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=WHISPER_CPP_TIMEOUT)
+            except subprocess.TimeoutExpired as e:
+                raise RuntimeError(
+                    f"whisper-cli timed out after {WHISPER_CPP_TIMEOUT} seconds "
+                    f"(possible GPU hang or malformed audio): {binary}"
+                ) from e
+            except subprocess.CalledProcessError as e:
+                stderr = e.stderr.strip() if e.stderr else "No error output"
+                raise RuntimeError(f"whisper-cli failed: {stderr}") from e
+            except FileNotFoundError as e:
+                raise RuntimeError(f"whisper-cli binary not found: {binary}") from e
+
+            try:
+                raw = Path(json_path).read_text()
+            except OSError as e:
+                raise RuntimeError(f"whisper-cli did not produce the expected JSON output at {json_path}") from e
+
+        return _parse_whisper_cpp_json(raw, config.language)
 
 
 ENGINES: Tuple[TranscriptionEngine, ...] = (

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,5 +1,6 @@
 """Tests for sys2txt.engines module."""
 
+import json
 import os
 import subprocess
 import sys
@@ -16,11 +17,10 @@ from sys2txt.engines import (
     TranscriptionConfig,
     TranscriptionEngine,
     WhisperCppEngine,
-    _parse_whisper_cpp_output,
+    _parse_whisper_cpp_json,
     _resolve_device,
     _resolve_whisper_cpp_binary,
     _resolve_whisper_cpp_model_path,
-    _timestamp_to_seconds,
     get_engine,
     unload_engines,
 )
@@ -447,62 +447,78 @@ class TestResolveWhisperCppModelPath(unittest.TestCase):
         self.assertIn("ggml-small.bin", str(cm.exception))
 
 
-class TestParseWhisperCppOutput(unittest.TestCase):
-    """Tests for the _parse_whisper_cpp_output() function."""
+def whisper_cpp_json(segments, language=None):
+    """Build a whisper-cli ``-oj`` JSON document as a string.
+
+    Args:
+        segments: Iterable of (text, start_seconds, end_seconds) tuples
+        language: Value to put under result.language, or omitted if None
+    """
+    transcription = []
+    for text, start, end in segments:
+        transcription.append(
+            {
+                "timestamps": {
+                    "from": f"{start:012.3f}",  # display-only, not parsed
+                    "to": f"{end:012.3f}",
+                },
+                "offsets": {"from": int(start * 1000), "to": int(end * 1000)},
+                "text": text,
+            }
+        )
+    doc = {"transcription": transcription}
+    if language is not None:
+        doc["result"] = {"language": language}
+    return json.dumps(doc)
+
+
+class TestParseWhisperCppJson(unittest.TestCase):
+    """Tests for the _parse_whisper_cpp_json() function."""
 
     def test_parse_keeps_cue_times(self):
-        """Test parsing whisper.cpp output into cues that keep their times."""
-        output = """[00:00:00.000 --> 00:00:05.120]   Hello world
-[00:00:05.120 --> 00:00:10.240]   This is a test"""
+        """Test parsing whisper.cpp JSON into cues that keep their times."""
+        raw = whisper_cpp_json([("Hello world", 0.0, 5.12), ("This is a test", 5.12, 10.24)])
 
-        result = _parse_whisper_cpp_output(output)
+        result = _parse_whisper_cpp_json(raw)
 
         self.assertEqual(
             result.cues,
             (Cue(0.0, 5.12, "Hello world"), Cue(5.12, 10.24, "This is a test")),
         )
 
-    def test_parse_records_the_language(self):
-        """Test that the requested language is recorded on the transcript."""
-        result = _parse_whisper_cpp_output("[00:00:00.000 --> 00:00:05.120]   Bonjour", "fr")
+    def test_parse_prefers_detected_language_over_the_requested_one(self):
+        """whisper.cpp's own result.language wins over the caller's requested language."""
+        raw = whisper_cpp_json([("Bonjour", 0.0, 5.12)], language="fr")
+
+        result = _parse_whisper_cpp_json(raw, "en")
+
+        self.assertEqual(result.language, "fr")
+
+    def test_parse_falls_back_to_requested_language_without_a_detected_one(self):
+        """Without a result.language field, the requested language is recorded instead."""
+        raw = whisper_cpp_json([("Bonjour", 0.0, 5.12)])
+
+        result = _parse_whisper_cpp_json(raw, "fr")
 
         self.assertEqual(result.language, "fr")
 
     def test_parse_empty_segments_ignored(self):
         """Test that empty segments are ignored."""
-        output = """[00:00:00.000 --> 00:00:05.120]   Hello
-[00:00:05.120 --> 00:00:10.240]
-[00:00:10.240 --> 00:00:15.000]   World"""
+        raw = whisper_cpp_json([("Hello", 0.0, 5.12), ("", 5.12, 10.24), ("World", 10.24, 15.0)])
 
-        result = _parse_whisper_cpp_output(output)
+        result = _parse_whisper_cpp_json(raw)
 
         self.assertEqual(result.text, "Hello World")
 
-    def test_parse_non_matching_lines_ignored(self):
-        """Test that non-matching lines are ignored."""
-        output = """whisper_init_from_file_no_state: loading model...
-[00:00:00.000 --> 00:00:05.120]   Hello world
-main: some debug output"""
+    def test_parse_malformed_json_raises(self):
+        """A body that isn't the documented JSON shape is a failure, not silent empty output."""
+        with self.assertRaises(RuntimeError):
+            _parse_whisper_cpp_json("not json")
 
-        result = _parse_whisper_cpp_output(output)
-
-        self.assertEqual(result.text, "Hello world")
-
-
-class TestTimestampToSeconds(unittest.TestCase):
-    """Tests for the _timestamp_to_seconds() function."""
-
-    def test_simple_seconds(self):
-        """Test simple seconds conversion."""
-        self.assertAlmostEqual(_timestamp_to_seconds("00:00:05.120"), 5.12, places=3)
-
-    def test_minutes_and_seconds(self):
-        """Test minutes and seconds conversion."""
-        self.assertAlmostEqual(_timestamp_to_seconds("00:02:30.500"), 150.5, places=3)
-
-    def test_hours_minutes_seconds(self):
-        """Test hours, minutes, and seconds conversion."""
-        self.assertAlmostEqual(_timestamp_to_seconds("01:30:45.750"), 5445.75, places=3)
+    def test_parse_missing_transcription_key_raises(self):
+        """Valid JSON that lacks the expected shape is still a failure."""
+        with self.assertRaises(RuntimeError):
+            _parse_whisper_cpp_json(json.dumps({"unexpected": []}))
 
 
 @patch("sys2txt.engines._resolve_whisper_cpp_binary", return_value="/path/to/whisper-cli")
@@ -515,7 +531,14 @@ class TestWhisperCppEngine(unittest.TestCase):
 
     @staticmethod
     def _stdout(mock_run, text="Hello world"):
-        mock_run.return_value = MagicMock(stdout=f"[00:00:00.000 --> 00:00:05.000]   {text}\n", returncode=0)
+        """Make the mocked whisper-cli write the JSON file its ``-of``/``-oj`` args request."""
+
+        def write_json(cmd, **kwargs):
+            output_prefix = cmd[cmd.index("-of") + 1]
+            Path(output_prefix + ".json").write_text(whisper_cpp_json([(text, 0.0, 5.0)]))
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = write_json
 
     @patch("subprocess.run")
     def test_transcribe_success(self, mock_run, _model_path, _binary):
@@ -539,6 +562,17 @@ class TestWhisperCppEngine(unittest.TestCase):
         self.assertIn("fr", call_args)
 
     @patch("subprocess.run")
+    def test_transcribe_requests_json_output(self, mock_run, _model_path, _binary):
+        """Test that whisper-cli is asked for -oj JSON rather than relying on stdout."""
+        self._stdout(mock_run)
+
+        self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig())
+
+        call_args = mock_run.call_args[0][0]
+        self.assertIn("-oj", call_args)
+        self.assertIn("-of", call_args)
+
+    @patch("subprocess.run")
     def test_transcribe_cpu_device(self, mock_run, _model_path, _binary):
         """Test transcription with CPU device adds --no-gpu flag."""
         self._stdout(mock_run)
@@ -557,19 +591,12 @@ class TestWhisperCppEngine(unittest.TestCase):
         self.assertNotIn("--no-gpu", mock_run.call_args[0][0])
 
     @patch("subprocess.run")
-    def test_transcribe_no_timestamps_does_not_pass_no_timestamps_flag(self, mock_run, _model_path, _binary):
-        """Regression test for #42: --no-timestamps must never be passed to whisper-cli.
+    def test_transcribe_missing_json_output_raises(self, mock_run, _model_path, _binary):
+        """If whisper-cli exits successfully but never writes the JSON file, that's a failure."""
+        mock_run.return_value = MagicMock(returncode=0)
 
-        whisper-cli only emits bracketed timestamp lines when timestamps are enabled;
-        with --no-timestamps its plain-text output doesn't match the parser's regex,
-        so the transcript would silently come back empty.
-        """
-        self._stdout(mock_run)
-
-        result = self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig())
-
-        self.assertNotIn("--no-timestamps", mock_run.call_args[0][0])
-        self.assertEqual(result.text, "Hello world")
+        with self.assertRaises(RuntimeError):
+            self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig())
 
     @patch("subprocess.run")
     def test_transcribe_passes_the_configured_paths(self, mock_run, mock_model_path, mock_binary):


### PR DESCRIPTION
## Summary
- Replaces the whisper.cpp engine's regex parsing of `whisper-cli`'s human-readable `[HH:MM:SS.mmm --> HH:MM:SS.mmm]` console lines with `-oj`/`-of` JSON output, read from a temp file and parsed with `json.loads`.
- Removes `_timestamp_to_seconds` entirely — JSON's `offsets.from`/`offsets.to` are already millisecond integers, so there's no display-format timestamp string to parse or silently zero out on failure.
- A malformed or missing JSON file now raises `RuntimeError` instead of the old parser's silent "no lines matched → empty transcript" behavior.
- `Transcript.language` now prefers whisper.cpp's own detected `result.language` over the caller's requested language when present.
- Documents in the README that `sys2txt` relies on `-oj`, and that this predates Vulkan support so any build following the existing instructions works.

Fixes #65.

## Test plan
- [x] `python -m unittest discover -s tests -p "test_*.py"` — 254 tests pass
- [x] `ruff check` / `ruff format --check` — clean
- [x] Updated `tests/test_engines.py` fixtures/tests to build and assert against `-oj` JSON documents instead of bracketed timestamp text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nue8rGzmNUsEbUEhniC