### PR TITLE
chore: fix ruff target-version, lint tests/, add packaging metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,15 @@ on:
 
 permissions:
   contents: write
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -22,6 +28,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install system dependencies
         run: |
@@ -36,15 +43,20 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,all]"
 
       - name: Run ruff format check
         run: |
-          ruff format --check src/
+          ruff format --check src/ tests/
 
       - name: Run ruff linting
         run: |
-          ruff check src/
+          ruff check src/ tests/
+
+      - name: Smoke test the installed entry point
+        run: |
+          sys2txt --version
+          python -c "import sys2txt"
 
       - name: Run unit tests with coverage
         run: |

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -30,9 +30,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       - name: Run ruff format check
-        run: ruff format --check src/
+        run: ruff format --check src/ tests/
       - name: Run ruff linting
-        run: ruff check src/
+        run: ruff check src/ tests/
       - name: Run unit tests
         run: pytest
 
@@ -83,4 +83,4 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1

--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -33,10 +33,10 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Run ruff format check
-        run: ruff format --check src/
+        run: ruff format --check src/ tests/
 
       - name: Run ruff linting
-        run: ruff check src/
+        run: ruff check src/ tests/
 
       - name: Run unit tests
         run: pytest
@@ -88,6 +88,6 @@ jobs:
           path: dist/
 
       - name: Publish distribution to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,25 @@ requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [{ name = "Joe Heffer", email = "jheffer@gmail.com" }]
 dependencies = []
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Multimedia :: Sound/Audio :: Speech",
+    "Topic :: Text Processing :: Linguistic",
+]
+
+[project.urls]
+Homepage = "https://github.com/Joe-Heffer/sys2txt"
+Issues = "https://github.com/Joe-Heffer/sys2txt/issues"
 
 [project.scripts]
 sys2txt = "sys2txt.__main__:main"
@@ -19,7 +38,7 @@ sys2txt = "sys2txt.__main__:main"
 [project.optional-dependencies]
 faster = ["faster-whisper>=1.0.0"]
 openai = ["openai-whisper>=20231117"]
-all = ["faster-whisper>=1.0.0", "openai-whisper>=20231117"]
+all = ["sys2txt[faster,openai]"]
 dev = ["ruff>=0.8.0", "pytest>=8.0.0", "pytest-cov>=5.0.0", "genbadge[coverage]>=1.1.0"]
 
 [tool.setuptools.packages.find]
@@ -30,7 +49,7 @@ sys2txt = ["py.typed"]
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]


### PR DESCRIPTION
## Summary
- `ruff` `target-version` now matches `requires-python` (`py310`, was `py39`)
- Lint and format-check `tests/` in CI and both publish workflows, not just `src/`
- Add trove classifiers and `[project.urls]` so PyPI shows Python/license/OS support and a homepage/issue-tracker link
- Collapse the `all` extra to the PEP 685 self-reference (`all = ["sys2txt[faster,openai]"]`) instead of duplicating both dependency lists
- Pin `pypa/gh-action-pypi-publish` to a commit SHA in both publish workflows instead of the floating `release/v1` branch ref
- Add a `github-actions` ecosystem block to `dependabot.yml`
- CI: add a `concurrency` group to cancel superseded runs, `timeout-minutes`, pip caching in `setup-python`, a post-install smoke test (`sys2txt --version` / `import sys2txt`), and install the `all` extra so `faster-whisper`/`openai-whisper` are exercised on every matrix leg

Addresses part of #67 — the CI/packaging/tooling-config items. Left for a follow-up: adding mypy, unifying the `Optional[str]`/`str | None` annotation style, and annotating the remaining untyped signatures — that needs its own pass once a type checker is in place to hold it to, so this PR does not close #67.

## Test plan
- [x] `ruff format --check src/ tests/` and `ruff check src/ tests/` pass
- [x] `validate-pyproject pyproject.toml` passes
- [x] `pytest -q` passes (259 tests)
- [x] `sys2txt --version` and `python -c "import sys2txt"` work after `pip install -e ".[dev]"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ7nue8rGzmNUsEbUEhniC