### PR TITLE
docs: add changelog page to docs site

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+--8<-- "CHANGELOG.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,9 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.highlight
+  - pymdownx.snippets:
+      base_path: .
+      check_paths: true
   - tables
   - toc:
       permalink: true
@@ -47,3 +50,4 @@ nav:
   - Examples: examples.md
   - Python API: python-api.md
   - Troubleshooting: troubleshooting.md
+  - Changelog: changelog.md


### PR DESCRIPTION
## Summary
- Adds a Changelog nav entry to the MkDocs Material site that renders the root `CHANGELOG.md` via `pymdownx.snippets`

## Test plan
- [ ] `mkdocs build --strict` locally
- [ ] Check the rendered Changelog page in `mkdocs serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179dZYnYjdcxCyRzzTUUhJd