### PR TITLE
Polish PyPI packaging metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,all]"
+          pip install -e ".[all]" --group dev
 
       - name: Run ruff format check
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,9 @@ jobs:
           python-version: "3.13"
 
       - name: Install docs dependencies
-        run: pip install -e ".[docs]"
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . --group docs
 
       - name: Deploy to GitHub Pages
         run: |

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e . --group dev
       - name: Run ruff format check
         run: ruff format --check src/ tests/
       - name: Run ruff linting

--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e . --group dev
 
       - name: Run ruff format check
         run: ruff format --check src/ tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ description = "Record system audio and transcribe to text using AI"
 readme = "README.md"
 # https://devguide.python.org/versions/
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Joe Heffer", email = "jheffer@gmail.com" }]
 keywords = [
     "whisper",
@@ -28,7 +29,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
@@ -54,6 +54,8 @@ sys2txt = "sys2txt.__main__:main"
 faster = ["faster-whisper>=1.0.0"]
 openai = ["openai-whisper>=20231117"]
 all = ["sys2txt[faster,openai]"]
+
+[dependency-groups]
 dev = ["ruff>=0.8.0", "pytest>=8.0.0", "pytest-cov>=5.0.0", "genbadge[coverage]>=1.1.0"]
 docs = ["mkdocs-material>=9.5.0"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,18 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [{ name = "Joe Heffer", email = "jheffer@gmail.com" }]
+keywords = [
+    "whisper",
+    "speech-to-text",
+    "transcription",
+    "pulseaudio",
+    "pipewire",
+    "audio",
+    "cli",
+    "linux",
+    "faster-whisper",
+    "whisper.cpp",
+]
 dependencies = []
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary
- Audited `pyproject.toml` against issue #114's checklist: `readme`, `classifiers`, `[project.urls]` (Homepage/Documentation/Repository/Issues/Changelog), and `license` were already complete and consistent.
- Added the missing `keywords` field (whisper, speech-to-text, transcription, pulseaudio, pipewire, audio, cli, linux, faster-whisper, whisper.cpp) for PyPI search/discovery.
- Migrated `license` to the PEP 639 SPDX expression form (`license = "MIT"` + `license-files`), dropping the now-redundant `License :: OSI Approved :: MIT License` classifier.
- Moved `dev`/`docs` deps from optional-dependencies extras to PEP 735 `[dependency-groups]`, updating all four workflows to install with `--group` instead of `.[dev]`/`.[docs]`/`.[dev,all]`.

## Test plan
- [x] `python -m build` succeeds, producing wheel + sdist
- [x] `python -m twine check dist/*` → both PASSED, no warnings
- [ ] Tag `v*-rc*` to trigger `publish-to-testpypi.yml` and eyeball the rendered TestPyPI page (not done here — needs a maintainer-triggered tag push)

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179dZYnYjdcxCyRzzTUUhJd