### PR TITLE
docs: add bug reporting instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Report a problem with sys2txt
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. For anything that looks like a security
+        vulnerability, please follow the process in
+        [SECURITY.md](https://github.com/Joe-Heffer/sys2txt/blob/main/SECURITY.md) instead of
+        filing a public issue.
+
+  - type: input
+    id: version
+    attributes:
+      label: sys2txt version
+      description: Output of `sys2txt --version`
+    validations:
+      required: true
+
+  - type: input
+    id: install-method
+    attributes:
+      label: Installation method
+      description: e.g. pip, pipx, editable install from source
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS / distro
+    validations:
+      required: true
+
+  - type: dropdown
+    id: audio-system
+    attributes:
+      label: Audio system
+      options:
+        - PulseAudio
+        - PipeWire
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command
+      description: The full command you ran, including flags
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: error
+    attributes:
+      label: Error message / traceback
+      description: The complete error message or traceback, ideally with `--verbose`/`-v` for debug logging
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Joe-Heffer/sys2txt/blob/main/SECURITY.md
+    about: Please report security vulnerabilities privately instead of filing a public issue.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,6 +8,23 @@
 - `SYS2TXT_DEVICE`/`--device` apply to openai-whisper too, which needs a CUDA-capable PyTorch build for `cuda`.
 - For AMD GPUs, use whisper.cpp with Vulkan support (see [Engines & devices](engines-and-devices.md#amd-gpu-vulkan)).
 
+## Reporting bugs
+
+Found a bug? Please [open an issue](https://github.com/Joe-Heffer/sys2txt/issues/new) on GitHub.
+
+To help us fix it quickly, include:
+
+- The `sys2txt` version (`sys2txt --version`) and how you installed it
+- Your OS/distro and whether you're using PulseAudio or PipeWire
+- The full command you ran, including flags
+- The complete error message or traceback, ideally with `--verbose`/`-v` for debug logging
+- What you expected to happen versus what actually happened
+- Steps to reproduce, if you can find them
+
+For anything that looks like a security vulnerability, please follow the process in
+[SECURITY.md](https://github.com/Joe-Heffer/sys2txt/blob/main/SECURITY.md) instead of filing a
+public issue.
+
 ## Contributing
 
 Contributions are welcome! Please see [CONTRIBUTING.md](https://github.com/Joe-Heffer/sys2txt/blob/main/CONTRIBUTING.md) for:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,9 +10,8 @@
 
 ## Reporting bugs
 
-Found a bug? Please [open an issue](https://github.com/Joe-Heffer/sys2txt/issues/new) on GitHub.
-
-To help us fix it quickly, include:
+Found a bug? Please [open an issue](https://github.com/Joe-Heffer/sys2txt/issues/new/choose) on
+GitHub using the bug report template, which will prompt you for:
 
 - The `sys2txt` version (`sys2txt --version`) and how you installed it
 - Your OS/distro and whether you're using PulseAudio or PipeWire


### PR DESCRIPTION
## Summary
- Adds a "Reporting bugs" section to the troubleshooting doc page, pointing to GitHub Issues and listing what info to include (version, OS, command, error output, repro steps)
- Links to SECURITY.md for vulnerability reports instead of public issues

## Test plan
- [ ] `mkdocs build --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179dZYnYjdcxCyRzzTUUhJd