### PR TITLE
Reduce test-suite coupling to implementation control flow

### DIFF
--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -13,6 +13,7 @@ from sys2txt.__main__ import (
     _build_options,
     _build_transcription_config,
     _check_output_writable,
+    _ColorFormatter,
     _configure_logging,
     _format_segment,
     _save_transcript,
@@ -951,20 +952,17 @@ class TestConfigureLogging(unittest.TestCase):
         root.level = self._original_level
 
     def test_verbose_sets_debug(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("SYS2TXT_LOG_LEVEL", None)
+        with patch.dict(os.environ, {}, clear=True):
             _configure_logging(verbose=True, quiet=False)
         self.assertEqual(logging.getLogger().level, logging.DEBUG)
 
     def test_quiet_sets_warning(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("SYS2TXT_LOG_LEVEL", None)
+        with patch.dict(os.environ, {}, clear=True):
             _configure_logging(verbose=False, quiet=True)
         self.assertEqual(logging.getLogger().level, logging.WARNING)
 
     def test_default_sets_warning(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("SYS2TXT_LOG_LEVEL", None)
+        with patch.dict(os.environ, {}, clear=True):
             _configure_logging(verbose=False, quiet=False)
         self.assertEqual(logging.getLogger().level, logging.WARNING)
 
@@ -984,11 +982,50 @@ class TestConfigureLogging(unittest.TestCase):
         self.assertEqual(logging.getLogger().level, logging.WARNING)
 
     def test_configure_logging_does_not_duplicate_handlers(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("SYS2TXT_LOG_LEVEL", None)
+        with patch.dict(os.environ, {}, clear=True):
             _configure_logging(verbose=False, quiet=False)
             _configure_logging(verbose=False, quiet=False)
         self.assertEqual(len(logging.getLogger().handlers), 1)
+
+
+class TestColorFormatter(unittest.TestCase):
+    """Tests for _ColorFormatter."""
+
+    def _record(self, level):
+        return logging.LogRecord(
+            name="sys2txt", level=level, pathname=__file__, lineno=1, msg="hello", args=(), exc_info=None
+        )
+
+    def test_wraps_the_level_name_in_its_color_code(self):
+        formatter = _ColorFormatter("%(levelname)s: %(message)s")
+
+        formatted = formatter.format(self._record(logging.WARNING))
+
+        self.assertIn(_ColorFormatter.COLORS[logging.WARNING], formatted)
+        self.assertIn(_ColorFormatter.RESET, formatted)
+        self.assertIn("hello", formatted)
+
+    def test_different_levels_get_different_colors(self):
+        formatter = _ColorFormatter("%(levelname)s")
+
+        warning = formatter.format(self._record(logging.WARNING))
+        error = formatter.format(self._record(logging.ERROR))
+
+        self.assertNotEqual(
+            _ColorFormatter.COLORS[logging.WARNING],
+            _ColorFormatter.COLORS[logging.ERROR],
+        )
+        self.assertIn(_ColorFormatter.COLORS[logging.WARNING], warning)
+        self.assertIn(_ColorFormatter.COLORS[logging.ERROR], error)
+
+    def test_does_not_mutate_the_original_record(self):
+        """The formatter must not leave colored level names on records other handlers also see."""
+        formatter = _ColorFormatter("%(levelname)s")
+        record = self._record(logging.ERROR)
+
+        formatter.format(record)
+
+        self.assertEqual(record.levelname, "ERROR")
 
 
 if __name__ == "__main__":

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -77,13 +77,13 @@ class TestRecordOnce(unittest.TestCase):
         """Test record_once() handles KeyboardInterrupt gracefully."""
         mock_which.return_value = "/usr/bin/ffmpeg"
         mock_proc = _mock_proc()
-        mock_proc.wait.side_effect = [KeyboardInterrupt(), None]
+        mock_proc.wait.side_effect = chain([KeyboardInterrupt()], repeat(None))
         mock_popen.return_value = mock_proc
 
         record_once("test.monitor", "/tmp/test.wav")
 
         mock_proc.send_signal.assert_called_once_with(signal.SIGINT)
-        self.assertEqual(mock_proc.wait.call_count, 2)
+        self.assertGreaterEqual(mock_proc.wait.call_count, 2)
 
     @patch("sys2txt.audio.which")
     @patch("sys2txt.audio.subprocess.Popen")
@@ -91,7 +91,7 @@ class TestRecordOnce(unittest.TestCase):
         """A non-zero exit caused by our own SIGINT is not a genuine failure."""
         mock_which.return_value = "/usr/bin/ffmpeg"
         mock_proc = _mock_proc(returncode=255)
-        mock_proc.wait.side_effect = [KeyboardInterrupt(), None]
+        mock_proc.wait.side_effect = chain([KeyboardInterrupt()], repeat(None))
         mock_popen.return_value = mock_proc
 
         record_once("test.monitor", "/tmp/test.wav")
@@ -152,23 +152,25 @@ class TestStopFfmpeg(unittest.TestCase):
         """A process that ignores both the quit signal and SIGTERM is killed, not waited on forever."""
         proc = MagicMock()
         proc.poll.return_value = None
-        proc.wait.side_effect = [
-            subprocess.TimeoutExpired(cmd="ffmpeg", timeout=3.0),
-            subprocess.TimeoutExpired(cmd="ffmpeg", timeout=3.0),
-            None,
-        ]
+        proc.wait.side_effect = chain(
+            [
+                subprocess.TimeoutExpired(cmd="ffmpeg", timeout=3.0),
+                subprocess.TimeoutExpired(cmd="ffmpeg", timeout=3.0),
+            ],
+            repeat(None),
+        )
 
         _stop_ffmpeg(proc)
 
         proc.terminate.assert_called_once()
         proc.kill.assert_called_once()
-        self.assertEqual(proc.wait.call_count, 3)
+        self.assertGreaterEqual(proc.wait.call_count, 3)
 
     def test_stops_after_terminate_without_escalating_to_kill(self):
         """A process that responds to SIGTERM is not also killed."""
         proc = MagicMock()
         proc.poll.return_value = None
-        proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="ffmpeg", timeout=3.0), None]
+        proc.wait.side_effect = chain([subprocess.TimeoutExpired(cmd="ffmpeg", timeout=3.0)], repeat(None))
 
         _stop_ffmpeg(proc)
 

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -83,14 +83,14 @@ class TestRegistry(unittest.TestCase):
     @patch.dict(os.environ, {}, clear=True)
     def test_auto_falls_back_to_whisper_cpp(self):
         with patch.dict("sys.modules", {"faster_whisper": None, "whisper": None}):
-            with patch("shutil.which", return_value="/usr/bin/whisper-cli"):
+            with patch("sys2txt.engines.shutil.which", return_value="/usr/bin/whisper-cli"):
                 self.assertEqual(get_engine("auto").name, "cpp")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_auto_with_nothing_installed_names_every_engine(self):
         """Regression for #63: auto used to fall through to cpp and report a missing binary."""
         with patch.dict("sys.modules", {"faster_whisper": None, "whisper": None}):
-            with patch("shutil.which", return_value=None):
+            with patch("sys2txt.engines.shutil.which", return_value=None):
                 with self.assertRaises(RuntimeError) as cm:
                     get_engine("auto")
 
@@ -100,14 +100,19 @@ class TestRegistry(unittest.TestCase):
             self.assertIn(name, message)
 
     def test_unload_engines_releases_every_cached_model(self):
-        engine = get_engine("faster")
-        engine._model = object()
-        engine._key = ("small", "cpu", "int8")
+        mock_model_class = MagicMock()
+        mock_model_class.return_value.transcribe.return_value = ([], None)
+        fake_module = MagicMock(WhisperModel=mock_model_class)
 
-        unload_engines()
+        with patch.dict("sys.modules", {"faster_whisper": fake_module}):
+            engine = get_engine("faster")
+            config = TranscriptionConfig(device="cpu")
+            engine.transcribe("/path/to/audio.wav", config)
 
-        self.assertIsNone(engine._model)
-        self.assertIsNone(engine._key)
+            unload_engines()
+            engine.transcribe("/path/to/audio.wav", config)
+
+        self.assertEqual(mock_model_class.call_count, 2)
 
 
 class TestResolveDevice(unittest.TestCase):
@@ -318,24 +323,31 @@ class TestModelCache(unittest.TestCase):
 
         self.engine.transcribe("/path/to/audio.wav", config)
         self.engine.unload()
-        self.assertIsNone(self.engine._model)
-        self.assertIsNone(self.engine._key)
-
         self.engine.transcribe("/path/to/audio.wav", config)
 
         self.assertEqual(mock_model_class.call_count, 2)
 
     @patch("faster_whisper.WhisperModel")
     def test_concurrent_calls_load_model_once(self, mock_model_class):
-        """Concurrent transcriptions with same params should only load the model once."""
-        mock_model_class.return_value.transcribe.return_value = ([whisper_segment(" Hello ", 0.0, 1.0)], None)
+        """Concurrent transcriptions with same params should only load the model once.
 
-        barrier = threading.Barrier(4)
+        Rather than racing real threads against each other (a source of CI flakes), the
+        model constructor itself blocks every caller on one Event, so all four threads are
+        guaranteed to be inside the critical section together before any of them proceeds.
+        """
+        release = threading.Event()
+
+        def slow_constructor(*args, **kwargs):
+            release.wait(timeout=10)
+            model = MagicMock()
+            model.transcribe.return_value = ([whisper_segment(" Hello ", 0.0, 1.0)], None)
+            return model
+
+        mock_model_class.side_effect = slow_constructor
         errors = []
 
         def worker():
             try:
-                barrier.wait()
                 self.engine.transcribe("/path/to/audio.wav", TranscriptionConfig(device="cpu"))
             except Exception as e:
                 errors.append(e)
@@ -343,8 +355,12 @@ class TestModelCache(unittest.TestCase):
         threads = [threading.Thread(target=worker) for _ in range(4)]
         for thread in threads:
             thread.start()
+        # Give every thread a chance to block on the lock before releasing the constructor -
+        # only one of them can be inside it at a time, so this just needs to outlast scheduling.
+        threading.Event().wait(0.05)
+        release.set()
         for thread in threads:
-            thread.join(timeout=30)
+            thread.join(timeout=10)
 
         # A join() timeout alone can't fail the test on its own, so check explicitly that
         # nothing is still running -- a genuine deadlock should fail loudly, not pass quietly.
@@ -358,14 +374,14 @@ class TestResolveWhisperCppBinary(unittest.TestCase):
 
     def test_explicit_path_valid(self):
         """Test explicit path that exists."""
-        with patch("os.path.isfile", return_value=True):
+        with patch("sys2txt.engines.os.path.isfile", return_value=True):
             result = _resolve_whisper_cpp_binary("/path/to/whisper-cli")
 
         self.assertEqual(result, "/path/to/whisper-cli")
 
     def test_explicit_path_invalid(self):
         """Test explicit path that doesn't exist."""
-        with patch("os.path.isfile", return_value=False):
+        with patch("sys2txt.engines.os.path.isfile", return_value=False):
             with self.assertRaises(RuntimeError) as cm:
                 _resolve_whisper_cpp_binary("/path/to/whisper-cli")
 
@@ -374,7 +390,7 @@ class TestResolveWhisperCppBinary(unittest.TestCase):
     @patch.dict(os.environ, {"SYS2TXT_WHISPER_CPP": "/env/whisper-cli"})
     def test_env_var_valid(self):
         """Test environment variable path that exists."""
-        with patch("os.path.isfile", return_value=True):
+        with patch("sys2txt.engines.os.path.isfile", return_value=True):
             result = _resolve_whisper_cpp_binary(None)
 
         self.assertEqual(result, "/env/whisper-cli")
@@ -382,7 +398,7 @@ class TestResolveWhisperCppBinary(unittest.TestCase):
     @patch.dict(os.environ, {"SYS2TXT_WHISPER_CPP": "/env/whisper-cli"})
     def test_env_var_invalid(self):
         """Test environment variable path that doesn't exist."""
-        with patch("os.path.isfile", return_value=False):
+        with patch("sys2txt.engines.os.path.isfile", return_value=False):
             with self.assertRaises(RuntimeError) as cm:
                 _resolve_whisper_cpp_binary(None)
 
@@ -391,7 +407,7 @@ class TestResolveWhisperCppBinary(unittest.TestCase):
     @patch.dict(os.environ, {}, clear=True)
     def test_path_lookup_found(self):
         """Test PATH lookup succeeds."""
-        with patch("shutil.which", return_value="/usr/bin/whisper-cli"):
+        with patch("sys2txt.engines.shutil.which", return_value="/usr/bin/whisper-cli"):
             result = _resolve_whisper_cpp_binary(None)
 
         self.assertEqual(result, "/usr/bin/whisper-cli")
@@ -399,7 +415,7 @@ class TestResolveWhisperCppBinary(unittest.TestCase):
     @patch.dict(os.environ, {}, clear=True)
     def test_path_lookup_not_found(self):
         """Test PATH lookup fails."""
-        with patch("shutil.which", return_value=None):
+        with patch("sys2txt.engines.shutil.which", return_value=None):
             with self.assertRaises(RuntimeError) as cm:
                 _resolve_whisper_cpp_binary(None)
 
@@ -411,14 +427,14 @@ class TestResolveWhisperCppModelPath(unittest.TestCase):
 
     def test_explicit_path_valid(self):
         """Test explicit model path that exists."""
-        with patch("os.path.isfile", return_value=True):
+        with patch("sys2txt.engines.os.path.isfile", return_value=True):
             result = _resolve_whisper_cpp_model_path("/path/to/model.bin", "small")
 
         self.assertEqual(result, "/path/to/model.bin")
 
     def test_explicit_path_invalid(self):
         """Test explicit model path that doesn't exist."""
-        with patch("os.path.isfile", return_value=False):
+        with patch("sys2txt.engines.os.path.isfile", return_value=False):
             with self.assertRaises(RuntimeError) as cm:
                 _resolve_whisper_cpp_model_path("/path/to/model.bin", "small")
 
@@ -427,7 +443,7 @@ class TestResolveWhisperCppModelPath(unittest.TestCase):
     @patch.dict(os.environ, {"SYS2TXT_WHISPER_CPP_MODELS": "/models"})
     def test_env_var_models_dir(self):
         """Test models directory from environment variable."""
-        with patch("os.path.isfile", return_value=True):
+        with patch("sys2txt.engines.os.path.isfile", return_value=True):
             result = _resolve_whisper_cpp_model_path(None, "small")
 
         self.assertEqual(result, "/models/ggml-small.bin")
@@ -445,7 +461,7 @@ class TestResolveWhisperCppModelPath(unittest.TestCase):
     @patch.dict(os.environ, {}, clear=True)
     def test_model_not_found_download_disabled(self):
         """Test model not found anywhere and downloading is disabled."""
-        with patch("os.path.isfile", return_value=False):
+        with patch("sys2txt.engines.os.path.isfile", return_value=False):
             with patch.object(Path, "is_file", return_value=False):
                 with self.assertRaises(RuntimeError) as cm:
                     _resolve_whisper_cpp_model_path(None, "small", download=False)
@@ -457,7 +473,7 @@ class TestResolveWhisperCppModelPath(unittest.TestCase):
         """Test a missing model is downloaded to the default directory."""
         expected_path = Path.home() / ".local" / "share" / "whisper.cpp" / "models" / "ggml-small.bin"
 
-        with patch("os.path.isfile", return_value=False):
+        with patch("sys2txt.engines.os.path.isfile", return_value=False):
             with patch.object(Path, "is_file", return_value=False):
                 result = _resolve_whisper_cpp_model_path(None, "small")
 
@@ -468,7 +484,7 @@ class TestResolveWhisperCppModelPath(unittest.TestCase):
     @patch("sys2txt.engines._download_whisper_cpp_model")
     def test_model_missing_downloads_to_env_dir(self, mock_download):
         """Test a missing model is downloaded to SYS2TXT_WHISPER_CPP_MODELS if set."""
-        with patch("os.path.isfile", return_value=False):
+        with patch("sys2txt.engines.os.path.isfile", return_value=False):
             result = _resolve_whisper_cpp_model_path(None, "small")
 
         mock_download.assert_called_once_with("ggml-small.bin", Path("/models/ggml-small.bin"))
@@ -479,7 +495,7 @@ class TestResolveWhisperCppModelPath(unittest.TestCase):
         """Test a failed download still raises the original 'not found' error."""
         mock_download.side_effect = RuntimeError("network unreachable")
 
-        with patch("os.path.isfile", return_value=False):
+        with patch("sys2txt.engines.os.path.isfile", return_value=False):
             with patch.object(Path, "is_file", return_value=False):
                 with self.assertRaises(RuntimeError) as cm:
                     _resolve_whisper_cpp_model_path(None, "small")
@@ -499,7 +515,7 @@ class TestDownloadWhisperCppModel(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             destination = Path(tmpdir) / "models" / "ggml-small.bin"
-            with patch("urllib.request.urlopen", return_value=response):
+            with patch("sys2txt.engines.urllib.request.urlopen", return_value=response):
                 _download_whisper_cpp_model("ggml-small.bin", destination)
 
             self.assertTrue(destination.is_file())
@@ -510,7 +526,7 @@ class TestDownloadWhisperCppModel(unittest.TestCase):
         """Test a network failure raises RuntimeError and cleans up the .part file."""
         with tempfile.TemporaryDirectory() as tmpdir:
             destination = Path(tmpdir) / "models" / "ggml-small.bin"
-            with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("boom")):
+            with patch("sys2txt.engines.urllib.request.urlopen", side_effect=urllib.error.URLError("boom")):
                 with self.assertRaises(RuntimeError) as cm:
                     _download_whisper_cpp_model("ggml-small.bin", destination)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,7 +21,7 @@ from unittest.mock import patch
 
 from sys2txt.audio import record_once
 from sys2txt.formats import Cue, Transcript
-from sys2txt.pulse import get_default_monitor_source
+from sys2txt.pulse import get_default_monitor_source, run_command
 
 FFMPEG_AVAILABLE = shutil.which("ffmpeg") is not None
 
@@ -131,8 +131,16 @@ class TestCliOverARealWavFile(unittest.TestCase):
 
 
 def _real_pulse_default_source():
-    """The default monitor source, or None if PulseAudio isn't actually reachable here."""
+    """The default monitor source, or None if PulseAudio isn't actually reachable here.
+
+    `get_default_monitor_source()` falls back to the literal string "default" whenever pactl
+    can't be reached at all (no PulseAudio/PipeWire server, as on most CI runners), so a truthy
+    return there does not mean a real server is up. Check reachability directly instead.
+    """
     try:
+        code, _, _ = run_command(["pactl", "info"])
+        if code != 0:
+            return None
         return get_default_monitor_source()
     except Exception:
         return None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,165 @@
+"""End-to-end tests that exercise real ffmpeg (and, when available, real PulseAudio).
+
+Every other test module mocks ffmpeg and PulseAudio entirely, so nothing in the suite has
+ever caught an ffmpeg argument-shape mismatch or a real subprocess timing bug -- despite CI
+installing both packages. These tests spend that installation: they run the real `ffmpeg`
+binary and assert on the files/output it actually produces, rather than on mock call shapes.
+
+The transcription engine itself is mocked (downloading a real Whisper model in CI would be
+slow and network-dependent, exactly the kind of flake risk this suite is trying to remove
+elsewhere) -- these tests are about the audio and CLI plumbing around it.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from sys2txt.audio import record_once
+from sys2txt.formats import Cue, Transcript
+from sys2txt.pulse import get_default_monitor_source
+
+FFMPEG_AVAILABLE = shutil.which("ffmpeg") is not None
+
+
+def _make_fixture_wav(path: str, duration: float = 0.5) -> None:
+    """Generate a short real WAV file with real ffmpeg (a synthetic tone, no audio device needed)."""
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            f"sine=frequency=440:duration={duration}",
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            path,
+            "-y",
+        ],
+        check=True,
+    )
+
+
+@unittest.skipUnless(FFMPEG_AVAILABLE, "ffmpeg is not installed")
+class TestRealFfmpegFixture(unittest.TestCase):
+    """Sanity-checks the fixture generator itself produces a real, valid WAV file."""
+
+    def test_fixture_is_a_real_wav_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "fixture.wav")
+            _make_fixture_wav(path)
+
+            self.assertTrue(os.path.isfile(path))
+            with open(path, "rb") as f:
+                header = f.read(12)
+            self.assertEqual(header[:4], b"RIFF")
+            self.assertEqual(header[8:12], b"WAVE")
+            self.assertGreater(os.path.getsize(path), 1024)
+
+
+@unittest.skipUnless(FFMPEG_AVAILABLE, "ffmpeg is not installed")
+class TestCliOverARealWavFile(unittest.TestCase):
+    """Runs the real `sys2txt once --input` CLI path over a real WAV file.
+
+    Only the transcription engine is mocked; argument parsing, option validation, transcript
+    rendering and file writing all run for real.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.wav_path = os.path.join(self.tmpdir.name, "fixture.wav")
+        _make_fixture_wav(self.wav_path)
+        self.output_path = os.path.join(self.tmpdir.name, "out.txt")
+
+    @patch("sys2txt.__main__.transcribe_file_cues")
+    def test_transcribes_a_real_wav_file_and_writes_the_output(self, mock_transcribe):
+        mock_transcribe.return_value = Transcript(cues=(Cue(0.0, 0.5, "test tone"),))
+
+        argv = [
+            "sys2txt",
+            "once",
+            "--input",
+            self.wav_path,
+            "--output",
+            self.output_path,
+        ]
+        with patch.object(sys, "argv", argv):
+            from sys2txt.__main__ import main
+
+            main()
+
+        mock_transcribe.assert_called_once()
+        self.assertEqual(mock_transcribe.call_args[0][0], self.wav_path)
+        with open(self.output_path) as f:
+            content = f.read()
+        self.assertIn("test tone", content)
+
+    @patch("sys2txt.__main__.transcribe_file_cues")
+    def test_json_format_produces_valid_json_over_a_real_wav_file(self, mock_transcribe):
+        mock_transcribe.return_value = Transcript(cues=(Cue(0.0, 0.5, "test tone"),), language="en")
+
+        argv = [
+            "sys2txt",
+            "once",
+            "--input",
+            self.wav_path,
+            "--format",
+            "json",
+            "--output",
+            self.output_path,
+        ]
+        with patch.object(sys, "argv", argv):
+            from sys2txt.__main__ import main
+
+            main()
+
+        with open(self.output_path) as f:
+            document = json.load(f)
+        self.assertEqual(document["language"], "en")
+        self.assertEqual(document["segments"][0]["text"], "test tone")
+
+
+def _real_pulse_default_source():
+    """The default monitor source, or None if PulseAudio isn't actually reachable here."""
+    try:
+        return get_default_monitor_source()
+    except Exception:
+        return None
+
+
+@unittest.skipUnless(FFMPEG_AVAILABLE, "ffmpeg is not installed")
+@unittest.skipUnless(_real_pulse_default_source(), "no reachable PulseAudio/PipeWire source")
+class TestRealPulseRecording(unittest.TestCase):
+    """A true end-to-end smoke test: real ffmpeg capturing from a real PulseAudio source.
+
+    Skips itself on any machine without a reachable PulseAudio/PipeWire server (most CI
+    runners), rather than failing -- it runs for real wherever audio is actually available.
+    """
+
+    def test_record_once_produces_a_real_wav_file(self):
+        source = _real_pulse_default_source()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "capture.wav")
+
+            record_once(source, path, duration=1)
+
+            self.assertTrue(os.path.isfile(path))
+            with open(path, "rb") as f:
+                header = f.read(12)
+            self.assertEqual(header[:4], b"RIFF")
+            self.assertEqual(header[8:12], b"WAVE")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -160,6 +160,8 @@ class TestTranscribeLive(unittest.TestCase):
         first, second = MagicMock(), MagicMock()
         first.submit.return_value = stuck
         second.submit.return_value = recovered
+        # Exactly two executors are expected here (the abandoned one, then its replacement) -
+        # this is the behaviour under test, not an incidental iteration count.
         mock_executor_cls.side_effect = [first, second]
 
         with self.assertLogs("sys2txt.pipeline", level="WARNING"):


### PR DESCRIPTION
## Summary
Closes #64. The issue was filed against an older, monolithic version of the codebase; the subsequent split into `audio.py`/`pipeline.py`/`engines.py`/`formats.py`/`transcribe.py` already resolved most of its complaints (module-qualified patching, `clear=True` env isolation, a public `unload_engines()` reset API, coverage of `_stop_ffmpeg` and the timeout paths). This PR fixes what was still genuinely present:

- Fixed-length `side_effect` lists for `wait()`/`poll()` in `tests/test_audio.py` replaced with `chain(fixed, repeat(terminal))`, so an extra internal call doesn't raise `StopIteration` for a behaviour-preserving change.
- `tests/test_engines.py` no longer pokes `FasterWhisperEngine._model`/`._key` directly as setup/teardown; the cache tests now go through `unload()`/`unload_engines()` and assert on observable behaviour (does the model constructor get called again).
- The model-cache concurrency test no longer races real threads on a `threading.Barrier` — it uses a deterministic `Event`-gated fake model constructor instead, removing a CI flake source.
- `os.path.isfile`/`shutil.which`/`urllib.request.urlopen` patches in `test_engines.py` are now scoped to `sys2txt.engines.*` rather than patching the stdlib globally.
- Added a test for `_ColorFormatter`, previously uncovered.
- Added `tests/test_integration.py`: real `ffmpeg` (and, on a machine with a reachable PulseAudio/PipeWire source, a real recording) driving the CLI and audio pipeline end-to-end — the first tests to actually use the `ffmpeg`/`pulseaudio` packages CI installs.

## Test plan
- [x] `python -m unittest discover -s tests -p "test_*.py"` — 265 tests pass
- [x] `pytest --cov=sys2txt --cov-report=term-missing` — 98% coverage
- [x] Ran the full suite 5x in a row to confirm the reworked concurrency test doesn't flake
- [x] Manually added a spare `proc.wait()` call inside `_stop_ffmpeg` and confirmed the previously-brittle tests still pass, then reverted
- [x] `ruff format --check src/ tests/` and `ruff check src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179dZYnYjdcxCyRzzTUUhJd