### PR TITLE
feat: auto-download missing whisper.cpp models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Common flags:
 - `--timestamps`: Include timestamps in output
 - `--model-path <path>`: Path to whisper.cpp model file (for cpp engine)
 - `--whisper-cpp-path <path>`: Path to whisper-cli binary (for cpp engine)
+- `--no-download`: Don't auto-download a missing whisper.cpp model file (for cpp engine)
 - `--verbose`/`-v`: Enable debug logging
 - `--quiet`/`-q`: Suppress informational log messages
 
@@ -106,7 +107,7 @@ The codebase is organized into focused modules by functionality:
 - `run_command()`: Helper for running system commands
 
 **engines.py** - The transcription engines and the registry that selects between them:
-- `TranscriptionConfig`: Dataclass bundling engine, model, device, language, timestamps, model_path, and whisper_cpp_path. Engines take it whole; nothing destructures it into positional arguments
+- `TranscriptionConfig`: Dataclass bundling engine, model, device, language, timestamps, model_path, whisper_cpp_path, and download_model. Engines take it whole; nothing destructures it into positional arguments
 - `TranscriptionEngine`: `Protocol` of `name`, `is_available()`, `transcribe(path, config) -> Transcript` and `unload()`
 - `_CachedModelEngine`: Base for engines that load a model. Holds the model, its key and a lock as instance state, reloading only when the key changes. One model per engine: a second would double the memory a transcription needs, and a run only ever uses one
 - `FasterWhisperEngine` (`faster`): faster_whisper.WhisperModel with VAD filter, keyed on `(model, device, compute_type)`
@@ -114,7 +115,8 @@ The codebase is organized into focused modules by functionality:
 - `WhisperCppEngine` (`cpp`): Runs the whisper-cli subprocess with GPU/CPU support. Caches nothing, since the binary loads its own model
 - `_resolve_device()`: `auto` reads `SYS2TXT_DEVICE` then falls back to CPU; the whisper.cpp-only GPU choices (`vulkan`, `gpu`) resolve to CPU for the Python engines
 - `_resolve_whisper_cpp_binary()`: Resolves whisper-cli path from arg/env/PATH
-- `_resolve_whisper_cpp_model_path()`: Resolves model path from arg/env/default
+- `_resolve_whisper_cpp_model_path()`: Resolves model path from arg/env/default, downloading a missing model from the `ggerganov/whisper.cpp` Hugging Face repo unless `download=False` (`config.download_model`, set from `--no-download`)
+- `_download_whisper_cpp_model()`: Streams a model to a `.part` file and renames it into place on success; failures are caught by the resolver and fall back to the existing "not found" error
 - `_parse_whisper_cpp_output()`: Parses whisper.cpp's `[HH:MM:SS.mmm --> HH:MM:SS.mmm]` lines into cues
 - `ENGINES`: The registry, in the order `auto` prefers them. `ENGINE_NAMES` derives the `--engine` choices from it, so adding an engine means writing one class and adding it here
 - `get_engine(name)`: `auto` returns the first engine whose `is_available()` is true, raising `RuntimeError` naming all of them if none is installed; a named engine is returned without the availability check, so the user gets that backend's own diagnostic; anything else raises `ValueError`
@@ -126,7 +128,7 @@ The codebase is organized into focused modules by functionality:
 - `transcribe_file(path, config)`: The text form, `render_transcript(..., "txt", timestamps=config.timestamps)` over the above. Output is unchanged from before formats existed
 - Re-exports `TranscriptionConfig` from `engines.py`, so `from sys2txt.transcribe import TranscriptionConfig` keeps working
 
-**constants.py** - Configuration shared by library and CLI: default model, capture `SAMPLE_RATE`/`CHANNELS`, segment length and poll interval, minimum segment size, ffmpeg shutdown grace, transcription timeouts, `LAG_WARN_FACTOR`, `MAX_CONSECUTIVE_SEGMENT_FAILURES`, default output format.
+**constants.py** - Configuration shared by library and CLI: default model, capture `SAMPLE_RATE`/`CHANNELS`, segment length and poll interval, minimum segment size, ffmpeg shutdown grace, transcription timeouts, `LAG_WARN_FACTOR`, `MAX_CONSECUTIVE_SEGMENT_FAILURES`, default output format, `WHISPER_CPP_MODEL_URL_TEMPLATE`.
 
 **utils.py** - Utility functions:
 - `which()`: Find command in PATH or raise RuntimeError

--- a/README.md
+++ b/README.md
@@ -337,6 +337,10 @@ cmake --build build --config Release
 
 ### Download models
 
+sys2txt downloads a missing model automatically the first time it's needed, saving it to
+`SYS2TXT_WHISPER_CPP_MODELS` (or `~/.local/share/whisper.cpp/models` by default). Pass `--no-download`
+to disable this and fail instead, or fetch a model yourself:
+
 ```bash
 # Download a model (e.g., small)
 ./models/download-ggml-model.sh small

--- a/src/sys2txt/__main__.py
+++ b/src/sys2txt/__main__.py
@@ -42,6 +42,7 @@ class Options:
     list_sources: bool = False
     model_path: Optional[str] = None
     whisper_cpp_path: Optional[str] = None
+    download_model: bool = True
     output: Optional[str] = None
     duration: Optional[int] = None
     input_path: Optional[str] = None
@@ -132,6 +133,8 @@ def _build_options(args: argparse.Namespace) -> Options:
             logger.warning("--model-path is only used with --engine cpp")
         if args.whisper_cpp_path:
             logger.warning("--whisper-cpp-path is only used with --engine cpp")
+        if args.no_download:
+            logger.warning("--no-download is only used with --engine cpp")
 
     if args.device in ("vulkan", "gpu") and args.engine != "cpp":
         logger.warning(
@@ -153,6 +156,7 @@ def _build_options(args: argparse.Namespace) -> Options:
         list_sources=args.list_sources,
         model_path=args.model_path,
         whisper_cpp_path=args.whisper_cpp_path,
+        download_model=not args.no_download,
         output=args.output,
         duration=duration,
         input_path=input_path,
@@ -173,6 +177,7 @@ def _build_transcription_config(options: Options) -> TranscriptionConfig:
         timestamps=options.timestamps,
         model_path=options.model_path,
         whisper_cpp_path=options.whisper_cpp_path,
+        download_model=options.download_model,
         device=options.device,
     )
 
@@ -321,6 +326,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--whisper-cpp-path",
         default=None,
         help="Path to whisper-cli binary (for cpp engine)",
+    )
+    common.add_argument(
+        "--no-download",
+        action="store_true",
+        help="Don't automatically download a missing whisper.cpp model file (for cpp engine)",
     )
 
     once = sub.add_parser("once", parents=[common], help="Record once and transcribe after")

--- a/src/sys2txt/constants.py
+++ b/src/sys2txt/constants.py
@@ -38,6 +38,9 @@ MIN_TRANSCRIBE_TIMEOUT = 60
 WHISPER_CPP_TIMEOUT = 300
 "Seconds to wait for whisper-cli before assuming a GPU hang or malformed audio"
 
+WHISPER_CPP_MODEL_URL_TEMPLATE = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/{filename}"
+"URL template for downloading a missing whisper.cpp GGML model; {filename} is e.g. ggml-small.bin"
+
 LAG_WARN_FACTOR = 2
 "Live mode warns that it is falling behind once the backlog exceeds this many segments"
 

--- a/src/sys2txt/engines.py
+++ b/src/sys2txt/engines.py
@@ -25,11 +25,13 @@ import shutil
 import subprocess
 import tempfile
 import threading
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Protocol, Tuple, runtime_checkable
 
-from .constants import WHISPER_CPP_TIMEOUT
+from .constants import WHISPER_CPP_MODEL_URL_TEMPLATE, WHISPER_CPP_TIMEOUT
 from .formats import Cue, Transcript
 
 logger = logging.getLogger(__name__)
@@ -46,6 +48,7 @@ class TranscriptionConfig:
     timestamps: bool = False
     model_path: Optional[str] = None
     whisper_cpp_path: Optional[str] = None
+    download_model: bool = True
 
 
 @runtime_checkable
@@ -245,23 +248,65 @@ def _resolve_whisper_cpp_binary(whisper_cpp_path: Optional[str]) -> str:
     )
 
 
-def _resolve_whisper_cpp_model_path(model_path: Optional[str], model_size: str) -> str:
-    """Resolve the path to a whisper.cpp model file.
+def _download_whisper_cpp_model(model_filename: str, destination: Path) -> None:
+    """Download a whisper.cpp GGML model from the ggerganov/whisper.cpp Hugging Face repo.
+
+    Streams to a ``.part`` file alongside ``destination`` and renames it into place on
+    success, so a failed or interrupted download never leaves a file that later looks
+    like a complete model.
+
+    Raises:
+        RuntimeError: If the download fails for any reason
+    """
+    url = WHISPER_CPP_MODEL_URL_TEMPLATE.format(filename=model_filename)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    partial = destination.with_suffix(destination.suffix + ".part")
+
+    logger.info("Downloading whisper.cpp model '%s' from %s", model_filename, url)
+    try:
+        with urllib.request.urlopen(url) as response, open(partial, "wb") as f:
+            total = response.getheader("Content-Length")
+            total_bytes = int(total) if total else None
+            written = 0
+            last_logged_percent = -1
+            while chunk := response.read(1024 * 1024):
+                f.write(chunk)
+                written += len(chunk)
+                if total_bytes:
+                    percent = written * 100 // total_bytes
+                    if percent >= last_logged_percent + 10:
+                        logger.info("Downloading %s: %d%%", model_filename, percent)
+                        last_logged_percent = percent
+    except (urllib.error.URLError, OSError) as e:
+        partial.unlink(missing_ok=True)
+        raise RuntimeError(f"Failed to download whisper.cpp model '{model_filename}' from {url}: {e}") from e
+
+    partial.rename(destination)
+    logger.info("Downloaded whisper.cpp model to %s", destination)
+
+
+def _resolve_whisper_cpp_model_path(model_path: Optional[str], model_size: str, download: bool = True) -> str:
+    """Resolve the path to a whisper.cpp model file, downloading it if missing.
 
     Priority:
     1. Explicit model_path argument
     2. SYS2TXT_WHISPER_CPP_MODELS directory + ggml-{model_size}.bin
     3. ~/.local/share/whisper.cpp/models/ggml-{model_size}.bin
 
+    If none of these exist and ``download`` is true, the model is fetched from the
+    ggerganov/whisper.cpp Hugging Face repo into the resolved models directory
+    (``SYS2TXT_WHISPER_CPP_MODELS`` if set, else the default directory above).
+
     Args:
         model_path: Explicit path to model file
         model_size: Whisper model size (tiny, base, small, medium, large-v2)
+        download: Whether to attempt downloading a missing model
 
     Returns:
         Path to model file
 
     Raises:
-        RuntimeError: If model file cannot be found
+        RuntimeError: If model file cannot be found or downloaded
     """
     if model_path:
         if not os.path.isfile(model_path):
@@ -280,6 +325,17 @@ def _resolve_whisper_cpp_model_path(model_path: Optional[str], model_size: str) 
     default_path = default_dir / model_filename
     if default_path.is_file():
         return str(default_path)
+
+    target_dir = Path(env_models_dir) if env_models_dir else default_dir
+    target_path = target_dir / model_filename
+
+    if download:
+        try:
+            _download_whisper_cpp_model(model_filename, target_path)
+        except RuntimeError as e:
+            logger.warning("%s", e)
+        else:
+            return str(target_path)
 
     raise RuntimeError(
         f"whisper.cpp model '{model_filename}' not found. Either:\n"
@@ -359,7 +415,7 @@ class WhisperCppEngine:
             RuntimeError: If whisper-cli or its model cannot be found, or it fails
         """
         binary = _resolve_whisper_cpp_binary(config.whisper_cpp_path)
-        model = _resolve_whisper_cpp_model_path(config.model_path, config.model)
+        model = _resolve_whisper_cpp_model_path(config.model_path, config.model, download=config.download_model)
 
         with tempfile.TemporaryDirectory(prefix="sys2txt-whisper-cpp-") as tmpdir:
             output_prefix = os.path.join(tmpdir, "output")

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -37,6 +37,7 @@ def make_args(**overrides):
         list_sources=False,
         model_path=None,
         whisper_cpp_path=None,
+        no_download=False,
         output=None,
         segment_seconds=8,
         silence_timeout=0,
@@ -127,6 +128,7 @@ class TestBuildOptions(unittest.TestCase):
         self.assertTrue(options.timestamps)
         self.assertEqual(options.model_path, "/models/ggml.bin")
         self.assertEqual(options.whisper_cpp_path, "/usr/local/bin/whisper-cli")
+        self.assertTrue(options.download_model)
         self.assertEqual(options.output, "/tmp/out.txt")
         self.assertEqual(options.duration, 30)
 
@@ -209,10 +211,10 @@ class TestBuildOptions(unittest.TestCase):
                 _build_options(make_args(timestamps=True, output_format="txt"))
 
     def test_warns_about_cpp_only_flags(self):
-        args = make_args(engine="faster", model_path="/m.bin", whisper_cpp_path="/w")
+        args = make_args(engine="faster", model_path="/m.bin", whisper_cpp_path="/w", no_download=True)
         with self.assertLogs("sys2txt.__main__", level="WARNING") as logs:
             _build_options(args)
-        self.assertEqual(len(logs.output), 2)
+        self.assertEqual(len(logs.output), 3)
 
     def test_warns_that_vulkan_device_falls_back_to_cpu_on_non_cpp_engine(self):
         args = make_args(engine="faster", device="vulkan")

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -4,8 +4,10 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import threading
 import unittest
+import urllib.error
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -17,6 +19,7 @@ from sys2txt.engines import (
     TranscriptionConfig,
     TranscriptionEngine,
     WhisperCppEngine,
+    _download_whisper_cpp_model,
     _parse_whisper_cpp_json,
     _resolve_device,
     _resolve_whisper_cpp_binary,
@@ -437,14 +440,79 @@ class TestResolveWhisperCppModelPath(unittest.TestCase):
         self.assertEqual(result, str(expected_path))
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_model_not_found(self):
-        """Test model not found anywhere."""
+    def test_model_not_found_download_disabled(self):
+        """Test model not found anywhere and downloading is disabled."""
+        with patch("os.path.isfile", return_value=False):
+            with patch.object(Path, "is_file", return_value=False):
+                with self.assertRaises(RuntimeError) as cm:
+                    _resolve_whisper_cpp_model_path(None, "small", download=False)
+
+        self.assertIn("ggml-small.bin", str(cm.exception))
+
+    @patch("sys2txt.engines._download_whisper_cpp_model")
+    def test_model_missing_downloads_it(self, mock_download):
+        """Test a missing model is downloaded to the default directory."""
+        expected_path = Path.home() / ".local" / "share" / "whisper.cpp" / "models" / "ggml-small.bin"
+
+        with patch("os.path.isfile", return_value=False):
+            with patch.object(Path, "is_file", return_value=False):
+                result = _resolve_whisper_cpp_model_path(None, "small")
+
+        mock_download.assert_called_once_with("ggml-small.bin", expected_path)
+        self.assertEqual(result, str(expected_path))
+
+    @patch.dict(os.environ, {"SYS2TXT_WHISPER_CPP_MODELS": "/models"})
+    @patch("sys2txt.engines._download_whisper_cpp_model")
+    def test_model_missing_downloads_to_env_dir(self, mock_download):
+        """Test a missing model is downloaded to SYS2TXT_WHISPER_CPP_MODELS if set."""
+        with patch("os.path.isfile", return_value=False):
+            result = _resolve_whisper_cpp_model_path(None, "small")
+
+        mock_download.assert_called_once_with("ggml-small.bin", Path("/models/ggml-small.bin"))
+        self.assertEqual(result, "/models/ggml-small.bin")
+
+    @patch("sys2txt.engines._download_whisper_cpp_model")
+    def test_download_failure_falls_back_to_error(self, mock_download):
+        """Test a failed download still raises the original 'not found' error."""
+        mock_download.side_effect = RuntimeError("network unreachable")
+
         with patch("os.path.isfile", return_value=False):
             with patch.object(Path, "is_file", return_value=False):
                 with self.assertRaises(RuntimeError) as cm:
                     _resolve_whisper_cpp_model_path(None, "small")
 
         self.assertIn("ggml-small.bin", str(cm.exception))
+
+
+class TestDownloadWhisperCppModel(unittest.TestCase):
+    """Tests for the _download_whisper_cpp_model() function."""
+
+    def test_downloads_and_renames_into_place(self):
+        """Test the body is streamed to a .part file and renamed on success."""
+        response = MagicMock()
+        response.getheader.return_value = None
+        response.read.side_effect = [b"chunk1", b"chunk2", b""]
+        response.__enter__.return_value = response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            destination = Path(tmpdir) / "models" / "ggml-small.bin"
+            with patch("urllib.request.urlopen", return_value=response):
+                _download_whisper_cpp_model("ggml-small.bin", destination)
+
+            self.assertTrue(destination.is_file())
+            self.assertEqual(destination.read_bytes(), b"chunk1chunk2")
+            self.assertFalse(destination.with_suffix(".bin.part").exists())
+
+    def test_download_failure_removes_partial_file(self):
+        """Test a network failure raises RuntimeError and cleans up the .part file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            destination = Path(tmpdir) / "models" / "ggml-small.bin"
+            with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("boom")):
+                with self.assertRaises(RuntimeError) as cm:
+                    _download_whisper_cpp_model("ggml-small.bin", destination)
+
+            self.assertIn("Failed to download", str(cm.exception))
+            self.assertFalse((destination.parent / "ggml-small.bin.part").exists())
 
 
 def whisper_cpp_json(segments, language=None):
@@ -607,7 +675,7 @@ class TestWhisperCppEngine(unittest.TestCase):
         self.engine.transcribe("/path/to/audio.wav", config)
 
         mock_binary.assert_called_once_with("/custom/whisper-cli")
-        mock_model_path.assert_called_once_with("/custom/model.bin", "small")
+        mock_model_path.assert_called_once_with("/custom/model.bin", "small", download=True)
 
     @patch("subprocess.run")
     def test_transcribe_failure(self, mock_run, _model_path, _binary):


### PR DESCRIPTION
## Summary
- The `cpp` engine now downloads a missing GGML model file from the `ggerganov/whisper.cpp` Hugging Face repo into the resolved models directory (`SYS2TXT_WHISPER_CPP_MODELS` or `~/.local/share/whisper.cpp/models`), instead of erroring out and requiring a manual `wget`/`download-ggml-model.sh` step.
- Downloads stream to a `.part` file and are renamed into place on success, so an interrupted download never leaves a file that looks like a complete model; a download failure falls back to the original "not found" error.
- Add `--no-download` to restore the old strict behaviour (also settable via `TranscriptionConfig.download_model`).

Closes #71

## Test plan
- [x] `pytest` (259 passed)
- [x] `ruff check` / `ruff format --check`
- [x] `sys2txt once --help` shows `--no-download`
- [x] New unit tests cover the download helper (success, .part cleanup on failure) and the resolver's download/fallback paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nue8rGzmNUsEbUEhniC