### PR TITLE
docs: add animated demo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 [![PyPI version](https://badge.fury.io/py/sys2txt.svg)](https://badge.fury.io/py/sys2txt)
 ![Coverage](badge.svg)
 
+[![asciicast](https://asciinema.org/a/6Ob4WmuccSXEljRm.svg)](https://asciinema.org/a/6Ob4WmuccSXEljRm)
+
+*`sys2txt live` transcribing a public-domain LibriVox reading of Wordsworth's
+["We Are Seven"](https://archive.org/details/spc277_2607_librivox) (recording by David Freisty, public domain).*
+
 Record system audio and automatically transcribe to text using ✨AI✨.
 
 **Full documentation:** [Joe-Heffer.github.io/sys2txt/](https://joe-heffer.github.io/sys2txt/)


### PR DESCRIPTION
## Summary
- Embeds an asciinema recording of `sys2txt live` transcribing audio near the top of the README, under the existing badges
- The demo audio is a public-domain LibriVox reading of William Wordsworth's "We Are Seven" (archive.org item [spc277_2607_librivox](https://archive.org/details/spc277_2607_librivox), reader David Freisty) — chosen specifically so the transcribed content itself is unambiguously public domain
- Adds a one-line credit/attribution under the embed

Closes #113

## Test plan
- [x] Recorded locally with `asciinema rec`, played back with `asciinema play demo.cast` to confirm the transcript streams correctly
- [x] Uploaded to asciinema.org and linked to the author's account (https://asciinema.org/~jheffer) so the cast won't be auto-deleted after 7 days
- [x] Visually confirmed the README embed and credit line render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179dZYnYjdcxCyRzzTUUhJd